### PR TITLE
feat(scan): whole-word title_filter with regex escape hatch and --explain CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `portals.yml` `title_filter` terms now match whole words, case-insensitive (was: case-insensitive substring). `intern` no longer rejects `International`, but also no longer matches `Interns`/`Internship` — add explicit plural variants, or use the new `/regex/flags` escape hatch for full control.
+
+### Added
+
+- `npm run explain -- "<title>" [--company "<co>"]` CLI traces why a title is accepted or filtered by the current `portals.yml` + `candidate-profile.yml`.
+
 ## [0.1.0-alpha.0] — 2026-04-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "check:pii": "bash scripts/check-no-pii.sh",
     "scan": "node src/scan/index.mjs",
     "score": "node src/score/index.mjs",
-    "dashboard": "node src/dashboard/build.mjs"
+    "dashboard": "node src/dashboard/build.mjs",
+    "explain": "node src/scan/explain.mjs"
   },
   "keywords": [
     "claude-code",

--- a/src/lib/prefilter-rules.mjs
+++ b/src/lib/prefilter-rules.mjs
@@ -83,23 +83,32 @@ export function checkStartDate(offer, minStartDateIso) {
   return { pass: false, reason: `start_date: all parsed dates before ${minStartDateIso}` };
 }
 
+// Compile a title-filter term into a RegExp.
+//
+// Escape hatch: a term of the form "/pattern/flags" is parsed as a real regex.
+// Case-insensitivity is enforced — if the user omits "i", we add it.
+//
+// Plain string: case-insensitive, word-boundary match with special chars
+// escaped. "stage" → /\bstage\b/i, matches "Stage Data" but NOT "Backstage".
+function compileMatcher(term) {
+  const s = String(term);
+  const m = s.match(/^\/(.+)\/([gimsuy]*)$/);
+  if (m) {
+    const flags = m[2].includes('i') ? m[2] : m[2] + 'i';
+    return new RegExp(m[1], flags);
+  }
+  const escaped = s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`\\b${escaped}\\b`, 'i');
+}
+
 export function checkTitle(offer, whitelist) {
-  const title = (offer.title || '').toLowerCase();
-  const neg = (whitelist.negative || []).find((n) => title.includes(n.toLowerCase()));
+  const title = offer.title || '';
+  const neg = (whitelist.negative || []).find((n) => compileMatcher(n).test(title));
   if (neg) return { pass: false, reason: `title: negative match "${neg}"` };
-  const pos = (whitelist.positive || []).some((p) => title.includes(p.toLowerCase()));
+  const pos = (whitelist.positive || []).some((p) => compileMatcher(p).test(title));
   if (!pos) return { pass: false, reason: 'title: no positive match' };
-  // Optional: if required_any is defined, the title must contain at least one
-  // of these keywords as a WHOLE WORD (word-boundary match on both sides).
-  // This prevents "Intern" from matching "International" / "Internal" while
-  // still catching "Intern", "Interns", "Internship" (explicit variants).
   if (Array.isArray(whitelist.required_any) && whitelist.required_any.length > 0) {
-    const req = whitelist.required_any.some((r) => {
-      const escaped = String(r)
-        .toLowerCase()
-        .replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      return new RegExp(`\\b${escaped}\\b`).test(title);
-    });
+    const req = whitelist.required_any.some((r) => compileMatcher(r).test(title));
     if (!req) return { pass: false, reason: 'title: missing required_any keyword' };
   }
   return { pass: true };

--- a/src/lib/prefilter-rules.mjs
+++ b/src/lib/prefilter-rules.mjs
@@ -93,25 +93,46 @@ export function checkStartDate(offer, minStartDateIso) {
 function compileMatcher(term) {
   const s = String(term);
   const m = s.match(/^\/(.+)\/([gimsuy]*)$/);
-  if (m) {
-    const flags = m[2].includes('i') ? m[2] : m[2] + 'i';
-    return new RegExp(m[1], flags);
+  try {
+    if (m) {
+      const flags = m[2].includes('i') ? m[2] : m[2] + 'i';
+      return new RegExp(m[1], flags);
+    }
+    const escaped = s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`\\b${escaped}\\b`, 'i');
+  } catch (err) {
+    const e = new Error(`invalid title_filter term "${s}": ${err.message}`);
+    e.code = 'INVALID_TITLE_FILTER_TERM';
+    e.term = s;
+    throw e;
   }
-  const escaped = s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return new RegExp(`\\b${escaped}\\b`, 'i');
+}
+
+function findMatch(terms, title) {
+  for (const t of terms || []) {
+    if (compileMatcher(t).test(title)) return t;
+  }
+  return null;
 }
 
 export function checkTitle(offer, whitelist) {
   const title = offer.title || '';
-  const neg = (whitelist.negative || []).find((n) => compileMatcher(n).test(title));
-  if (neg) return { pass: false, reason: `title: negative match "${neg}"` };
-  const pos = (whitelist.positive || []).some((p) => compileMatcher(p).test(title));
-  if (!pos) return { pass: false, reason: 'title: no positive match' };
-  if (Array.isArray(whitelist.required_any) && whitelist.required_any.length > 0) {
-    const req = whitelist.required_any.some((r) => compileMatcher(r).test(title));
-    if (!req) return { pass: false, reason: 'title: missing required_any keyword' };
+  try {
+    const neg = findMatch(whitelist.negative, title);
+    if (neg) return { pass: false, reason: `title: negative match "${neg}"` };
+    const pos = findMatch(whitelist.positive, title);
+    if (!pos) return { pass: false, reason: 'title: no positive match' };
+    if (Array.isArray(whitelist.required_any) && whitelist.required_any.length > 0) {
+      const req = findMatch(whitelist.required_any, title);
+      if (!req) return { pass: false, reason: 'title: missing required_any keyword' };
+    }
+    return { pass: true };
+  } catch (err) {
+    if (err.code === 'INVALID_TITLE_FILTER_TERM') {
+      return { pass: false, reason: `title: ${err.message}` };
+    }
+    throw err;
   }
-  return { pass: true };
 }
 
 export function checkBlacklist(offer, blacklist) {

--- a/src/scan/explain.mjs
+++ b/src/scan/explain.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Explain why a given job title is accepted or rejected by the current
+// title_filter / blacklist / location / start-date rules.
+//
+// Usage:
+//   node src/scan/explain.mjs "Some Job Title" [--company "Foo"]
+//
+// Reads config/portals.yml and (optionally) config/profile.yml from
+// CLAUDE_APPLY_CONFIG_DIR or the repo's ./config dir. Inlines a tiny YAML
+// loader so this file is independent of any shared profile-loading helper.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+
+import {
+  checkTitle,
+  checkBlacklist,
+  checkLocation,
+  checkStartDate,
+} from '../lib/prefilter-rules.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function loadYamlOptional(filePath) {
+  try {
+    return yaml.load(fs.readFileSync(filePath, 'utf8')) || {};
+  } catch (err) {
+    if (err.code === 'ENOENT') return {};
+    throw err;
+  }
+}
+
+function loadYamlRequired(filePath) {
+  return yaml.load(fs.readFileSync(filePath, 'utf8')) || {};
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  if (args.length === 0 || args[0].startsWith('--')) {
+    return { error: 'usage: node src/scan/explain.mjs "<title>" [--company "<company>"]' };
+  }
+  const title = args[0];
+  let company = '';
+  const ci = args.indexOf('--company');
+  if (ci >= 0) company = args[ci + 1] || '';
+  return { title, company };
+}
+
+function runTrace(offer, config) {
+  const trace = [];
+  const steps = [
+    { name: 'title', fn: () => checkTitle(offer, config.whitelist) },
+    { name: 'blacklist', fn: () => checkBlacklist(offer, config.blacklist) },
+    { name: 'location', fn: () => checkLocation(offer) },
+    { name: 'start_date', fn: () => checkStartDate(offer, config.minStartDate) },
+  ];
+  for (const s of steps) {
+    const r = s.fn();
+    trace.push({ name: s.name, result: r });
+    if (!r.pass) return { pass: false, reason: r.reason, trace };
+  }
+  return { pass: true, trace };
+}
+
+function formatTrace(offer, outcome, whitelist) {
+  const lines = [];
+  lines.push(`Title:   ${offer.title}`);
+  lines.push(`Company: ${offer.company || '(none)'}`);
+  lines.push('');
+  for (const step of outcome.trace) {
+    const mark = step.result.pass ? '✓' : '✗';
+    if (step.name === 'title' && !step.result.pass) {
+      lines.push(`${mark} title — ${step.result.reason}`);
+      const pos = whitelist.positive || [];
+      const neg = whitelist.negative || [];
+      if (pos.length > 0) {
+        lines.push(`    positive tried: ${pos.map((t) => `"${t}"`).join(', ')}`);
+      }
+      if (neg.length > 0) {
+        lines.push(`    negative tried: ${neg.map((t) => `"${t}"`).join(', ')}`);
+      }
+    } else if (step.result.pass) {
+      lines.push(`${mark} ${step.name}`);
+    } else {
+      lines.push(`${mark} ${step.name} — ${step.result.reason}`);
+    }
+  }
+  lines.push('');
+  if (outcome.pass) {
+    lines.push('ACCEPTED');
+  } else {
+    lines.push(`REJECTED: ${outcome.reason}`);
+  }
+  return lines.join('\n');
+}
+
+function main() {
+  const parsed = parseArgs(process.argv);
+  if (parsed.error) {
+    console.error(parsed.error);
+    process.exit(2);
+  }
+
+  const CONFIG_DIR =
+    process.env.CLAUDE_APPLY_CONFIG_DIR || path.join(__dirname, '..', '..', 'config');
+
+  const portals = loadYamlRequired(path.join(CONFIG_DIR, 'portals.yml'));
+  const profile = loadYamlOptional(path.join(CONFIG_DIR, 'profile.yml'));
+
+  const whitelist = portals.title_filter || { positive: [], negative: [] };
+  const config = {
+    whitelist,
+    blacklist: profile.evaluation?.blacklist_companies || [],
+    minStartDate: profile.evaluation?.min_start_date || '2026-08-24',
+  };
+
+  const offer = { title: parsed.title, company: parsed.company, body: '' };
+  const outcome = runTrace(offer, config);
+  console.log(formatTrace(offer, outcome, whitelist));
+  process.exit(outcome.pass ? 0 : 1);
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  try {
+    main();
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}

--- a/src/scan/explain.mjs
+++ b/src/scan/explain.mjs
@@ -5,7 +5,7 @@
 // Usage:
 //   node src/scan/explain.mjs "Some Job Title" [--company "Foo"]
 //
-// Reads config/portals.yml and (optionally) config/profile.yml from
+// Reads config/portals.yml and (optionally) config/candidate-profile.yml from
 // CLAUDE_APPLY_CONFIG_DIR or the repo's ./config dir. Inlines a tiny YAML
 // loader so this file is independent of any shared profile-loading helper.
 
@@ -54,8 +54,10 @@ function runTrace(offer, config) {
     { name: 'title', fn: () => checkTitle(offer, config.whitelist) },
     { name: 'blacklist', fn: () => checkBlacklist(offer, config.blacklist) },
     { name: 'location', fn: () => checkLocation(offer) },
-    { name: 'start_date', fn: () => checkStartDate(offer, config.minStartDate) },
   ];
+  if (config.minStartDate) {
+    steps.push({ name: 'start_date', fn: () => checkStartDate(offer, config.minStartDate) });
+  }
   for (const s of steps) {
     const r = s.fn();
     trace.push({ name: s.name, result: r });
@@ -107,13 +109,13 @@ function main() {
     process.env.CLAUDE_APPLY_CONFIG_DIR || path.join(__dirname, '..', '..', 'config');
 
   const portals = loadYamlRequired(path.join(CONFIG_DIR, 'portals.yml'));
-  const profile = loadYamlOptional(path.join(CONFIG_DIR, 'profile.yml'));
+  const profile = loadYamlOptional(path.join(CONFIG_DIR, 'candidate-profile.yml'));
 
   const whitelist = portals.title_filter || { positive: [], negative: [] };
   const config = {
     whitelist,
-    blacklist: profile.evaluation?.blacklist_companies || [],
-    minStartDate: profile.evaluation?.min_start_date || '2026-08-24',
+    blacklist: profile.blacklist_companies || [],
+    minStartDate: profile.min_start_date || null,
   };
 
   const offer = { title: parsed.title, company: parsed.company, body: '' };

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -21,7 +21,17 @@ tracked_companies:
     enabled: true
 
 title_filter:
-  # Titles must contain at least one of these (case-insensitive substring).
+  # positive and negative terms match WHOLE WORDS, case-insensitive.
+  # Examples:
+  #   - "stage"    matches "Stage Data", does NOT match "Backstage"
+  #   - "intern"   matches "Intern", does NOT match "International"
+  #     (add "interns", "internship" explicitly if you want those)
+  #
+  # Escape hatch — wrap a real regex in slashes for power cases:
+  #   - "/^stage\\b/i"        anchor to start of title
+  #   - "/ml\\s*engineer/i"   allow optional whitespace
+  #
+  # Titles must contain at least one of these.
   positive:
     - Intern
     - Internship
@@ -32,6 +42,6 @@ title_filter:
   negative: []
 
   # Optional secondary filter applied *on top of* positive/negative:
-  # if set, the title must also contain at least one of these keywords.
-  # Leave empty or omit to skip this extra check.
+  # if set, the title must also match at least one of these (same whole-word
+  # semantics and regex escape hatch as above). Leave empty or omit to skip.
   required_any: []

--- a/tests/lib/prefilter-title.test.mjs
+++ b/tests/lib/prefilter-title.test.mjs
@@ -1,0 +1,85 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkTitle } from '../../src/lib/prefilter-rules.mjs';
+
+test('checkTitle: "stage" matches "Stage Data Science"', () => {
+  const wl = { positive: ['stage'], negative: [] };
+  assert.deepEqual(checkTitle({ title: 'Stage Data Science' }, wl), { pass: true });
+});
+
+test('checkTitle: "stage" does NOT match "Backstage Portal"', () => {
+  const wl = { positive: ['stage'], negative: [] };
+  const r = checkTitle({ title: 'Backstage Portal' }, wl);
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /no positive match/);
+});
+
+test('checkTitle: "intern" matches "Summer Intern 2026"', () => {
+  const wl = { positive: ['intern'], negative: [] };
+  assert.deepEqual(checkTitle({ title: 'Summer Intern 2026' }, wl), { pass: true });
+});
+
+test('checkTitle: "intern" does NOT match "Interns wanted" (plural — \\b on both sides)', () => {
+  const wl = { positive: ['intern'], negative: [] };
+  const r = checkTitle({ title: 'Interns wanted' }, wl);
+  assert.equal(r.pass, false);
+});
+
+test('checkTitle: "intern" does NOT match "International Trade"', () => {
+  const wl = { positive: ['intern'], negative: [] };
+  const r = checkTitle({ title: 'International Trade' }, wl);
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /no positive match/);
+});
+
+test('checkTitle: positive is case-insensitive', () => {
+  const wl = { positive: ['STAGE'], negative: [] };
+  assert.deepEqual(checkTitle({ title: 'stage data' }, wl), { pass: true });
+});
+
+test('checkTitle: negative match short-circuits positive', () => {
+  const wl = { positive: ['intern'], negative: ['sales'] };
+  const r = checkTitle({ title: 'Sales Intern' }, wl);
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /negative match "sales"/);
+});
+
+test('checkTitle: negative "stage" does NOT match "Backstage"', () => {
+  const wl = { positive: ['engineer'], negative: ['stage'] };
+  assert.deepEqual(checkTitle({ title: 'Backstage Engineer' }, wl), { pass: true });
+});
+
+test('checkTitle: "/^stage\\b/i" matches "Stage Data" (anchored)', () => {
+  const wl = { positive: ['/^stage\\b/i'], negative: [] };
+  assert.deepEqual(checkTitle({ title: 'Stage Data' }, wl), { pass: true });
+});
+
+test('checkTitle: "/^stage\\b/i" does NOT match "Full Stage"', () => {
+  const wl = { positive: ['/^stage\\b/i'], negative: [] };
+  const r = checkTitle({ title: 'Full Stage' }, wl);
+  assert.equal(r.pass, false);
+});
+
+test('checkTitle: regex escape hatch is case-insensitive even without /i flag', () => {
+  const wl = { positive: ['/^stage\\b/'], negative: [] };
+  assert.deepEqual(checkTitle({ title: 'STAGE DATA' }, wl), { pass: true });
+});
+
+test('checkTitle: empty positive list → reject', () => {
+  const wl = { positive: [], negative: [] };
+  const r = checkTitle({ title: 'Anything' }, wl);
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /no positive match/);
+});
+
+test('checkTitle: required_any uses word-boundary (regression guard)', () => {
+  const wl = { positive: ['engineer'], negative: [], required_any: ['intern'] };
+  const r = checkTitle({ title: 'International Engineer' }, wl);
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /required_any/);
+});
+
+test('checkTitle: required_any accepts regex escape hatch', () => {
+  const wl = { positive: ['engineer'], negative: [], required_any: ['/^ml\\b/i'] };
+  assert.deepEqual(checkTitle({ title: 'ML Engineer' }, wl), { pass: true });
+});

--- a/tests/lib/prefilter-title.test.mjs
+++ b/tests/lib/prefilter-title.test.mjs
@@ -83,3 +83,11 @@ test('checkTitle: required_any accepts regex escape hatch', () => {
   const wl = { positive: ['engineer'], negative: [], required_any: ['/^ml\\b/i'] };
   assert.deepEqual(checkTitle({ title: 'ML Engineer' }, wl), { pass: true });
 });
+
+test('checkTitle: invalid regex escape hatch rejects cleanly without crashing', () => {
+  const wl = { positive: ['/[unclosed/'], negative: [] };
+  const r = checkTitle({ title: 'Anything' }, wl);
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /invalid title_filter term/);
+  assert.match(r.reason, /\[unclosed/);
+});

--- a/tests/scan/explain.test.mjs
+++ b/tests/scan/explain.test.mjs
@@ -14,7 +14,7 @@ function makeFixtureConfig(portalsYml, profileYml) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-apply-explain-'));
   fs.writeFileSync(path.join(dir, 'portals.yml'), portalsYml);
   if (profileYml !== null) {
-    fs.writeFileSync(path.join(dir, 'profile.yml'), profileYml);
+    fs.writeFileSync(path.join(dir, 'candidate-profile.yml'), profileYml);
   }
   return dir;
 }
@@ -62,7 +62,7 @@ test('explain: negative match is reported with the matched term', () => {
 test('explain: --company flag is honored for blacklist check', () => {
   const dir = makeFixtureConfig(
     'tracked_companies: []\ntitle_filter:\n  positive:\n    - intern\n  negative: []\n',
-    'evaluation:\n  blacklist_companies:\n    - Foo\n  min_start_date: "2026-08-24"\n'
+    'blacklist_companies:\n  - Foo\nmin_start_date: "2026-08-24"\n'
   );
   const res = runExplain(['ML Intern', '--company', 'Foo'], dir);
   assert.equal(res.status, 1);

--- a/tests/scan/explain.test.mjs
+++ b/tests/scan/explain.test.mjs
@@ -1,0 +1,77 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const EXPLAIN = path.join(REPO_ROOT, 'src', 'scan', 'explain.mjs');
+
+function makeFixtureConfig(portalsYml, profileYml) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-apply-explain-'));
+  fs.writeFileSync(path.join(dir, 'portals.yml'), portalsYml);
+  if (profileYml !== null) {
+    fs.writeFileSync(path.join(dir, 'profile.yml'), profileYml);
+  }
+  return dir;
+}
+
+function runExplain(args, configDir) {
+  return spawnSync('node', [EXPLAIN, ...args], {
+    env: { ...process.env, CLAUDE_APPLY_CONFIG_DIR: configDir },
+    encoding: 'utf8',
+  });
+}
+
+test('explain: rejects "Backstage Portal" when positive is ["stage"]', () => {
+  const dir = makeFixtureConfig(
+    'tracked_companies: []\ntitle_filter:\n  positive:\n    - stage\n  negative: []\n',
+    null
+  );
+  const res = runExplain(['Backstage Portal'], dir);
+  assert.equal(res.status, 1, `stderr: ${res.stderr}`);
+  assert.match(res.stdout, /REJECTED/);
+  assert.match(res.stdout, /no positive match|title\.positive/);
+  assert.match(res.stdout, /stage/);
+});
+
+test('explain: accepts "Stage Data Science" when positive is ["stage"]', () => {
+  const dir = makeFixtureConfig(
+    'tracked_companies: []\ntitle_filter:\n  positive:\n    - stage\n  negative: []\n',
+    null
+  );
+  const res = runExplain(['Stage Data Science'], dir);
+  assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+  assert.match(res.stdout, /ACCEPTED|PASSED|pass/i);
+});
+
+test('explain: negative match is reported with the matched term', () => {
+  const dir = makeFixtureConfig(
+    'tracked_companies: []\ntitle_filter:\n  positive:\n    - intern\n  negative:\n    - sales\n',
+    null
+  );
+  const res = runExplain(['Sales Intern'], dir);
+  assert.equal(res.status, 1);
+  assert.match(res.stdout, /negative/);
+  assert.match(res.stdout, /sales/);
+});
+
+test('explain: --company flag is honored for blacklist check', () => {
+  const dir = makeFixtureConfig(
+    'tracked_companies: []\ntitle_filter:\n  positive:\n    - intern\n  negative: []\n',
+    'evaluation:\n  blacklist_companies:\n    - Foo\n  min_start_date: "2026-08-24"\n'
+  );
+  const res = runExplain(['ML Intern', '--company', 'Foo'], dir);
+  assert.equal(res.status, 1);
+  assert.match(res.stdout, /blacklist/i);
+});
+
+test('explain: exits 2 with a usage error if no title given', () => {
+  const dir = makeFixtureConfig('tracked_companies: []\ntitle_filter:\n  positive: []\n', null);
+  const res = runExplain([], dir);
+  assert.equal(res.status, 2);
+  assert.match(res.stderr, /usage/i);
+});


### PR DESCRIPTION
## Summary
- `title_filter` terms now match on whole words (fix: `intern` no longer rejects `International`)
- `/regex/flags` escape hatch for advanced patterns; invalid regex rejects cleanly instead of crashing the scanner
- `npm run explain -- "<title>" [--company "<co>"]` CLI traces why a title is kept or filtered out
- CHANGELOG entry flagging the breaking whole-word semantics

## Context
Fixes issue #3 from the external test feedback series. Trade-off: `\bintern\b` does NOT match `Interns` — users add explicit plural variants or use the regex escape hatch. Left-only `\bintern` was rejected because it reintroduces the `International` bug.

Code-review follow-up (commit 53c5cc1):
- wrapped `compileMatcher` in try/catch so a malformed `title_filter` term no longer crashes `/scan`
- fixed `explain.mjs` to read `candidate-profile.yml` with the flat schema (prior nested `profile.evaluation.*` paths were stale after PR #3)
- dropped the `2026-08-24` magic fallback; start_date check is skipped when `min_start_date` is absent

## Test plan
- [x] 179/179 tests pass (`npm test`)
- [x] Lint + PII gate clean
- [ ] Manual: run `npm run explain -- "<title>"` on a real title

🤖 Generated with [Claude Code](https://claude.com/claude-code)
