### PR TITLE
feat(apply): Lever card labels + scoped clickInQuestion (PR 4/5)

### DIFF
--- a/.claude/commands/apply.md
+++ b/.claude/commands/apply.md
@@ -86,14 +86,19 @@ Many ATSes hide education / experience / language / link / skill subforms behind
 
 ### 4.2 Scan fields
 
-1. Via `javascript_tool`, extract every `input`, `select`, `textarea`, `button[type=submit]` with attributes `name`, `id`, `type`, `placeholder`, `required`, and the associated `<label>` (via `for` or DOM proximity).
+1. Import the browser-side DOM helpers from Node **once**, then inject them into every relevant page evaluation:
 
    ```javascript
+   // In the agent's Node context (before calling javascript_tool):
+   import { EXTRACT_LABEL_SRC } from './src/apply/dom-label.mjs';
+   ```
+
+2. Pass the following script to `mcp__claude-in-chrome__javascript_tool`. It injects `EXTRACT_LABEL_SRC` (which defines `extractLabel` and `clickInQuestion`) and then builds the `fields[]` array using the ATS-aware `extractLabel`:
+
+   ```javascript
+   // The agent constructs this string via: EXTRACT_LABEL_SRC + "\n" + <scan body>
+   ${EXTRACT_LABEL_SRC}
    const out = [];
-   const labelFor = (id) => {
-     const l = document.querySelector(`label[for="${id}"]`);
-     return l ? l.textContent.trim() : '';
-   };
    for (const el of document.querySelectorAll('input, select, textarea')) {
      out.push({
        tag: el.tagName.toLowerCase(),
@@ -102,17 +107,36 @@ Many ATSes hide education / experience / language / link / skill subforms behind
        type: el.type || '',
        placeholder: el.placeholder || '',
        required: el.required || el.hasAttribute('aria-required'),
-       label: labelFor(el.id) || el.closest('label')?.textContent?.trim() || '',
+       label: extractLabel(el),
      });
    }
    return out;
    ```
 
-2. For each field, call `classifyField` from `src/apply/field-classifier.mjs` to get its canonical key (`email`, `first_name`, `cv_upload`, `cover_letter_upload`, `education_school`, `experience_company`, `free_text`, `unknown`, …).
+   `extractLabel` resolves Lever `cards[uuid][fieldN]` inputs via `.application-question .text`, Greenhouse via `.field label`, Ashby via `[data-qa="question"] [data-qa="label"]`, and falls back to `<label for>`, wrapping `<label>`, and `aria-label[ledby]`. See `src/apply/dom-label.browser.js` for the full chain.
 
-3. Build `fields = [{ descriptor, classKey, value, sectionIndex }]`. For repeatable sections (education/experience), associate each field with an index based on DOM order. Use `mapProfileValue(classKey, profile, { educationIndex, experienceIndex })` to resolve values.
+3. For each field, call `classifyField` from `src/apply/field-classifier.mjs` to get its canonical key (`email`, `first_name`, `cv_upload`, `cover_letter_upload`, `education_school`, `experience_company`, `free_text`, `unknown`, …).
+
+4. Build `fields = [{ descriptor, classKey, value, sectionIndex }]`. For repeatable sections (education/experience), associate each field with an index based on DOM order. Use `mapProfileValue(classKey, profile, { educationIndex, experienceIndex })` to resolve values.
 
 ## 5. Structured filling
+
+### 5.0 Scoped clicks for per-question radios and checkboxes
+
+Lever, Greenhouse and Ashby all render custom questions inside a container that holds both the question text **and** the choice `<label>`s. Clicking a `<label>` by matching its text against the whole document is **unsafe**: a question like "Yes / No / Prefer not to say" can appear multiple times on the same page (end-of-study, work authorization, visa sponsorship, …) and the first match is rarely the right one.
+
+**Rule:** **never** click a radio or checkbox by doing `document.querySelector('label')` + substring match, and **never** write an ad-hoc `clickByLabel` inside a `javascript_tool` call. Always use `clickInQuestion(questionText, choiceLabel)` from `src/apply/dom-label.browser.js`, which scopes the search to the `.application-question` (Lever) / `[data-qa="question"]` (Ashby) / `.field` (Greenhouse) that contains the matching question text.
+
+Invocation pattern, via `javascript_tool` (the agent prepends `EXTRACT_LABEL_SRC` read from `src/apply/dom-label.mjs`):
+
+```javascript
+${EXTRACT_LABEL_SRC}
+return clickInQuestion('final year of study', 'No');
+```
+
+Pass a **distinctive unique substring** of the question (e.g. `'final year of study'`, not the full sentence), because the helper does a case-insensitive `includes()` — accents and punctuation are brittle, substrings are not. The helper returns `{ question, choice }` so you can log what was actually clicked and cross-check it against the intended question. After any click, re-read `element.checked` / `aria-checked` on the target input to confirm the framework state updated.
+
+If `clickInQuestion` throws `question not found` or `choice not found`, **STOP** and ask the user — do not fall back to an unscoped search.
 
 **Filling methods differ by field type and framework**:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "js-yaml": "^4.1.0"
       },
       "devDependencies": {
+        "jsdom": "^29.0.2",
         "playwright": "^1.47.0",
         "prettier": "^3.3.0"
       },
@@ -19,11 +20,279 @@
         "node": ">=20"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
+      "integrity": "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
+      "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -40,6 +309,26 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -50,6 +339,77 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/playwright": {
@@ -99,6 +459,177 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "homepage": "https://github.com/LeoLaborie/claude-apply#readme",
   "devDependencies": {
+    "jsdom": "^29.0.2",
     "playwright": "^1.47.0",
     "prettier": "^3.3.0"
   },

--- a/src/apply/dom-label.browser.js
+++ b/src/apply/dom-label.browser.js
@@ -1,0 +1,113 @@
+// Browser-side DOM helpers. Plain JS, no imports/exports. Two entry points:
+//   extractLabel(el)               -> best human label for a form element
+//   clickInQuestion(qText, choice) -> scoped click on a radio/checkbox
+// Must work both when injected into a live page (via javascript_tool) and when
+// evaluated inside jsdom via `new Function(src + "; return extractLabel;")`.
+
+function extractLabel(el) {
+  if (!el) return '';
+  var isChoice = el.type === 'radio' || el.type === 'checkbox';
+  if (isChoice) {
+    var qLever = el.closest && el.closest('.application-question');
+    if (qLever) {
+      var lt = qLever.querySelector('.text, .application-question-text');
+      if (lt && lt.textContent && lt.textContent.trim()) return lt.textContent.trim();
+    }
+    var qAsh = el.closest && el.closest('[data-qa="question"]');
+    if (qAsh) {
+      var at = qAsh.querySelector('[data-qa="label"]');
+      if (at && at.textContent && at.textContent.trim()) return at.textContent.trim();
+    }
+  }
+  if (el.id) {
+    var _win = el.ownerDocument && el.ownerDocument.defaultView;
+    var _cssEscape =
+      (_win && _win.CSS && _win.CSS.escape) ||
+      (typeof CSS !== 'undefined' && CSS.escape) ||
+      function (s) {
+        return String(s).replace(/"/g, '\\"');
+      };
+    const byFor = el.ownerDocument.querySelector('label[for="' + _cssEscape(el.id) + '"]');
+    if (byFor && byFor.textContent) {
+      const t = byFor.textContent.trim();
+      if (t) return t;
+    }
+  }
+  const wrap = el.closest && el.closest('label');
+  if (wrap && wrap.textContent) {
+    const t = wrap.textContent.trim();
+    if (t) return t;
+  }
+  const aria = el.getAttribute && el.getAttribute('aria-label');
+  if (aria && aria.trim()) return aria.trim();
+  const ariaBy = el.getAttribute && el.getAttribute('aria-labelledby');
+  if (ariaBy) {
+    const ref = el.ownerDocument.getElementById(ariaBy);
+    if (ref && ref.textContent) {
+      const t = ref.textContent.trim();
+      if (t) return t;
+    }
+  }
+  const lever = el.closest && el.closest('.application-question');
+  if (lever) {
+    const t = lever.querySelector('.text, .application-question-text');
+    if (t && t.textContent && t.textContent.trim()) return t.textContent.trim();
+  }
+  const gh = el.closest && el.closest('.field');
+  if (gh) {
+    const t = gh.querySelector('label');
+    if (t && t.textContent && t.textContent.trim()) return t.textContent.trim();
+  }
+  const ash = el.closest && el.closest('[data-qa="question"]');
+  if (ash) {
+    const t = ash.querySelector('[data-qa="label"]');
+    if (t && t.textContent && t.textContent.trim()) return t.textContent.trim();
+  }
+  return '';
+}
+
+function clickInQuestion(questionText, choiceLabel, root) {
+  var doc = (root && root.ownerDocument) || document;
+  var scope = root || doc;
+  var needle = String(questionText || '')
+    .trim()
+    .toLowerCase();
+  var choice = String(choiceLabel || '')
+    .trim()
+    .toLowerCase();
+  if (!needle) throw new Error('clickInQuestion: empty questionText');
+  if (!choice) throw new Error('clickInQuestion: empty choiceLabel');
+
+  var containers = Array.prototype.slice.call(
+    scope.querySelectorAll('.application-question, [data-qa="question"], .field')
+  );
+  var q = containers.find(function (el) {
+    var header = el.querySelector('.text, .application-question-text, [data-qa="label"], label');
+    var text = (header && header.textContent) || '';
+    return text.trim().toLowerCase().indexOf(needle) !== -1;
+  });
+  if (!q) throw new Error('clickInQuestion: question not found: ' + questionText);
+
+  var labels = Array.prototype.slice.call(q.querySelectorAll('label'));
+  var target = labels.find(function (l) {
+    return (l.textContent || '').trim().toLowerCase() === choice;
+  });
+  if (!target) {
+    throw new Error(
+      'clickInQuestion: choice "' + choiceLabel + '" not found in question "' + questionText + '"'
+    );
+  }
+  if (target.htmlFor) {
+    var input = doc.getElementById(target.htmlFor);
+    if (input) {
+      input.checked = true;
+      if (typeof input.click === 'function') input.click();
+    }
+  } else {
+    target.click();
+  }
+  return {
+    question: (q.textContent || '').trim().slice(0, 80),
+    choice: choiceLabel,
+  };
+}

--- a/src/apply/dom-label.browser.js
+++ b/src/apply/dom-label.browser.js
@@ -81,12 +81,24 @@ function clickInQuestion(questionText, choiceLabel, root) {
   var containers = Array.prototype.slice.call(
     scope.querySelectorAll('.application-question, [data-qa="question"], .field')
   );
-  var q = containers.find(function (el) {
+  var matches = containers.filter(function (el) {
     var header = el.querySelector('.text, .application-question-text, [data-qa="label"], label');
     var text = (header && header.textContent) || '';
     return text.trim().toLowerCase().indexOf(needle) !== -1;
   });
-  if (!q) throw new Error('clickInQuestion: question not found: ' + questionText);
+  if (matches.length === 0) {
+    throw new Error('clickInQuestion: question not found: ' + questionText);
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      'clickInQuestion: ambiguous questionText "' +
+        questionText +
+        '" matched ' +
+        matches.length +
+        ' questions; pass a more distinctive substring'
+    );
+  }
+  var q = matches[0];
 
   var labels = Array.prototype.slice.call(q.querySelectorAll('label'));
   var target = labels.find(function (l) {

--- a/src/apply/dom-label.mjs
+++ b/src/apply/dom-label.mjs
@@ -1,0 +1,25 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BROWSER_SRC = fs.readFileSync(path.join(__dirname, 'dom-label.browser.js'), 'utf8');
+
+export const EXTRACT_LABEL_SRC = BROWSER_SRC;
+
+function loadBrowserFns() {
+  const fn = new Function(
+    BROWSER_SRC + '\nreturn { extractLabel: extractLabel, clickInQuestion: clickInQuestion };'
+  );
+  return fn();
+}
+
+const _fns = loadBrowserFns();
+
+export function extractLabel(el) {
+  return _fns.extractLabel(el);
+}
+
+export function clickInQuestion(questionText, choiceLabel, root) {
+  return _fns.clickInQuestion(questionText, choiceLabel, root);
+}

--- a/tests/apply/click-in-question.test.mjs
+++ b/tests/apply/click-in-question.test.mjs
@@ -43,6 +43,16 @@ test('clickInQuestion: unknown choice throws', () => {
   );
 });
 
+test('clickInQuestion: ambiguous substring matching multiple questions throws', () => {
+  const dom = loadLever();
+  assert.throws(
+    () => clickInQuestion('you', 'No', dom.window.document.body),
+    /ambiguous questionText/
+  );
+  assert.equal(dom.window.document.querySelector('#q1-no').checked, false);
+  assert.equal(dom.window.document.querySelector('#q2-no').checked, false);
+});
+
 test('clickInQuestion: case-insensitive substring match on question text', () => {
   const dom = loadLever();
   const doc = dom.window.document;

--- a/tests/apply/click-in-question.test.mjs
+++ b/tests/apply/click-in-question.test.mjs
@@ -1,0 +1,51 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { JSDOM } from 'jsdom';
+import { clickInQuestion } from '../../src/apply/dom-label.mjs';
+
+function loadLever() {
+  const html = fs.readFileSync(
+    path.join(process.cwd(), 'tests/fixtures/apply/lever-question.html'),
+    'utf8'
+  );
+  return new JSDOM(html);
+}
+
+test('clickInQuestion: scoped to the matching question (not the first Yes/No on the page)', () => {
+  const dom = loadLever();
+  const doc = dom.window.document;
+  assert.equal(doc.querySelector('#q1-no').checked, false);
+  assert.equal(doc.querySelector('#q2-no').checked, false);
+
+  const result = clickInQuestion('final year of study', 'No', doc.body);
+  assert.equal(result.choice, 'No');
+  assert.ok(result.question.toLowerCase().includes('final year'));
+
+  assert.equal(doc.querySelector('#q1-no').checked, true);
+  assert.equal(doc.querySelector('#q2-no').checked, false);
+});
+
+test('clickInQuestion: unknown question throws', () => {
+  const dom = loadLever();
+  assert.throws(
+    () => clickInQuestion('nonexistent question text', 'No', dom.window.document.body),
+    /question not found/
+  );
+});
+
+test('clickInQuestion: unknown choice throws', () => {
+  const dom = loadLever();
+  assert.throws(
+    () => clickInQuestion('final year of study', 'Maybe', dom.window.document.body),
+    /choice "Maybe" not found/
+  );
+});
+
+test('clickInQuestion: case-insensitive substring match on question text', () => {
+  const dom = loadLever();
+  const doc = dom.window.document;
+  clickInQuestion('FINAL YEAR', 'Yes', doc.body);
+  assert.equal(doc.querySelector('#q1-yes').checked, true);
+});

--- a/tests/apply/dom-label.test.mjs
+++ b/tests/apply/dom-label.test.mjs
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { JSDOM } from 'jsdom';
+import { extractLabel } from '../../src/apply/dom-label.mjs';
+
+function loadFixture(rel) {
+  const html = fs.readFileSync(path.join(process.cwd(), rel), 'utf8');
+  return new JSDOM(html);
+}
+
+test('extractLabel: Lever cards[uuid] radio picks up .application-question .text', () => {
+  const dom = loadFixture('tests/fixtures/apply/lever-question.html');
+  const input = dom.window.document.querySelector(
+    'input[name="cards[abc-uuid][field0]"][value="Yes"]'
+  );
+  assert.equal(extractLabel(input), 'Are you currently in your final year of study?');
+});
+
+test('extractLabel: second Lever question is resolved independently', () => {
+  const dom = loadFixture('tests/fixtures/apply/lever-question.html');
+  const input = dom.window.document.querySelector(
+    'input[name="cards[def-uuid][field0]"][value="No"]'
+  );
+  assert.equal(
+    extractLabel(input),
+    'Do you have authorization to work in the country of employment?'
+  );
+});
+
+test('extractLabel: plain <label for> (Greenhouse-style)', () => {
+  const dom = loadFixture('tests/fixtures/apply/greenhouse-form.html');
+  const input = dom.window.document.querySelector('#first_name');
+  assert.equal(extractLabel(input), 'First Name');
+});
+
+test('extractLabel: Ashby data-qa container', () => {
+  const dom = loadFixture('tests/fixtures/apply/ashby-question.html');
+  const input = dom.window.document.querySelector('#ashby-auth');
+  assert.equal(extractLabel(input), 'What is your current work authorization status?');
+});
+
+test('extractLabel: orphan input returns empty string', () => {
+  const dom = loadFixture('tests/fixtures/apply/lever-question.html');
+  const input = dom.window.document.querySelector('#orphan');
+  assert.equal(extractLabel(input), '');
+});

--- a/tests/fixtures/apply/ashby-question.html
+++ b/tests/fixtures/apply/ashby-question.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <body>
+    <form>
+      <div data-qa="question">
+        <div data-qa="label">What is your current work authorization status?</div>
+        <input type="text" id="ashby-auth" name="_systemfield_auth" />
+      </div>
+    </form>
+  </body>
+</html>

--- a/tests/fixtures/apply/lever-question.html
+++ b/tests/fixtures/apply/lever-question.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+  <body>
+    <form>
+      <ul class="application-questions">
+        <li class="application-question">
+          <div class="text">Are you currently in your final year of study?</div>
+          <fieldset>
+            <input type="radio" id="q1-yes" name="cards[abc-uuid][field0]" value="Yes" />
+            <label for="q1-yes">Yes</label>
+            <input type="radio" id="q1-no" name="cards[abc-uuid][field0]" value="No" />
+            <label for="q1-no">No</label>
+          </fieldset>
+        </li>
+        <li class="application-question">
+          <div class="text">Do you have authorization to work in the country of employment?</div>
+          <fieldset>
+            <input type="radio" id="q2-yes" name="cards[def-uuid][field0]" value="Yes" />
+            <label for="q2-yes">Yes</label>
+            <input type="radio" id="q2-no" name="cards[def-uuid][field0]" value="No" />
+            <label for="q2-no">No</label>
+          </fieldset>
+        </li>
+      </ul>
+      <input type="text" id="orphan" name="orphan" />
+    </form>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add `src/apply/dom-label.browser.js` (`extractLabel` + `clickInQuestion`) and its ESM wrapper `dom-label.mjs` exposing `EXTRACT_LABEL_SRC` for `javascript_tool` injection.
- Teach `.claude/commands/apply.md` §4.2 to inject `EXTRACT_LABEL_SRC` so Lever `cards[uuid][fieldN]` radios resolve to the real question text in `.application-question .text` (fixes #6).
- New §5.0 requires `clickInQuestion(questionText, choiceLabel)` for every radio/checkbox click in per-question forms and bans unscoped `label` text matches (fixes #7).
- Add `jsdom` devDependency + 9 unit tests covering Lever, Greenhouse, Ashby, and orphan cases.

## Merge order
Independent of PRs 1, 2, 3. Conflicts with PR 5 on `.claude/commands/apply.md` — this PR must merge first.

## Test plan
- [x] `npm test` green (168/168)
- [x] `npm run lint` clean
- [x] `npm run check:pii` clean
- [ ] Manual: run `/apply` against one live Lever posting with a custom question

🤖 Generated with [Claude Code](https://claude.com/claude-code)