### PR TITLE
feat(onboard): verifySlug primitive and extension host permissions (PR 5/5)

### DIFF
--- a/.claude/commands/apply.md
+++ b/.claude/commands/apply.md
@@ -31,6 +31,30 @@ Do not try to apply with the example templates.
 
 5. **Check the CDP port for CV upload.** Run `curl -sf http://127.0.0.1:9222/json/version` via Bash. If it responds: OK, CV upload will work in step 5. If not: warn the user that Chrome was not launched with `--remote-debugging-port=9222` (the `chrome-apply` alias installs this). Continue without CDP — you will ask for a manual CV drop later.
 
+6. **Pre-flight: extension host permission.** Before the first `find` / `read_page` on the target host, probe via `javascript_tool`:
+
+   ```js
+   // Returns "ok" if the extension has access, throws a permission error
+   // otherwise (which the extension surfaces as a rejected tool call).
+   typeof document !== 'undefined' ? 'ok' : 'no document';
+   ```
+
+   If the probe call itself fails with `"Extension manifest must request permission to access the respective host"`, **stop** and print this block verbatim (substitute `<host>` with the URL's hostname):
+
+   ```
+   ❌ The claude-in-chrome extension does not have permission to access <host>.
+
+   Fix:
+     1. Click the puzzle-piece icon in Chrome's toolbar.
+     2. Open claude-in-chrome → Site access → On specific sites.
+     3. Add https://<host>/*.
+     4. Refresh the tab and re-run /apply.
+
+   See /onboard step 7.4 for the full list of hosts.
+   ```
+
+   Do not attempt to work around this — stopping on ambiguity is the invariant.
+
 ## 1. Open the tab and start GIF recording
 
 1. Open `$ARGUMENTS` in a new tab with `mcp__claude-in-chrome__tabs_create_mcp`.

--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -140,20 +140,29 @@ Run **at least 6 queries** (2 per ATS, varying the keyword/location). Collect un
 
 If the domain is very niche and WebSearch returns fewer than 15 candidates total, ask the user for hints ("Any companies you already have in mind?") and add them.
 
-### 5.2 Verify each URL
+### 5.2 Verify each URL via the ATS API
 
-For each candidate, verify the careers URL actually returns offers via the public ATS API. Use `curl -sfI` for a quick HEAD check, then trust `src/scan/ats-detect.mjs` behavior. You may run a dry-run scan on a single company:
+`curl -sfI` on the public careers page is **not** authoritative — Ashby for example returns `200` on the careers HTML even when the JSON board does not exist (e.g. `dust-tt`). The only honest check is to call the same JSON endpoint `/scan` will use.
+
+For each candidate company, call `verifyCompany(careers_url)` from `src/scan/ats-detect.mjs`. Run it inline via `node -e`:
 
 ```bash
-# Write a minimal temp portals.yml with one company and run:
-node src/scan/index.mjs --dry-run --only <slug>
+node -e "
+  import('./src/scan/ats-detect.mjs').then(async m => {
+    const r = await m.verifyCompany('https://jobs.lever.co/mistral');
+    console.log(JSON.stringify(r));
+  });
+"
 ```
 
-Drop any candidate where:
+Response shape:
 
-- The URL 404s or 301s to a non-ATS host
-- The company has zero current offers matching `title_filter` (not a hard drop — keep if at least 3 total offers exist on the board, the filter may match next week)
-- The company is a clear duplicate (same org, multiple slugs)
+- `{ ok: true, count: N }` → slug is live, `N` offers currently on the board. Keep the company. If `count` is 0, flag it for the user to sanity-check ("board exists but empty — check slug spelling").
+- `{ ok: false, status, reason }` → drop the company. If you get a transient failure (5xx, network error), retry **once** with a 2 s backoff before dropping.
+
+Add a 100 ms delay between verifications to be polite to the APIs (30 companies × 100 ms ≈ 3 s extra).
+
+Also drop any candidate that is a clear duplicate (same org, multiple slugs).
 
 ### 5.3 Trim to ~30 and present for approval
 

--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -230,6 +230,36 @@ exit 1
 - **If CDP comes up**: great, continue to 7.3.
 - **If not** (8s elapsed): Chrome may have failed to start. Check the background task output for errors. Fall back to telling the user to run `chrome-apply` manually and print the summary from 7.3 anyway.
 
+### 7.4 Grant extension host permissions
+
+The `claude-in-chrome` extension requires per-host permission for every ATS domain it touches. Chrome does **not** expose a programmatic grant — the user must click. Without this, `/apply` fails on the first `find` call with "Extension manifest must request permission to access the respective host".
+
+Derive the list of hosts from the single source of truth — don't hard-code it:
+
+```bash
+node -e "
+  import('./src/scan/ats-detect.mjs').then(m => {
+    for (const h of m.getSupportedHosts()) console.log('  - ' + h);
+  });
+"
+```
+
+Print this exact instruction block to the user, substituting the host list from the command above:
+
+```
+After you click "Add to Chrome" and approve the install:
+
+  1. Click the puzzle-piece icon in Chrome's toolbar.
+  2. Find "claude-in-chrome" → three-dot menu → "This can read and
+     change site data" → "On specific sites".
+  3. Add each of these hosts (one by one):
+       <host list from getSupportedHosts() above>
+  4. If prompted during install, also allow
+     https://chromewebstore.google.com/*.
+```
+
+Do **not** continue past 7.3 until the user confirms the permissions are granted. If you skip this, `/apply` will fail the first time it is run.
+
 ### 7.3 Final summary
 
 Print a clean summary. The only manual step left is clicking "Add to Chrome" on the extension page that should now be open:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `npm run explain -- "<title>" [--company "<co>"]` CLI traces why a title is accepted or filtered by the current `portals.yml` + `candidate-profile.yml`.
+- `verifySlug(slug)` primitive on each ATS fetcher (`lever`, `greenhouse`, `ashby`), returning `{ ok, count }` or `{ ok: false, status, reason }`.
+- `verifyCompany(careersUrl)` dispatcher and `getSupportedHosts()` helper in `src/scan/ats-detect.mjs`.
+- `/onboard` step 7.4 documents the four `claude-in-chrome` host permissions the user must grant after installing the extension, with the host list derived from `getSupportedHosts()` (single source of truth).
+- `/apply` step 0 now pre-flights the extension host permission and surfaces a clear remediation block on failure.
+
+### Changed (continued)
+
+- `/onboard` step 5.2 now verifies candidate companies via the JSON API endpoint (`verifyCompany`) instead of `curl -sfI` on the public careers page. Fixes a silent-drop bug where Ashby returned `200` on the careers HTML but `404` on the JSON board (e.g. `dust-tt`).
 
 ## [0.1.0-alpha.0] — 2026-04-10
 

--- a/src/scan/ats-detect.mjs
+++ b/src/scan/ats-detect.mjs
@@ -16,3 +16,27 @@ export function detectPlatform(careersUrl) {
   }
   return null;
 }
+
+const VERIFIABLE_PLATFORMS = new Set(['lever', 'greenhouse', 'ashby']);
+
+const SUPPORTED_HOSTS = [
+  'https://jobs.lever.co/*',
+  'https://boards.greenhouse.io/*',
+  'https://job-boards.greenhouse.io/*',
+  'https://jobs.ashbyhq.com/*',
+];
+
+export function getSupportedHosts() {
+  return [...SUPPORTED_HOSTS];
+}
+
+export async function verifyCompany(careersUrl) {
+  const det = detectPlatform(careersUrl);
+  if (!det) return { ok: false, reason: 'unknown platform' };
+  const { platform, slug } = det;
+  if (!VERIFIABLE_PLATFORMS.has(platform)) {
+    return { ok: false, reason: `platform ${platform} not supported by verifySlug` };
+  }
+  const mod = await import(`./ats/${platform}.mjs`);
+  return mod.verifySlug(slug);
+}

--- a/src/scan/ats/ashby.mjs
+++ b/src/scan/ats/ashby.mjs
@@ -20,3 +20,16 @@ export async function fetchAshby(slug, companyName) {
     platform: 'ashby',
   }));
 }
+
+export async function verifySlug(slug) {
+  const url = `https://api.ashbyhq.com/posting-api/job-board/${slug}?includeCompensation=false`;
+  const res = await fetch(url, {
+    headers: { Accept: 'application/json', 'User-Agent': 'claude-apply-verify/1.0' },
+  });
+  if (res.ok) {
+    const data = await res.json();
+    const count = Array.isArray(data?.jobs) ? data.jobs.length : 0;
+    return { ok: true, count };
+  }
+  return { ok: false, status: res.status, reason: `HTTP ${res.status}` };
+}

--- a/src/scan/ats/greenhouse.mjs
+++ b/src/scan/ats/greenhouse.mjs
@@ -41,3 +41,16 @@ export async function fetchGreenhouse(slug, companyName) {
     platform: 'greenhouse',
   }));
 }
+
+export async function verifySlug(slug) {
+  const url = `https://boards-api.greenhouse.io/v1/boards/${slug}/jobs?content=true`;
+  const res = await fetch(url, {
+    headers: { Accept: 'application/json', 'User-Agent': 'claude-apply-verify/1.0' },
+  });
+  if (res.ok) {
+    const data = await res.json();
+    const count = Array.isArray(data?.jobs) ? data.jobs.length : 0;
+    return { ok: true, count };
+  }
+  return { ok: false, status: res.status, reason: `HTTP ${res.status}` };
+}

--- a/src/scan/ats/lever.mjs
+++ b/src/scan/ats/lever.mjs
@@ -23,3 +23,15 @@ export async function fetchLever(slug, companyName) {
     platform: 'lever',
   }));
 }
+
+export async function verifySlug(slug) {
+  const url = `https://api.lever.co/v0/postings/${slug}?mode=json`;
+  const res = await fetch(url, {
+    headers: { Accept: 'application/json', 'User-Agent': 'claude-apply-verify/1.0' },
+  });
+  if (res.ok) {
+    const data = await res.json();
+    return { ok: true, count: Array.isArray(data) ? data.length : 0 };
+  }
+  return { ok: false, status: res.status, reason: `HTTP ${res.status}` };
+}

--- a/tests/scan/verify-company.test.mjs
+++ b/tests/scan/verify-company.test.mjs
@@ -1,0 +1,62 @@
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { installMockFetch } from '../helpers.mjs';
+import { verifyCompany, getSupportedHosts } from '../../src/scan/ats-detect.mjs';
+
+let restore;
+afterEach(() => {
+  if (restore) restore();
+});
+
+test('verifyCompany — dispatche Lever via URL', async () => {
+  restore = installMockFetch({
+    'https://api.lever.co/v0/postings/mistral?mode=json': [{ id: '1' }],
+  });
+  const r = await verifyCompany('https://jobs.lever.co/mistral');
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 1);
+});
+
+test('verifyCompany — dispatche Greenhouse via URL', async () => {
+  restore = installMockFetch({
+    'https://boards-api.greenhouse.io/v1/boards/anthropic/jobs?content=true': {
+      jobs: [{ id: 1 }, { id: 2 }],
+    },
+  });
+  const r = await verifyCompany('https://boards.greenhouse.io/anthropic');
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 2);
+});
+
+test('verifyCompany — dispatche Ashby via URL', async () => {
+  restore = installMockFetch({
+    'https://api.ashbyhq.com/posting-api/job-board/hex?includeCompensation=false': {
+      jobs: [{ id: 'a' }],
+    },
+  });
+  const r = await verifyCompany('https://jobs.ashbyhq.com/hex');
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 1);
+});
+
+test('verifyCompany — URL non reconnue renvoie ok:false', async () => {
+  const r = await verifyCompany('https://careers.example.com/jobs');
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /unknown platform/);
+});
+
+test('verifyCompany — plateforme sans verifySlug (workable) renvoie ok:false', async () => {
+  const r = await verifyCompany('https://apply.workable.com/acme');
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /not supported/i);
+});
+
+test('getSupportedHosts — retourne les 4 hôtes ATS avec fetcher vérifiable', () => {
+  const hosts = getSupportedHosts();
+  assert.deepEqual(hosts.sort(), [
+    'https://boards.greenhouse.io/*',
+    'https://job-boards.greenhouse.io/*',
+    'https://jobs.ashbyhq.com/*',
+    'https://jobs.lever.co/*',
+  ]);
+});

--- a/tests/scan/verify-slug.test.mjs
+++ b/tests/scan/verify-slug.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { installMockFetch } from '../helpers.mjs';
 import { verifySlug as verifyLever } from '../../src/scan/ats/lever.mjs';
 import { verifySlug as verifyGreenhouse } from '../../src/scan/ats/greenhouse.mjs';
+import { verifySlug as verifyAshby } from '../../src/scan/ats/ashby.mjs';
 
 let restore;
 afterEach(() => {
@@ -65,6 +66,40 @@ test('verifySlug (greenhouse) — slug invalide 404', async () => {
     },
   });
   const r = await verifyGreenhouse('nope');
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 404);
+});
+
+test('verifySlug (ashby) — slug valide avec postings', async () => {
+  restore = installMockFetch({
+    'https://api.ashbyhq.com/posting-api/job-board/hex?includeCompensation=false': {
+      jobs: [{ id: 'a' }],
+    },
+  });
+  const r = await verifyAshby('hex');
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 1);
+});
+
+test('verifySlug (ashby) — board vide', async () => {
+  restore = installMockFetch({
+    'https://api.ashbyhq.com/posting-api/job-board/quiet?includeCompensation=false': {
+      jobs: [],
+    },
+  });
+  const r = await verifyAshby('quiet');
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 0);
+});
+
+test('verifySlug (ashby) — slug invalide 404 (cas Dust)', async () => {
+  restore = installMockFetch({
+    'https://api.ashbyhq.com/posting-api/job-board/dust-tt?includeCompensation=false': {
+      status: 404,
+      body: {},
+    },
+  });
+  const r = await verifyAshby('dust-tt');
   assert.equal(r.ok, false);
   assert.equal(r.status, 404);
 });

--- a/tests/scan/verify-slug.test.mjs
+++ b/tests/scan/verify-slug.test.mjs
@@ -1,0 +1,37 @@
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { installMockFetch } from '../helpers.mjs';
+import { verifySlug as verifyLever } from '../../src/scan/ats/lever.mjs';
+
+let restore;
+afterEach(() => {
+  if (restore) restore();
+});
+
+test('verifySlug (lever) — slug valide avec postings', async () => {
+  restore = installMockFetch({
+    'https://api.lever.co/v0/postings/mistral?mode=json': [{ id: '1' }, { id: '2' }],
+  });
+  const r = await verifyLever('mistral');
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 2);
+});
+
+test('verifySlug (lever) — slug valide avec 0 posting', async () => {
+  restore = installMockFetch({
+    'https://api.lever.co/v0/postings/empty-co?mode=json': [],
+  });
+  const r = await verifyLever('empty-co');
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 0);
+});
+
+test('verifySlug (lever) — slug invalide renvoie ok:false + status', async () => {
+  restore = installMockFetch({
+    'https://api.lever.co/v0/postings/nope?mode=json': { status: 404, body: {} },
+  });
+  const r = await verifyLever('nope');
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 404);
+  assert.match(r.reason, /HTTP 404/);
+});

--- a/tests/scan/verify-slug.test.mjs
+++ b/tests/scan/verify-slug.test.mjs
@@ -2,6 +2,7 @@ import { test, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { installMockFetch } from '../helpers.mjs';
 import { verifySlug as verifyLever } from '../../src/scan/ats/lever.mjs';
+import { verifySlug as verifyGreenhouse } from '../../src/scan/ats/greenhouse.mjs';
 
 let restore;
 afterEach(() => {
@@ -34,4 +35,36 @@ test('verifySlug (lever) — slug invalide renvoie ok:false + status', async () 
   assert.equal(r.ok, false);
   assert.equal(r.status, 404);
   assert.match(r.reason, /HTTP 404/);
+});
+
+test('verifySlug (greenhouse) — slug valide avec postings', async () => {
+  restore = installMockFetch({
+    'https://boards-api.greenhouse.io/v1/boards/anthropic/jobs?content=true': {
+      jobs: [{ id: 1 }, { id: 2 }, { id: 3 }],
+    },
+  });
+  const r = await verifyGreenhouse('anthropic');
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 3);
+});
+
+test('verifySlug (greenhouse) — board vide', async () => {
+  restore = installMockFetch({
+    'https://boards-api.greenhouse.io/v1/boards/quiet-co/jobs?content=true': { jobs: [] },
+  });
+  const r = await verifyGreenhouse('quiet-co');
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 0);
+});
+
+test('verifySlug (greenhouse) — slug invalide 404', async () => {
+  restore = installMockFetch({
+    'https://boards-api.greenhouse.io/v1/boards/nope/jobs?content=true': {
+      status: 404,
+      body: {},
+    },
+  });
+  const r = await verifyGreenhouse('nope');
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 404);
 });


### PR DESCRIPTION
## Summary

Final PR (5/5) of the test-feedback series. Fixes:

- **#9** — `/onboard` slug verification was using `curl -sfI` on the public careers page, which silently returned `200` for slugs whose JSON board didn't exist (e.g. `dust-tt` on Ashby). Now uses the same JSON endpoint `/scan` will hit.
- **#8** — `claude-in-chrome` extension host permissions were never explained, so first `/apply` always failed with "Extension manifest must request permission to access the respective host".

## Changes

**New primitives** (`src/scan/`):
- `verifySlug(slug)` on `lever.mjs`, `greenhouse.mjs`, `ashby.mjs` → `{ ok, count }` or `{ ok: false, status, reason }`.
- `verifyCompany(careersUrl)` dispatcher in `ats-detect.mjs`.
- `getSupportedHosts()` helper — single source of truth for the four ATS hosts the extension needs permission for.

**Docs**:
- `/onboard` §5.2 rewritten to use `verifyCompany` instead of `curl -sfI`.
- `/onboard` §7.4 (new) — instructs the user (and the agent) to grant per-host permissions after extension install, deriving the host list from `getSupportedHosts()`.
- `/apply` §0 step 6 (new) — pre-flight probe + clear remediation block on permission failure.
- `CHANGELOG.md` updated.

## Test plan

- [x] `npm test` — 229/229 green (15 new cases: 9 in `verify-slug.test.mjs`, 6 in `verify-company.test.mjs`)
- [x] `npm run lint` clean
- [x] `npm run check:pii` clean
- [ ] Manual smoke: `node -e "import('./src/scan/ats-detect.mjs').then(m => m.verifyCompany('https://jobs.lever.co/mistral').then(r => console.log(r)))"` against the live Lever API

## Notes

- Spec dependency on PR 1 from the original 5-PR plan is moot — PR 1 was never split out, so this PR carries both the §5.2 rewrite and the §7.4 addition.
- Workable is intentionally **not** verifiable: no fetcher exists for it. `verifyCompany` returns `{ ok: false, reason: 'platform workable not supported by verifySlug' }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)