### PR TITLE
feat(scan): add Workday ATS support (Plan 1/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `verifyCompany(careersUrl)` dispatcher and `getSupportedHosts()` helper in `src/scan/ats-detect.mjs`.
 - `/onboard` step 7.4 documents the four `claude-in-chrome` host permissions the user must grant after installing the extension, with the host list derived from `getSupportedHosts()` (single source of truth).
 - `/apply` step 0 now pre-flights the extension host permission and surfaces a clear remediation block on failure.
+- Workday ATS support for `/scan` — new fetcher `src/scan/ats/workday.mjs` with `parseWorkdayUrl`, `fetchWorkday` (paginated), and `verifySlug`. Portals in `config/portals.yml` can now use `platform: workday` with the full career page URL (e.g. `https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers`). Unlocks scanning ~60% of CAC40 and a large share of Fortune 500 hiring. `/apply` support for Workday is not yet implemented.
 
 ### Changed (continued)
 

--- a/docs/superpowers/plans/2026-04-11-workday-pr8-fix.md
+++ b/docs/superpowers/plans/2026-04-11-workday-pr8-fix.md
@@ -1,0 +1,366 @@
+# Workday PR #8 Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two correctness bugs in PR #8 (missing Workday entry in scan `DISPATCH`; locale prefix not handled in `detectPlatform` regex) and add an integration test that exercises Workday end-to-end through `fetchCompanyOffers` so the regression class cannot recur.
+
+**Architecture:** Two minimal source edits and two new tests, all inside the existing `feat/scan-workday` branch. Tests follow TDD (red → green) within each task; the whole change ships as **one commit** force-pushed onto PR #8.
+
+**Tech Stack:** Node 20 ESM, `node:test`, existing `installMockFetch` helper from `tests/helpers.mjs`. Fixtures already in `tests/fixtures/`.
+
+**Spec:** [`docs/superpowers/specs/2026-04-11-workday-pr8-fix-design.md`](../specs/2026-04-11-workday-pr8-fix-design.md)
+
+---
+
+## File map
+
+| File | Action | Purpose |
+| --- | --- | --- |
+| `src/scan/ats-detect.mjs` | Modify (line 11) | Add optional locale group `(?:\/[a-z]{2}-[A-Z]{2})?` to Workday `PATTERNS` regex |
+| `src/scan/index.mjs` | Modify (lines ~21, ~32-36) | Import `fetchWorkday` and add `workday: fetchWorkday` to `DISPATCH` |
+| `tests/scan/ats-detect.test.mjs` | Modify (append test) | Unit test asserting `detectPlatform` accepts a locale-prefixed Workday URL and the captured slug round-trips through `parseWorkdayUrl` |
+| `tests/scan/scan.test.mjs` | Modify (append test) | Integration test running `runScan` with a Workday company, exercising the full `fetchCompanyOffers` → `DISPATCH` → `fetchWorkday` path for both bare and locale URLs |
+
+No new fixture files. Reuses `tests/fixtures/workday-totalenergies-page2.json` (the short / terminating page) so the test does not need to mock pagination.
+
+---
+
+## Task 1: Failing test for locale-prefix detection (RED)
+
+**Why first:** demonstrates the regex bug at the unit level before touching code.
+
+**Files:**
+- Modify: `tests/scan/ats-detect.test.mjs` (append at end of file)
+
+- [ ] **Step 1: Append the failing test**
+
+Open `tests/scan/ats-detect.test.mjs` and append at the end of the file (after the existing `getSupportedHosts` test):
+
+```js
+test('detectPlatform — Workday URL avec préfixe locale (en-US, fr-FR) reste valide', () => {
+  // Workday surfaces locale-prefixed URLs in the browser address bar.
+  // The captured slug must contain the real site segment so that
+  // parseWorkdayUrl downstream can resolve {tenant, pod, site} correctly.
+  const enUS = detectPlatform(
+    'https://totalenergies.wd3.myworkdayjobs.com/en-US/TotalEnergies_careers'
+  );
+  assert.equal(enUS.platform, 'workday');
+  assert.ok(
+    enUS.slug.includes('TotalEnergies_careers'),
+    `expected slug to retain site segment, got: ${enUS.slug}`
+  );
+
+  const frFR = detectPlatform(
+    'https://capgemini.wd5.myworkdayjobs.com/fr-FR/CapgeminiCareers'
+  );
+  assert.equal(frFR.platform, 'workday');
+  assert.ok(
+    frFR.slug.includes('CapgeminiCareers'),
+    `expected slug to retain site segment, got: ${frFR.slug}`
+  );
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `node --test --test-name-pattern="préfixe locale" tests/scan/ats-detect.test.mjs`
+
+Expected: FAIL. The current regex captures `…/en-US` (or `…/fr-FR`) as the slug, missing the site segment, so `slug.includes('TotalEnergies_careers')` is false.
+
+---
+
+## Task 2: Fix the `detectPlatform` Workday regex (GREEN)
+
+**Files:**
+- Modify: `src/scan/ats-detect.mjs:11`
+
+- [ ] **Step 1: Update the Workday pattern**
+
+In `src/scan/ats-detect.mjs`, replace lines 9-12:
+
+```js
+  {
+    platform: 'workday',
+    re: /^(https?:\/\/[^.]+\.wd\d+\.myworkdayjobs\.com\/[^\/?#]+)/i,
+  },
+```
+
+with:
+
+```js
+  {
+    platform: 'workday',
+    re: /^(https?:\/\/[^.]+\.wd\d+\.myworkdayjobs\.com(?:\/[a-z]{2}-[A-Z]{2})?\/[^\/?#]+)/i,
+  },
+```
+
+The capture group still wraps the entire URL prefix (locale segment included when present). `parseWorkdayUrl` in `src/scan/ats/workday.mjs` already strips the locale, so the captured slug remains a valid input to both `verifySlug` and `fetchWorkday`.
+
+- [ ] **Step 2: Run the locale test and confirm it passes**
+
+Run: `node --test --test-name-pattern="préfixe locale" tests/scan/ats-detect.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the full `ats-detect` suite to confirm no regression**
+
+Run: `node --test tests/scan/ats-detect.test.mjs`
+
+Expected: ALL PASS, including the existing `recognises Workday URL and returns full URL as slug` test (the bare-URL form is unchanged).
+
+---
+
+## Task 3: Failing integration test for Workday in `runScan` (RED)
+
+**Why:** the existing PR #8 tests cover `parseWorkdayUrl`, `fetchWorkday`, and `detectPlatform` in isolation, but never in composition through `runScan` / `fetchCompanyOffers`. Either bug from PR #8 review would have been caught immediately by such a test. This task adds it before fixing the wiring.
+
+**Files:**
+- Modify: `tests/scan/scan.test.mjs` (append at end of file)
+
+- [ ] **Step 1: Append the failing integration test**
+
+Open `tests/scan/scan.test.mjs` and append at the end of the file:
+
+```js
+test('runScan — Workday end-to-end (URL nue + URL avec locale)', async () => {
+  // Reuse the existing terminating-page fixture so we don't need pagination mocks.
+  const fxPath = path.join(
+    REPO_ROOT,
+    'tests',
+    'fixtures',
+    'workday-totalenergies-page2.json'
+  );
+  const workdayBody = JSON.parse(fs.readFileSync(fxPath, 'utf8'));
+
+  const portalsConfig = {
+    title_filter: { positive: [], negative: [] },
+    tracked_companies: [
+      {
+        name: 'TotalEnergies (bare)',
+        careers_url:
+          'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers',
+        enabled: true,
+      },
+      {
+        name: 'TotalEnergies (locale)',
+        careers_url:
+          'https://totalenergies.wd3.myworkdayjobs.com/en-US/TotalEnergies_careers',
+        enabled: true,
+      },
+    ],
+  };
+  const profile = { min_start_date: '2020-01-01', blacklist_companies: [] };
+
+  // Both companies hit the same Workday API endpoint (locale is stripped
+  // by parseWorkdayUrl). The fixture is a short page so fetchWorkday's
+  // pagination loop terminates after a single call per company.
+  const workdayEndpoint =
+    'https://totalenergies.wd3.myworkdayjobs.com/wday/cxs/totalenergies/TotalEnergies_careers/jobs';
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (reqUrl) => {
+    const key = typeof reqUrl === 'string' ? reqUrl : reqUrl.toString();
+    if (key !== workdayEndpoint) {
+      throw new Error(`unexpected fetch URL in test: ${key}`);
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => workdayBody,
+      text: async () => JSON.stringify(workdayBody),
+    };
+  };
+
+  try {
+    const pipelinePath = path.join(tmp, 'pipeline.md');
+    const historyPath = path.join(tmp, 'scan-history.tsv');
+    const filteredPath = path.join(tmp, 'filtered-out.tsv');
+    const applicationsPath = path.join(tmp, 'applications.md');
+    fs.writeFileSync(applicationsPath, '# Apps\n');
+
+    const result = await runScan({
+      portalsConfig,
+      profile,
+      pipelinePath,
+      historyPath,
+      filteredPath,
+      applicationsPath,
+      dryRun: false,
+    });
+
+    // Both companies must produce raw offers from the same fixture.
+    // (Exact count depends on the fixture; the key assertion is "> 0".)
+    assert.ok(
+      result.raw > 0,
+      `expected raw > 0 for Workday companies, got ${result.raw}`
+    );
+
+    // Neither company should error out. result.errors is the canonical
+    // place runScan records per-company failures.
+    const errs = (result.errors || []).filter((e) =>
+      String(e.company || '').startsWith('TotalEnergies')
+    );
+    assert.equal(
+      errs.length,
+      0,
+      `expected no Workday errors, got: ${JSON.stringify(errs)}`
+    );
+
+    // pipeline.md should mention TotalEnergies (proves offers were written).
+    const md = fs.readFileSync(pipelinePath, 'utf8');
+    assert.ok(
+      md.includes('TotalEnergies'),
+      'expected pipeline.md to contain at least one TotalEnergies offer'
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+```
+
+> **Note for the implementer:** the assertion `result.errors` assumes `runScan` exposes a per-company errors array. Before running the test, open `src/scan/index.mjs` and confirm the actual field name on the `runScan` return value (it may be called `errors`, `failed`, or stored on individual entries). If the name differs, adjust the test to match — the **intent** is "no per-company error for either Workday entry". Do **not** change `runScan` to fit the test.
+
+- [ ] **Step 2: Run the integration test and confirm it fails**
+
+Run: `node --test --test-name-pattern="Workday end-to-end" tests/scan/scan.test.mjs`
+
+Expected: FAIL. With `DISPATCH` missing the `workday` entry, `fetchCompanyOffers` returns `{ error: 'no fetcher', offers: [] }` for both companies, so `result.raw === 0` (and/or `result.errors` is non-empty), tripping the first assertion.
+
+---
+
+## Task 4: Wire `fetchWorkday` into `DISPATCH` (GREEN)
+
+**Files:**
+- Modify: `src/scan/index.mjs` (lines ~21 and ~32-36)
+
+- [ ] **Step 1: Add the import**
+
+In `src/scan/index.mjs`, find the existing fetcher imports (currently lines 21-23):
+
+```js
+import { fetchLever } from './ats/lever.mjs';
+import { fetchGreenhouse } from './ats/greenhouse.mjs';
+import { fetchAshby } from './ats/ashby.mjs';
+```
+
+Append a fourth line:
+
+```js
+import { fetchWorkday } from './ats/workday.mjs';
+```
+
+The four imports should now be in the same block, in alphabetical-ish order matching the existing pattern (lever, greenhouse, ashby, workday).
+
+- [ ] **Step 2: Add the `DISPATCH` entry**
+
+Find the `DISPATCH` map (currently lines 32-36):
+
+```js
+const DISPATCH = {
+  lever: fetchLever,
+  greenhouse: fetchGreenhouse,
+  ashby: fetchAshby,
+};
+```
+
+Replace with:
+
+```js
+const DISPATCH = {
+  lever: fetchLever,
+  greenhouse: fetchGreenhouse,
+  ashby: fetchAshby,
+  workday: fetchWorkday,
+};
+```
+
+- [ ] **Step 3: Run the integration test and confirm it passes**
+
+Run: `node --test --test-name-pattern="Workday end-to-end" tests/scan/scan.test.mjs`
+
+Expected: PASS. Both Workday companies now route through `fetchWorkday`, the locale URL is correctly detected (Task 2's fix), and `parseWorkdayUrl` strips the locale before constructing the API endpoint.
+
+- [ ] **Step 4: Run the full scan suite to confirm no regression**
+
+Run: `node --test tests/scan/scan.test.mjs tests/scan/ats-detect.test.mjs tests/scan/ats-workday.test.mjs`
+
+Expected: ALL PASS.
+
+---
+
+## Task 5: Full validation, single commit, force-push
+
+**Files:** none (delivery only)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm test`
+
+Expected: all tests pass (including the two new ones from Tasks 1 and 3, plus the 249 pre-existing tests on the branch).
+
+- [ ] **Step 2: Run lint**
+
+Run: `npm run lint`
+
+Expected: no Prettier diff. If it complains, run `npm run format` and re-run lint.
+
+- [ ] **Step 3: Run the PII gate**
+
+Run: `npm run check:pii`
+
+Expected: clean. The test fixtures touch only `TotalEnergies`, `totalenergies`, and `Capgemini`, all of which are public corporate names already used elsewhere in the branch — no PII risk.
+
+- [ ] **Step 4: Stage and commit**
+
+Run:
+
+```bash
+git add src/scan/ats-detect.mjs src/scan/index.mjs tests/scan/ats-detect.test.mjs tests/scan/scan.test.mjs
+git status
+```
+
+Confirm only those four files are staged. Then:
+
+```bash
+git commit -m "$(cat <<'EOF'
+fix(scan): wire Workday into DISPATCH and handle locale URLs
+
+PR #8 review caught two correctness bugs:
+
+- src/scan/index.mjs never imported fetchWorkday or added it to
+  the DISPATCH map, so Workday companies fell through to the
+  'no fetcher' branch and silently produced zero offers.
+- src/scan/ats-detect.mjs's Workday regex did not strip the
+  locale segment (e.g. /en-US/), so locale-prefixed URLs were
+  parsed as { site: 'en-US', ... } downstream and hit the wrong
+  Workday API endpoint.
+
+Adds an integration test in tests/scan/scan.test.mjs that runs
+runScan end-to-end against a mocked Workday endpoint for both
+bare and locale-prefixed URLs — either bug would have failed
+this test immediately.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 5: Force-push to PR #8**
+
+Run: `git push --force-with-lease origin feat/scan-workday`
+
+Expected: push succeeds, PR #8 picks up the new commit. `--force-with-lease` (not `--force`) protects against overwriting concurrent updates from another machine.
+
+- [ ] **Step 6: Verify PR state**
+
+Run: `gh pr view 8 --json state,statusCheckRollup,headRefOid`
+
+Expected: PR is OPEN, head SHA matches the new commit, CI is queued or green. No further action — the original review comment will be visibly resolved by the diff.
+
+---
+
+## Self-review
+
+- **Spec coverage:** Section 1 of the spec → Tasks 2 + 4. Section 2 → Task 2. Section 3 (integration test) → Tasks 3 + 4. Section 4 (delivery) → Task 5. All sections covered.
+- **Placeholder scan:** none. The one judgment call (the field name on `runScan`'s return value) is explicitly flagged with instructions on how to verify and adjust without changing production code.
+- **Type/identifier consistency:** all file paths verified against the actual codebase. The integration test uses `runScan` with the same destructured argument names already used by the existing `runScan — e2e` test. The fixture path matches what `tests/scan/ats-workday.test.mjs` already uses (`tests/fixtures/workday-totalenergies-page2.json`).
+- **TDD discipline:** every task either writes a failing test before code, or runs an existing failing test from a prior task before fixing it.

--- a/docs/superpowers/plans/2026-04-11-workday-scan.md
+++ b/docs/superpowers/plans/2026-04-11-workday-scan.md
@@ -1,0 +1,856 @@
+# Workday scan implementation plan (Plan 1 of 3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Workday support to `/scan`, so career pages at `{tenant}.wd{N}.myworkdayjobs.com/{site}` can be scanned and their offers appended to `data/pipeline.md`.
+
+**Architecture:** One new fetcher file `src/scan/ats/workday.mjs` holding `parseWorkdayUrl`, `fetchWorkday`, and `verifySlug` (same file structure as `lever.mjs` / `greenhouse.mjs` / `ashby.mjs`). The Workday API is `POST {origin}/wday/cxs/{tenant}/{site}/jobs` with JSON pagination. `src/scan/ats-detect.mjs` gets a new `PATTERNS` entry, `workday` added to `VERIFIABLE_PLATFORMS`, and `*.myworkdayjobs.com` added to `SUPPORTED_HOSTS`.
+
+**Tech Stack:** Node 20+ ESM, `node:test`, `node:fs`, Web `fetch`. Tests use `tests/helpers.mjs::installMockFetch` with a local stateful wrapper for the pagination case.
+
+**Out of scope (deferred to plans 2 + 3):** `/apply` Workday support, account creation, credential storage, playbook markdown, `CLAUDE.md` invariant change.
+
+**Pre-check before starting**: the branch `feat/scan-workday` must be rebased on `main` at a commit that already contains PR #7 (`verifyCompany` in `src/scan/ats-detect.mjs`, `verifySlug` in each fetcher file). Run `git log --oneline -5` and confirm you see `feat(onboard): verifySlug primitive and extension host permissions (PR 5/5) (#7)` (commit `cd8f931` or later).
+
+---
+
+## File structure
+
+**Create:**
+- `src/scan/ats/workday.mjs` — fetcher, URL parser, verifier
+- `tests/scan/ats-workday.test.mjs` — unit tests for the fetcher + parser + verifier
+- `tests/fixtures/workday-totalenergies-page1.json` — single-page canned fixture
+- `tests/fixtures/workday-totalenergies-page2.json` — partial second page fixture (for pagination)
+
+**Modify:**
+- `src/scan/ats-detect.mjs` — add `workday` pattern, `VERIFIABLE_PLATFORMS`, `SUPPORTED_HOSTS`
+- `tests/scan/ats-detect.test.mjs` — extend with Workday pattern tests
+- `tests/scan/verify-company.test.mjs` — extend with Workday dispatch case (if the file imports `verifyCompany`; otherwise keep in `ats-detect.test.mjs`)
+- `CHANGELOG.md` — under `## Unreleased`, add `feat(scan): add Workday fetcher and verifySlug`
+- `templates/portals.example.yml` — add a Workday example entry (if the file exists; otherwise skip)
+
+**Do not modify in this plan:**
+- Any file under `src/apply/`
+- `CLAUDE.md`
+- `.claude/commands/*`
+- `docs/ats-support.md`, `docs/apply-workflow.md`, `docs/extending.md` (these get batched in Plan 3)
+
+---
+
+## Task 1: Add canned Workday API fixtures
+
+**Files:**
+- Create: `tests/fixtures/workday-totalenergies-page1.json`
+- Create: `tests/fixtures/workday-totalenergies-page2.json`
+
+The Workday jobs API returns a JSON object with shape `{ total, jobPostings: [...] }` where each posting has `title`, `externalPath`, `locationsText`, `postedOn`, `bulletFields`, `jobRequisitionId`. We use hand-crafted fixtures so tests are deterministic and do not require network access. Real-tenant smoke verification happens at the end of the plan (Task 9).
+
+- [ ] **Step 1: Create page 1 fixture**
+
+```bash
+mkdir -p tests/fixtures
+```
+
+Write `tests/fixtures/workday-totalenergies-page1.json`:
+
+```json
+{
+  "total": 23,
+  "jobPostings": [
+    {
+      "title": "Data Engineer - Paris",
+      "externalPath": "/job/Paris/Data-Engineer---Paris_R12345",
+      "locationsText": "Paris, France",
+      "postedOn": "Posted 2 Days Ago",
+      "bulletFields": ["R12345", "2 Days Ago"],
+      "jobRequisitionId": "R12345"
+    },
+    {
+      "title": "Senior Software Engineer - Platform",
+      "externalPath": "/job/Courbevoie/Senior-Software-Engineer---Platform_R12346",
+      "locationsText": "Courbevoie, France",
+      "postedOn": "Posted 5 Days Ago",
+      "bulletFields": ["R12346", "5 Days Ago"],
+      "jobRequisitionId": "R12346"
+    },
+    {
+      "title": "Staff Data Scientist",
+      "externalPath": "/job/Remote/Staff-Data-Scientist_R12347",
+      "locationsText": "Remote - France",
+      "postedOn": "Posted Yesterday",
+      "bulletFields": ["R12347", "Yesterday"],
+      "jobRequisitionId": "R12347"
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Create page 2 fixture (partial, to signal pagination end)**
+
+Write `tests/fixtures/workday-totalenergies-page2.json`:
+
+```json
+{
+  "total": 23,
+  "jobPostings": [
+    {
+      "title": "Cloud Infrastructure Engineer",
+      "externalPath": "/job/Paris/Cloud-Infrastructure-Engineer_R12348",
+      "locationsText": "Paris, France",
+      "postedOn": "Posted 10 Days Ago",
+      "bulletFields": ["R12348", "10 Days Ago"],
+      "jobRequisitionId": "R12348"
+    }
+  ]
+}
+```
+
+The page 1 fixture has 3 postings (== page size in tests). The page 2 fixture has 1 posting (< page size), which is how the fetcher detects the last page.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/fixtures/workday-totalenergies-page1.json tests/fixtures/workday-totalenergies-page2.json
+git commit -m "test(scan): add Workday fixtures for TotalEnergies tenant"
+```
+
+---
+
+## Task 2: Implement and test `parseWorkdayUrl`
+
+**Files:**
+- Create: `src/scan/ats/workday.mjs`
+- Create: `tests/scan/ats-workday.test.mjs`
+
+`parseWorkdayUrl` is a pure function `(string) → { tenant, pod, site }` that extracts the three URL components. It throws on URLs that do not match the Workday shape.
+
+- [ ] **Step 1: Write the failing test**
+
+Write `tests/scan/ats-workday.test.mjs`:
+
+```javascript
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseWorkdayUrl } from '../../src/scan/ats/workday.mjs';
+
+test('parseWorkdayUrl — extracts tenant, pod, site from valid URL', () => {
+  const { tenant, pod, site } = parseWorkdayUrl(
+    'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers',
+  );
+  assert.equal(tenant, 'totalenergies');
+  assert.equal(pod, 'wd3');
+  assert.equal(site, 'TotalEnergies_careers');
+});
+
+test('parseWorkdayUrl — handles trailing slash', () => {
+  const { tenant, pod, site } = parseWorkdayUrl(
+    'https://sanofi.wd3.myworkdayjobs.com/SanofiCareers/',
+  );
+  assert.equal(tenant, 'sanofi');
+  assert.equal(pod, 'wd3');
+  assert.equal(site, 'SanofiCareers');
+});
+
+test('parseWorkdayUrl — handles pod wd5', () => {
+  const { pod } = parseWorkdayUrl(
+    'https://capgemini.wd5.myworkdayjobs.com/CapgeminiCareers',
+  );
+  assert.equal(pod, 'wd5');
+});
+
+test('parseWorkdayUrl — ignores query string and fragment', () => {
+  const { tenant, pod, site } = parseWorkdayUrl(
+    'https://schneider.wd3.myworkdayjobs.com/Global?foo=bar#section',
+  );
+  assert.equal(tenant, 'schneider');
+  assert.equal(pod, 'wd3');
+  assert.equal(site, 'Global');
+});
+
+test('parseWorkdayUrl — throws on non-Workday URL', () => {
+  assert.throws(
+    () => parseWorkdayUrl('https://jobs.lever.co/stripe'),
+    /not a Workday URL/,
+  );
+});
+
+test('parseWorkdayUrl — throws on Workday URL missing site', () => {
+  assert.throws(
+    () => parseWorkdayUrl('https://totalenergies.wd3.myworkdayjobs.com/'),
+    /not a Workday URL/,
+  );
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/scan/ats-workday.test.mjs`
+Expected: FAIL with `Cannot find module '../../src/scan/ats/workday.mjs'` or similar.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Write `src/scan/ats/workday.mjs`:
+
+```javascript
+// Fetcher for Workday-hosted job boards.
+// Endpoint: POST https://{tenant}.wd{N}.myworkdayjobs.com/wday/cxs/{tenant}/{site}/jobs
+// Returns Offer[] conforming to the Offer contract.
+
+const WORKDAY_URL_RE =
+  /^https?:\/\/([^.]+)\.(wd\d+)\.myworkdayjobs\.com\/([^\/?#]+)(?:\/|\?|#|$)/i;
+
+export function parseWorkdayUrl(url) {
+  if (typeof url !== 'string') {
+    throw new Error('parseWorkdayUrl: not a Workday URL (input is not a string)');
+  }
+  const m = url.match(WORKDAY_URL_RE);
+  if (!m) {
+    throw new Error(`parseWorkdayUrl: not a Workday URL: ${url}`);
+  }
+  return { tenant: m[1].toLowerCase(), pod: m[2].toLowerCase(), site: m[3] };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test tests/scan/ats-workday.test.mjs`
+Expected: PASS, 6 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/scan/ats/workday.mjs tests/scan/ats-workday.test.mjs
+git commit -m "feat(scan): add parseWorkdayUrl for Workday URL parsing"
+```
+
+---
+
+## Task 3: Implement and test `fetchWorkday` — single page
+
+**Files:**
+- Modify: `src/scan/ats/workday.mjs`
+- Modify: `tests/scan/ats-workday.test.mjs`
+
+The fetcher POSTs `{ appliedFacets: {}, limit, offset, searchText: '' }` and maps `jobPostings[]` to the `Offer` contract. The existing `installMockFetch` helper keys by URL only, not by method or body — good enough for single-page because there is only one URL, one call.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/scan/ats-workday.test.mjs`:
+
+```javascript
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach } from 'node:test';
+import { installMockFetch } from '../helpers.mjs';
+import { fetchWorkday } from '../../src/scan/ats/workday.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fx1Path = path.join(__dirname, '..', 'fixtures', 'workday-totalenergies-page1.json');
+const fx2Path = path.join(__dirname, '..', 'fixtures', 'workday-totalenergies-page2.json');
+
+let restore;
+afterEach(() => {
+  if (restore) restore();
+});
+
+test('fetchWorkday — single page, maps postings to Offer contract', async () => {
+  const fixture = JSON.parse(fs.readFileSync(fx1Path, 'utf8'));
+  restore = installMockFetch({
+    'https://totalenergies.wd3.myworkdayjobs.com/wday/cxs/totalenergies/TotalEnergies_careers/jobs':
+      fixture,
+  });
+
+  const offers = await fetchWorkday(
+    'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers',
+    'TotalEnergies',
+    { pageSize: 50 }, // > total, so only one call
+  );
+
+  assert.equal(offers.length, 3);
+  const o = offers[0];
+  assert.equal(o.title, 'Data Engineer - Paris');
+  assert.equal(
+    o.url,
+    'https://totalenergies.wd3.myworkdayjobs.com/en-US/TotalEnergies_careers/job/Paris/Data-Engineer---Paris_R12345',
+  );
+  assert.equal(o.company, 'TotalEnergies');
+  assert.equal(o.location, 'Paris, France');
+  assert.equal(o.platform, 'workday');
+  assert.equal(typeof o.body, 'string');
+});
+```
+
+Note the `url` includes `/en-US/{site}`: Workday's `externalPath` is `/job/...` and the public browsing URL prefixes the locale + site. The simplest stable convention that matches what users see in the browser is `{origin}/en-US/{site}{externalPath}`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/scan/ats-workday.test.mjs`
+Expected: FAIL — `fetchWorkday` is not exported yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `src/scan/ats/workday.mjs`:
+
+```javascript
+const DEFAULT_PAGE_SIZE = 20;
+
+function buildJobUrl({ tenant, pod, site }, externalPath) {
+  return `https://${tenant}.${pod}.myworkdayjobs.com/en-US/${site}${externalPath}`;
+}
+
+async function postJobs({ tenant, pod, site }, { limit, offset }) {
+  const url = `https://${tenant}.${pod}.myworkdayjobs.com/wday/cxs/${tenant}/${site}/jobs`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'User-Agent': 'claude-apply-scan/1.0',
+    },
+    body: JSON.stringify({ appliedFacets: {}, limit, offset, searchText: '' }),
+  });
+  if (!res.ok) {
+    throw new Error(`Workday API ${tenant}/${site}: HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function fetchWorkday(url, companyName, opts = {}) {
+  const parts = parseWorkdayUrl(url);
+  const pageSize = opts.pageSize ?? DEFAULT_PAGE_SIZE;
+  const offers = [];
+  let offset = 0;
+  while (true) {
+    const page = await postJobs(parts, { limit: pageSize, offset });
+    const postings = Array.isArray(page?.jobPostings) ? page.jobPostings : [];
+    for (const p of postings) {
+      offers.push({
+        url: buildJobUrl(parts, p.externalPath || ''),
+        title: p.title || '',
+        company: companyName,
+        location: p.locationsText || '',
+        body: '',
+        platform: 'workday',
+      });
+    }
+    if (postings.length < pageSize) break;
+    offset += pageSize;
+  }
+  return offers;
+}
+```
+
+`body` is empty: the listing API does not return job descriptions, they live on the detail page. The scan pipeline stores `body` for prefiltering, and an empty string is acceptable (prefilter rules apply to titles anyway). A future enhancement can fetch detail pages lazily.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test tests/scan/ats-workday.test.mjs`
+Expected: PASS, 7 tests green (6 parser + 1 fetcher).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/scan/ats/workday.mjs tests/scan/ats-workday.test.mjs
+git commit -m "feat(scan): add fetchWorkday single-page mapping"
+```
+
+---
+
+## Task 4: Extend `fetchWorkday` tests for pagination
+
+**Files:**
+- Modify: `tests/scan/ats-workday.test.mjs`
+
+The default `installMockFetch` keys by URL and cannot return different responses on successive calls to the same URL (both pages use the same POST URL). We build a small stateful wrapper locally in this test. If pagination already works in Task 3's implementation (it does), the test just verifies it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/scan/ats-workday.test.mjs`:
+
+```javascript
+function installSequentialMockFetch(url, responses) {
+  const original = globalThis.fetch;
+  let i = 0;
+  globalThis.fetch = async (reqUrl) => {
+    const key = typeof reqUrl === 'string' ? reqUrl : reqUrl.toString();
+    if (key !== url) throw new Error(`sequentialMock: unexpected URL ${key}`);
+    if (i >= responses.length) throw new Error(`sequentialMock: exhausted (called ${i + 1} times)`);
+    const body = responses[i++];
+    return {
+      ok: true,
+      status: 200,
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    };
+  };
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+test('fetchWorkday — paginates until a partial page is returned', async () => {
+  const page1 = JSON.parse(fs.readFileSync(fx1Path, 'utf8'));
+  const page2 = JSON.parse(fs.readFileSync(fx2Path, 'utf8'));
+  restore = installSequentialMockFetch(
+    'https://totalenergies.wd3.myworkdayjobs.com/wday/cxs/totalenergies/TotalEnergies_careers/jobs',
+    [page1, page2],
+  );
+
+  const offers = await fetchWorkday(
+    'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers',
+    'TotalEnergies',
+    { pageSize: 3 }, // page1 has 3 (full), page2 has 1 (partial → stop)
+  );
+
+  assert.equal(offers.length, 4);
+  assert.equal(offers[0].title, 'Data Engineer - Paris');
+  assert.equal(offers[3].title, 'Cloud Infrastructure Engineer');
+});
+
+test('fetchWorkday — stops on first empty page', async () => {
+  restore = installSequentialMockFetch(
+    'https://sanofi.wd3.myworkdayjobs.com/wday/cxs/sanofi/SanofiCareers/jobs',
+    [{ total: 0, jobPostings: [] }],
+  );
+
+  const offers = await fetchWorkday(
+    'https://sanofi.wd3.myworkdayjobs.com/SanofiCareers',
+    'Sanofi',
+    { pageSize: 20 },
+  );
+
+  assert.equal(offers.length, 0);
+});
+
+test('fetchWorkday — throws on HTTP error', async () => {
+  restore = installMockFetch({
+    'https://broken.wd3.myworkdayjobs.com/wday/cxs/broken/BrokenSite/jobs': {
+      status: 500,
+      body: { error: 'nope' },
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      fetchWorkday(
+        'https://broken.wd3.myworkdayjobs.com/BrokenSite',
+        'Broken',
+        { pageSize: 20 },
+      ),
+    /HTTP 500/,
+  );
+});
+```
+
+- [ ] **Step 2: Run tests to verify they pass (implementation already covers them)**
+
+Run: `node --test tests/scan/ats-workday.test.mjs`
+Expected: PASS, 10 tests green.
+
+If any fail, fix the implementation and re-run. The likely failure mode is the pagination loop not breaking correctly on `postings.length < pageSize`; review Task 3's `fetchWorkday`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/scan/ats-workday.test.mjs
+git commit -m "test(scan): cover Workday pagination, empty pages, and HTTP errors"
+```
+
+---
+
+## Task 5: Implement and test `verifySlug`
+
+**Files:**
+- Modify: `src/scan/ats/workday.mjs`
+- Modify: `tests/scan/ats-workday.test.mjs`
+
+`verifySlug(url)` takes the full Workday URL (not a slug — the dispatcher passes the full URL through because of how we wire Workday into `ats-detect.mjs` in Task 6). It returns `{ ok: true, count }` on success, `{ ok: false, status, reason }` on HTTP failure or non-Workday URL.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/scan/ats-workday.test.mjs`:
+
+```javascript
+import { verifySlug } from '../../src/scan/ats/workday.mjs';
+
+test('verifySlug — returns ok with count on valid response', async () => {
+  const page1 = JSON.parse(fs.readFileSync(fx1Path, 'utf8'));
+  restore = installMockFetch({
+    'https://totalenergies.wd3.myworkdayjobs.com/wday/cxs/totalenergies/TotalEnergies_careers/jobs':
+      page1,
+  });
+
+  const r = await verifySlug(
+    'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers',
+  );
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 3);
+});
+
+test('verifySlug — returns ok with count 0 on empty response', async () => {
+  restore = installMockFetch({
+    'https://sanofi.wd3.myworkdayjobs.com/wday/cxs/sanofi/SanofiCareers/jobs': {
+      total: 0,
+      jobPostings: [],
+    },
+  });
+
+  const r = await verifySlug('https://sanofi.wd3.myworkdayjobs.com/SanofiCareers');
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 0);
+});
+
+test('verifySlug — returns ko on HTTP 404', async () => {
+  restore = installMockFetch({
+    'https://missing.wd3.myworkdayjobs.com/wday/cxs/missing/Nope/jobs': {
+      status: 404,
+      body: {},
+    },
+  });
+
+  const r = await verifySlug('https://missing.wd3.myworkdayjobs.com/Nope');
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 404);
+  assert.match(r.reason, /HTTP 404/);
+});
+
+test('verifySlug — returns ko on non-Workday URL', async () => {
+  const r = await verifySlug('https://jobs.lever.co/stripe');
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /not a Workday URL/);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test tests/scan/ats-workday.test.mjs`
+Expected: FAIL — `verifySlug` not exported yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `src/scan/ats/workday.mjs`:
+
+```javascript
+export async function verifySlug(url) {
+  let parts;
+  try {
+    parts = parseWorkdayUrl(url);
+  } catch (err) {
+    return { ok: false, reason: err.message };
+  }
+  const endpoint = `https://${parts.tenant}.${parts.pod}.myworkdayjobs.com/wday/cxs/${parts.tenant}/${parts.site}/jobs`;
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'User-Agent': 'claude-apply-verify/1.0',
+    },
+    body: JSON.stringify({ appliedFacets: {}, limit: 1, offset: 0, searchText: '' }),
+  });
+  if (!res.ok) {
+    return { ok: false, status: res.status, reason: `HTTP ${res.status}` };
+  }
+  const data = await res.json();
+  const count = Array.isArray(data?.jobPostings) ? data.jobPostings.length : 0;
+  return { ok: true, count };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/scan/ats-workday.test.mjs`
+Expected: PASS, 14 tests green (10 prior + 4 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/scan/ats/workday.mjs tests/scan/ats-workday.test.mjs
+git commit -m "feat(scan): add verifySlug primitive for Workday"
+```
+
+---
+
+## Task 6: Wire Workday into `ats-detect.mjs`
+
+**Files:**
+- Modify: `src/scan/ats-detect.mjs`
+- Modify: `tests/scan/ats-detect.test.mjs`
+
+Three edits: add `workday` to `PATTERNS`, add `'workday'` to `VERIFIABLE_PLATFORMS`, and add the Workday wildcard host to `SUPPORTED_HOSTS`. The Workday `PATTERNS` entry captures the full URL as the `slug` field (unlike Lever/Greenhouse/Ashby, which capture a short company slug), because Workday's `verifySlug` needs the whole URL to re-extract tenant + pod + site.
+
+- [ ] **Step 1: Read the current `ats-detect.test.mjs` to see existing test style**
+
+Run:
+
+```bash
+cat tests/scan/ats-detect.test.mjs
+```
+
+Note: the file uses `node:test` and asserts on the shape `{platform, slug}` returned by `detectPlatform`.
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `tests/scan/ats-detect.test.mjs`:
+
+```javascript
+test('detectPlatform — recognises Workday URL and returns full URL as slug', () => {
+  const r = detectPlatform('https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers');
+  assert.equal(r.platform, 'workday');
+  assert.equal(r.slug, 'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers');
+});
+
+test('detectPlatform — recognises Workday URL on pod wd5', () => {
+  const r = detectPlatform('https://capgemini.wd5.myworkdayjobs.com/CapgeminiCareers');
+  assert.equal(r.platform, 'workday');
+});
+
+test('getSupportedHosts — includes myworkdayjobs wildcard', () => {
+  const hosts = getSupportedHosts();
+  assert.ok(hosts.some((h) => h.includes('myworkdayjobs.com')));
+});
+```
+
+If the imports at the top of `ats-detect.test.mjs` do not already include `getSupportedHosts`, add it:
+
+```javascript
+import { detectPlatform, getSupportedHosts } from '../../src/scan/ats-detect.mjs';
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `node --test tests/scan/ats-detect.test.mjs`
+Expected: FAIL on the new tests (detectPlatform returns null for Workday; hosts list missing workday).
+
+- [ ] **Step 4: Edit `src/scan/ats-detect.mjs`**
+
+Replace the `PATTERNS` array with a version that has a Workday entry using the full-URL capture:
+
+```javascript
+const PATTERNS = [
+  { platform: 'lever', re: /^https?:\/\/jobs\.lever\.co\/([^\/?#]+)/i },
+  { platform: 'greenhouse', re: /^https?:\/\/(?:job-boards|boards)\.greenhouse\.io\/([^\/?#]+)/i },
+  { platform: 'ashby', re: /^https?:\/\/jobs\.ashbyhq\.com\/([^\/?#]+)/i },
+  { platform: 'workable', re: /^https?:\/\/apply\.workable\.com\/([^\/?#]+)/i },
+  {
+    platform: 'workday',
+    re: /^(https?:\/\/[^.]+\.wd\d+\.myworkdayjobs\.com\/[^\/?#]+)/i,
+  },
+];
+```
+
+Note: the Workday regex captures the whole match (group 1 = `https://{tenant}.wd{N}.myworkdayjobs.com/{site}`), so `detectPlatform` returns `{ platform: 'workday', slug: '<full URL>' }`.
+
+Then add `workday` to `VERIFIABLE_PLATFORMS`:
+
+```javascript
+const VERIFIABLE_PLATFORMS = new Set(['lever', 'greenhouse', 'ashby', 'workday']);
+```
+
+And add the wildcard host to `SUPPORTED_HOSTS`:
+
+```javascript
+const SUPPORTED_HOSTS = [
+  'https://jobs.lever.co/*',
+  'https://boards.greenhouse.io/*',
+  'https://job-boards.greenhouse.io/*',
+  'https://jobs.ashbyhq.com/*',
+  'https://*.myworkdayjobs.com/*',
+];
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `node --test tests/scan/ats-detect.test.mjs`
+Expected: PASS, all tests green.
+
+- [ ] **Step 6: Verify the `verifyCompany` dispatcher handles Workday without changes**
+
+The existing `verifyCompany` reads `{platform, slug}` from `detectPlatform` and dynamically imports `./ats/${platform}.mjs`, then calls `mod.verifySlug(slug)`. Since our Workday `verifySlug` accepts the full URL as its argument (Task 5) and `slug` now contains the full URL (Task 6 regex), the existing dispatcher just works. No edit to `verifyCompany` required.
+
+Run the existing verify-company tests to confirm nothing regressed:
+
+```bash
+node --test tests/scan/verify-company.test.mjs
+```
+
+Expected: PASS, zero regressions.
+
+- [ ] **Step 7: Add a Workday case to `verify-company.test.mjs`**
+
+Read `tests/scan/verify-company.test.mjs` to see the existing style, then append a test that mocks the Workday endpoint and confirms `verifyCompany` returns `{ ok: true }`:
+
+```javascript
+test('verifyCompany — dispatches Workday URL to workday.verifySlug', async () => {
+  const restore = installMockFetch({
+    'https://totalenergies.wd3.myworkdayjobs.com/wday/cxs/totalenergies/TotalEnergies_careers/jobs':
+      { total: 5, jobPostings: [{ title: 'Test', externalPath: '/job/x' }] },
+  });
+  try {
+    const r = await verifyCompany(
+      'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers',
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.count, 1);
+  } finally {
+    restore();
+  }
+});
+```
+
+If the file does not yet import `installMockFetch`, add `import { installMockFetch } from '../helpers.mjs';` at the top.
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `node --test tests/scan/verify-company.test.mjs tests/scan/ats-detect.test.mjs tests/scan/ats-workday.test.mjs`
+Expected: PASS across all three files.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/scan/ats-detect.mjs tests/scan/ats-detect.test.mjs tests/scan/verify-company.test.mjs
+git commit -m "feat(scan): wire Workday into detectPlatform and verifyCompany"
+```
+
+---
+
+## Task 7: Update CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Read `CHANGELOG.md`**
+
+```bash
+head -40 CHANGELOG.md
+```
+
+Find the `## Unreleased` section (or create it at the top if missing).
+
+- [ ] **Step 2: Edit CHANGELOG.md**
+
+Under `## Unreleased` → `### Added` (create the subsection if it does not exist), add:
+
+```markdown
+- `scan`: Workday ATS support — new fetcher (`src/scan/ats/workday.mjs`) with `parseWorkdayUrl`, `fetchWorkday`, and `verifySlug`. Portals in `config/portals.yml` can now use `platform: workday` with the full career page URL (e.g. `https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers`). `/apply` support for Workday is not yet implemented and is tracked in plans 2 + 3.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): document Workday scan support"
+```
+
+---
+
+## Task 8: Full suite, lint, and PII gate
+
+**Files:** none.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm test`
+Expected: all tests pass, no new failures.
+
+If any pre-existing tests fail (unrelated to Workday), document them in the task summary but do not attempt to fix them in this plan.
+
+- [ ] **Step 2: Run Prettier check**
+
+Run: `npm run lint`
+Expected: PASS. If it fails, run `npm run format` and re-commit the formatting fix separately:
+
+```bash
+git add -u
+git commit -m "chore: prettier format"
+```
+
+- [ ] **Step 3: Run PII gate**
+
+Run: `npm run check:pii`
+Expected: PASS. The only PII in our changes is the example URL `totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers`, which is a public corporate career page URL, not personal data. If the gate flags anything, investigate before proceeding.
+
+- [ ] **Step 4: Verify no unexpected files were staged**
+
+Run: `git status`
+Expected: clean working tree. If anything is unstaged or untracked, review and clean up.
+
+---
+
+## Task 9 (optional, manual): Real tenant smoke test
+
+**Files:** none.
+
+This is a manual verification, not an automated test. Skip if the CAC40 tenants are unreachable (rate limiting, network, outage).
+
+- [ ] **Step 1: Hit a real tenant from a Node REPL**
+
+```bash
+node -e "import('./src/scan/ats/workday.mjs').then(m => m.fetchWorkday('https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers', 'TotalEnergies', { pageSize: 5 })).then(o => { console.log('count:', o.length); console.log(o[0]); })"
+```
+
+Expected output: a positive count and an Offer object with `platform: 'workday'`, a valid `url`, a non-empty `title`.
+
+If the request fails or the shape differs from the fixtures, stop and investigate. Common issues:
+- The real API requires a different `Content-Type` or a cookie.
+- `externalPath` format differs from the fixture.
+- The tenant uses a different pod (`wd5` instead of `wd3`).
+
+Fix the code if needed, add a regression test with the real response shape as a fixture, commit.
+
+- [ ] **Step 2: Hit `verifySlug` on a known-invalid URL**
+
+```bash
+node -e "import('./src/scan/ats/workday.mjs').then(m => m.verifySlug('https://nonexistent.wd3.myworkdayjobs.com/NoSuchSite')).then(r => console.log(r))"
+```
+
+Expected: `{ ok: false, status: 4xx, reason: 'HTTP 4xx' }`.
+
+---
+
+## Task 10: Push branch and open PR
+
+**Files:** none.
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin feat/scan-workday`
+Expected: push succeeds.
+
+- [ ] **Step 2: Open the PR**
+
+Run:
+
+```bash
+gh pr create --title "feat(scan): add Workday ATS support (Plan 1/3)" --body "$(cat <<'EOF'
+## Summary
+
+- New fetcher `src/scan/ats/workday.mjs` with `parseWorkdayUrl`, `fetchWorkday`, and `verifySlug`. Uses the public `POST /wday/cxs/{tenant}/{site}/jobs` API with JSON pagination.
+- `src/scan/ats-detect.mjs` gains a Workday entry in `PATTERNS`, `workday` in `VERIFIABLE_PLATFORMS`, and `*.myworkdayjobs.com` in `SUPPORTED_HOSTS`. The existing `verifyCompany` dispatcher handles Workday with zero code changes because the pattern captures the full URL as the `slug`.
+- Tests cover URL parsing, single-page mapping, pagination, empty response, HTTP errors, and `verifyCompany` dispatch.
+- CHANGELOG updated.
+
+This is **Plan 1 of 3** from `docs/superpowers/specs/2026-04-11-scan-and-apply-workday-design.md`. `/apply` Workday support is deferred to plans 2 (pure helpers) and 3 (playbook + CLAUDE.md invariant change).
+
+## Test plan
+
+- [ ] `npm test` passes
+- [ ] `npm run lint` passes
+- [ ] `npm run check:pii` passes
+- [ ] Manual: `/scan` on a `config/portals.yml` entry with `platform: workday` appends rows to `data/pipeline.md`
+- [ ] Manual: hit a real Workday tenant from a Node REPL and confirm the response shape matches the fixtures
+
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+---
+
+## Self-review checklist
+
+- **Spec coverage**: scan fetcher ✓, `parseWorkdayUrl` ✓, `verifySlug` ✓, `ats-detect.mjs` edits ✓, tests ✓, CHANGELOG ✓. Apply-side items are deferred to plans 2+3 — intentional.
+- **No placeholders**: every step has exact code/commands. Fixture content is hand-crafted; Task 9 notes real-tenant verification as a manual step with an explicit fallback procedure if the shape differs.
+- **Type consistency**: `parseWorkdayUrl` returns `{tenant, pod, site}` and is consumed by `fetchWorkday` (Task 3), `verifySlug` (Task 5), and referenced via `detectPlatform` (Task 6). `verifySlug(url)` takes the full URL everywhere; the `slug` returned by `detectPlatform` is the full URL for Workday only (Task 6). `fetchWorkday` takes `(url, companyName, opts?)` and the tests call it with `{pageSize}` consistently.

--- a/docs/superpowers/specs/2026-04-11-scan-and-apply-workday-design.md
+++ b/docs/superpowers/specs/2026-04-11-scan-and-apply-workday-design.md
@@ -39,11 +39,12 @@ Two independent subsystems, linked only by `platform: workday` in `config/portal
 
 ### Scan subsystem
 
-Single new fetcher: `src/scan/ats/workday.mjs`.
+Single new fetcher file: `src/scan/ats/workday.mjs`, following the same structure as `lever.mjs` / `greenhouse.mjs` / `ashby.mjs` (one file holding both `fetchWorkday` and `verifySlug`, matching the convention established in PR #7).
 
 ```
+parseWorkdayUrl(url) → { tenant, pod, site }   // pure helper, exported for tests + apply side
 fetchWorkday(url, companyName) → Offer[]
-verifyWorkdaySlug(url) → { ok: boolean, reason?: string }
+verifySlug(url) → { ok: boolean, reason?: string }
 ```
 
 Workday exposes a public JSON API for job listings at:
@@ -56,33 +57,32 @@ Body: { "appliedFacets": {}, "limit": 20, "offset": 0, "searchText": "" }
 
 The response contains `jobPostings[]` with `title`, `externalPath`, `locationsText`, `postedOn`, `bulletFields`. The fetcher paginates by incrementing `offset` until `jobPostings.length < limit`. Each posting maps to the existing `Offer` contract, with `url = https://{tenant}.wd{pod}.myworkdayjobs.com{externalPath}`, `platform: 'workday'`.
 
-The URL parser in `workday.mjs` extracts `tenant`, `pod`, and `site` from the `portals.yml` URL field and is reused by both `fetchWorkday` and `verifyWorkdaySlug`. `verifyWorkdaySlug` sends a single-page jobs request and returns `ok: true` if the response has a valid body and any `jobPostings` (or zero postings without a 404), `ok: false` otherwise.
+`parseWorkdayUrl` is shared by `fetchWorkday` and `verifySlug`. `verifySlug` sends a single-page jobs request and returns `ok: true` on HTTP 200 with a valid JSON body containing a `jobPostings` array (even if empty), `ok: false` otherwise.
 
-`src/scan/verify-company.mjs` (the dispatcher added in PR #7) gains a `workday` branch routing to `verifyWorkdaySlug`. `getSupportedHosts()` gains `*.myworkdayjobs.com`.
+`src/scan/ats-detect.mjs` gains three edits: a `workday` entry in `PATTERNS` (regex `^https?:\/\/([^.]+)\.wd\d+\.myworkdayjobs\.com\/`), `workday` added to `VERIFIABLE_PLATFORMS`, and one new host in `SUPPORTED_HOSTS` (`https://*.myworkdayjobs.com/*`). Because Workday URLs need full parsing (tenant + pod + site), `detectPlatform` returns the full URL as the `slug` field for Workday, and `verifyCompany` passes that URL straight to `workday.verifySlug(slug)` without any branch rewrite — the existing `mod.verifySlug(slug)` call just works.
 
 ### Apply subsystem
 
-New module `src/apply/workday/`:
+`/apply` is a Claude Code slash command implemented as a markdown playbook at `.claude/commands/apply.md`, not a Node CLI. The agent executes the playbook step by step, calling testable Node helpers (`field-classifier`, `confirmation-detector`, `upload-file`, `dom-label`) along the way. Workday support follows the same pattern: **orchestration lives in markdown, logic lives in pure helpers**.
+
+**New slash command** `.claude/commands/apply-workday.md`. A separate file rather than inlining into `apply.md`, because the Workday flow (account creation + email verification pause + multi-step navigation + signup captcha handling) is long enough that merging it would roughly double `apply.md`. `apply.md` gains a short early dispatch: if the URL host matches `*.myworkdayjobs.com`, stop and tell the user to run `/apply-workday <url>` instead.
+
+**New helpers** under `src/apply/workday/` — all pure, all unit-testable, no browser or network side effects:
 
 ```
 src/apply/workday/
-  index.mjs          - entry point, called from src/apply/index.mjs when platform === 'workday'
-  state-machine.mjs  - main loop, step detection, handler dispatch
-  account.mjs        - signup/login flow, credential generation
-  session.mjs        - login-wall detection, captcha detection, resume-from-state
-  steps/
-    my-information.mjs
-    my-experience.mjs
-    application-questions.mjs
-    voluntary-disclosures.mjs
-    self-identify.mjs
-    review.mjs
-    generic.mjs      - fallback, delegates to existing classifier
+  url-parse.mjs         - re-exports parseWorkdayUrl from src/scan/ats/workday.mjs
+  accounts.mjs          - readAccounts(path), findAccount(accounts, tenant),
+                          writeAccount(path, entry), markVerified(path, tenant),
+                          generateEmail(profileEmail, tenant),
+                          generatePassword() — crypto.randomBytes(24).toString('base64url')
+  step-detect.mjs       - detectStep({url, domMarkers}) → stepName | 'generic', pure function
+  step-signatures.mjs   - const STEP_SIGNATURES: URL regexes + DOM marker lists per known step
 ```
 
-New shared utility: `src/lib/workday-accounts.mjs` (YAML I/O for credential file).
+No `state-machine.mjs`, no `session.mjs`, no error classes — the state machine lives inside the `apply-workday.md` playbook as a "Repeat until Review" loop, and error handling is the playbook telling the agent "STOP and say X" (same pattern `apply.md` currently uses for login walls and captchas). Typed error classes would only be useful if a Node-side caller caught them, which there isn't.
 
-`src/apply/index.mjs` gains an early dispatch at the top: if the detected platform is `workday`, call `src/apply/workday/index.mjs` and return. All other platforms continue through the existing single-page classifier path.
+`parseWorkdayUrl` is defined once in `src/scan/ats/workday.mjs` (where the scan fetcher needs it) and re-exported from `src/apply/workday/url-parse.mjs` so the apply side has a stable import path without crossing the scan/apply module boundary in application code.
 
 ## Data flow
 
@@ -97,49 +97,52 @@ No change to `pipeline.md` format or downstream consumers.
 
 ### Apply
 
+The agent follows `.claude/commands/apply-workday.md` which encodes this flow:
+
 ```
-/apply <workday-url>
+/apply-workday <workday-url>
   │
-  ├─ detect platform = workday → delegate to workday/index.mjs
+  ├─ First-run guard (config/candidate-profile.yml exists), tool load, CDP probe
+  │  (copied from apply.md steps 0.1–0.5)
   │
-  ├─ parse tenant from URL
-  ├─ load config/workday-accounts.yml
+  ├─ Parse URL via parseWorkdayUrl → {tenant, pod, site}
+  ├─ readAccounts('config/workday-accounts.yml') → find entry for tenant
   │
-  ├─ navigate to URL, click "Apply" button
+  ├─ Open tab, start GIF, navigate to URL, click "Apply" button
   │
-  ├─ if login wall:
-  │    ├─ no account stored → signup:
-  │    │    ├─ generate email = {user.local}+{tenant}@{user.domain}
-  │    │    ├─ generate password = crypto.randomBytes(24).toString('base64url')
-  │    │    ├─ write account entry immediately (email_verified: false)
-  │    │    ├─ fill signup form, submit
-  │    │    ├─ if captcha → throw WorkdayCaptchaError (STOP)
-  │    │    └─ throw WorkdayEmailVerificationPendingError (STOP)
-  │    │       "Check your inbox and click the Workday verification link, then rerun /apply"
+  ├─ Branch: login wall detection
   │    │
-  │    └─ account stored → login:
-  │         ├─ fill email + password, submit
-  │         ├─ if captcha → throw WorkdayCaptchaError
-  │         ├─ if "email not verified" → throw WorkdayEmailVerificationPendingError
-  │         └─ if invalid creds → throw WorkdayLoginError
+  │    ├─ No stored account → signup sub-flow:
+  │    │    1. generateEmail(profile.email, tenant), generatePassword()
+  │    │    2. writeAccount(...) with email_verified: false   ← persisted BEFORE filling the form
+  │    │    3. Fill signup form (email, password, confirm, first name, last name)
+  │    │    4. Submit
+  │    │    5. If captcha → STOP: "Captcha on signup. Solve manually in Chrome, rerun /apply-workday <url>."
+  │    │    6. STOP: "Check your inbox for the Workday verification email for {tenant}, click the link, rerun /apply-workday <url>."
+  │    │
+  │    └─ Stored account → login sub-flow:
+  │         1. Fill email + password, submit
+  │         2. If captcha → STOP (same message pattern)
+  │         3. If "email not verified" banner → STOP: "Verification still pending for {tenant}, click the email link, rerun /apply-workday <url>."
+  │         4. If invalid creds error → STOP: "Stored password rejected for {tenant}. Delete the entry from config/workday-accounts.yml and rerun /apply-workday <url>."
+  │         5. On success, markVerified('config/workday-accounts.yml', tenant) if entry was not yet verified
   │
-  ├─ on first successful login, set email_verified: true in yaml
+  ├─ State machine loop (repeat until step === 'review'):
+  │    1. read_page → capture URL + DOM
+  │    2. detectStep({url, domMarkers}) → stepName
+  │    3. Fill this page using the existing field-classifier + mapProfileValue (playbook step 4–5 from apply.md, reused verbatim)
+  │    4. If any required field is 'unknown' → STOP and ask the user (same invariant as apply.md)
+  │    5. Click "Next" / "Save and Continue"
+  │    6. Re-run captcha + unknown-step checks:
+  │       - captcha detected → STOP
+  │       - detectStep returns 'generic' AND classifier finds zero fillable fields → STOP: "Unknown Workday step at {url}. Paste the DOM to the user for diagnostics."
   │
-  ├─ state machine loop:
-  │    while currentStep !== 'review':
-  │      step = detectStep(page.url, page.dom)
-  │      handler = steps[step] ?? steps.generic
-  │      await handler(page, profile, cv)
-  │      await clickNext(page)
-  │      if captchaDetected(page) → throw WorkdayCaptchaError
-  │      if unknownBlocker(page) → throw WorkdayUnknownStepError
+  ├─ Review page: human summary → click Submit
   │
-  ├─ review page: extract summary, clickSubmit
-  │
-  └─ existing confirmation detector → applications.md + apply-log.jsonl
+  └─ Existing confirmation-detector → applications.md + apply-log.jsonl
 ```
 
-Each thrown error carries a `resumeHint` string. The `/apply` CLI catches these errors, prints the hint, and exits non-zero. Re-running `/apply <url>` resumes from current state because the Chrome session persists cookies and Workday preserves the draft server-side.
+All STOPs are markdown instructions to the agent, not thrown exceptions. Re-running `/apply-workday <url>` resumes from the current state because the Chrome session persists cookies and Workday preserves the draft server-side.
 
 ## Credential storage
 
@@ -159,43 +162,48 @@ accounts:
     email_verified: false
 ```
 
-Plaintext, gitignored, same directory as the rest of `config/` (which already holds PII). Upgrade path to an encrypted file or OS keyring is preserved behind `src/lib/workday-accounts.mjs`.
+Plaintext, gitignored, same directory as the rest of `config/` (which already holds PII). Upgrade path to an encrypted file or OS keyring stays behind the `src/apply/workday/accounts.mjs` interface.
 
-Email generation: take `email` from `config/candidate-profile.yml`, split on `@`, inject `+{tenant}` before the `@`. Relies on sub-addressing (works on Gmail, Fastmail, ProtonMail). Password generation: `crypto.randomBytes(24).toString('base64url')` → 32 chars, URL-safe.
+Email generation: take `email` from `config/candidate-profile.yml`, split on `@`, inject `+{tenant}` before the `@`. Relies on sub-addressing (works on Gmail, Fastmail, ProtonMail with plus-addressing enabled). Password generation: `crypto.randomBytes(24).toString('base64url')` → 32 URL-safe characters.
 
-Atomic writes: write to `workday-accounts.yml.tmp`, `fs.rename` into place. A single-process lock file guards concurrent `/apply` runs.
+Atomic writes: write to `workday-accounts.yml.tmp`, `fs.rename` into place. Concurrent `/apply-workday` runs are not expected (the agent runs one at a time), so no lock file.
 
 ## Step detection
 
-`detectStep(url, dom)` uses a two-layer approach:
+`detectStep({url, domMarkers})` is a pure function that receives the current URL string and an array of DOM markers the agent already captured (via a `read_page` call). It returns a step name or `'generic'`.
 
-1. **URL regex** — Workday URLs contain step markers like `/myInformation`, `/myExperience`, `/voluntaryDisclosures`, `/review`. A lookup table maps these to step names.
-2. **DOM marker fallback** — if URL is ambiguous (some tenants use generic URLs), check for known H1 text or data-automation-id attributes (`data-automation-id="myExperience-SectionTitle"`).
+Two-layer matching driven by `STEP_SIGNATURES`:
 
-If neither layer matches, return `generic`. If the generic handler cannot find any fillable field either, throw `WorkdayUnknownStepError` with the current URL and a DOM dump path.
+1. **URL regex** — Workday URLs contain step markers like `/myInformation`, `/myExperience`, `/voluntaryDisclosures`, `/selfIdentify`, `/review`. Each known step has a regex tested against the URL.
+2. **DOM marker fallback** — if URL is ambiguous (some tenants use generic URLs), check for known `data-automation-id` attributes (`myInformation-SectionTitle`, `myExperience-SectionTitle`, etc.). The playbook extracts these via `javascript_tool` and passes them into `detectStep` as an array.
 
-## Error handling
+If neither layer matches, return `'generic'`. The playbook handles that case explicitly: if the classifier then finds zero fillable fields, STOP and ask the user.
 
-Typed error classes in `src/apply/workday/errors.mjs`, following the `UploadError` pattern:
+The agent does not call `detectStep` directly from the browser — it runs the Node helper with the captured URL and markers as arguments. Same pattern as `classifyField` today.
 
-| Error | When | Resume hint |
-|---|---|---|
-| `WorkdayLoginError` | Invalid creds | "Stored password rejected. Delete `config/workday-accounts.yml` entry for {tenant} and rerun." |
-| `WorkdayCaptchaError` | Captcha DOM detected | "Captcha on {tenant}. Solve it manually in Chrome, then rerun /apply {url}." |
-| `WorkdayEmailVerificationPendingError` | New signup or unverified login | "Check your inbox for the Workday verification email, click the link, then rerun /apply {url}." |
-| `WorkdayUnknownStepError` | No handler matched, generic failed | "Unknown step at {url}. DOM dumped to {path}. Open an issue or add a handler." |
-| `WorkdaySignupBlockedError` | Signup form explicitly refuses | "Signup refused (likely domain rejection). Manually create the account in Chrome, then rerun." |
+## Handling of STOP conditions
+
+There are no typed error classes. The `apply-workday.md` playbook enumerates each STOP condition inline with the exact user-facing message, matching the style of `apply.md`:
+
+| Condition | User-facing message |
+|---|---|
+| Captcha detected on signup/login/any step | "Captcha on {tenant}. Solve it manually in Chrome, then rerun /apply-workday {url}." |
+| New account created | "Check your inbox for the Workday verification email for {tenant}, click the link, then rerun /apply-workday {url}." |
+| Login succeeds but shows "verify your email" banner | "Verification still pending for {tenant}. Click the link in your inbox, then rerun /apply-workday {url}." |
+| Stored creds rejected | "Stored password rejected for {tenant}. Delete the entry from config/workday-accounts.yml and rerun /apply-workday {url}." |
+| Unknown step (generic + zero fields) | "Unknown Workday step at {url}. DOM dumped. Ask Leo for help, or add the step signature to step-signatures.mjs." |
+| Signup explicitly refused (domain banned, etc.) | "Signup refused for {tenant} (likely domain rejection). Create the account manually in Chrome, add it to config/workday-accounts.yml, then rerun." |
 
 ## Testing
 
 | Test file | What it covers |
 |---|---|
-| `tests/scan/ats/workday.test.mjs` | URL parser, `fetchWorkday` mapping against captured JSON fixtures from 2-3 real tenants, pagination |
-| `tests/scan/verify-company.test.mjs` (extended) | Workday dispatch branch |
-| `tests/apply/workday/state-machine.test.mjs` | `detectStep()` against captured HTML fixtures for each known step |
-| `tests/apply/workday/account.test.mjs` | Email/password generation, deterministic with seeded RNG |
-| `tests/lib/workday-accounts.test.mjs` | YAML read/write roundtrip, atomic write, lock file |
-| `tests/apply/workday/errors.test.mjs` | Error class hierarchy, resumeHint format |
+| `tests/scan/ats-workday.test.mjs` | `parseWorkdayUrl` (valid, invalid, missing pod/site), `fetchWorkday` against captured JSON fixtures (single page + multi-page pagination), `verifySlug` ok/ko against mocked fetch |
+| `tests/scan/ats-detect.test.mjs` (extended) | Workday pattern matching, `VERIFIABLE_PLATFORMS` + `SUPPORTED_HOSTS` include workday |
+| `tests/scan/verify-company.test.mjs` (extended) | Workday dispatch path end-to-end with mocked fetch |
+| `tests/apply/workday-url-parse.test.mjs` | `parseWorkdayUrl` re-export from url-parse.mjs |
+| `tests/apply/workday-accounts.test.mjs` | YAML read/write roundtrip, atomic write, `findAccount`, `markVerified`, `generateEmail`, `generatePassword` determinism with seeded RNG |
+| `tests/apply/workday-step-detect.test.mjs` | `detectStep` over URL-only, DOM-only, both, and neither cases, one test per step in `STEP_SIGNATURES` |
 
 No E2E Workday test runs in CI — no public test tenant exists. Manual smoke test procedure documented in `docs/testing.md` under a new "Workday manual checks" section.
 

--- a/docs/superpowers/specs/2026-04-11-scan-and-apply-workday-design.md
+++ b/docs/superpowers/specs/2026-04-11-scan-and-apply-workday-design.md
@@ -1,0 +1,219 @@
+# Workday support for /scan and /apply
+
+**Status:** Design approved, pending implementation plan
+**Branch:** `feat/scan-workday`
+**Date:** 2026-04-11
+
+## Motivation
+
+`claude-apply` currently supports Lever, Greenhouse, and Ashby. These three ATSes cover most startup and mid-size tech hiring, but the CAC40 and larger European enterprises sit almost entirely on Workday, SuccessFactors, and Taleo. Without Workday, users targeting TotalEnergies, Sanofi, Schneider, Capgemini, Orange, LVMH, Dassault, and ~12 other CAC40 companies cannot use the tool at all.
+
+Workday alone covers roughly 60% of the CAC40 and a large share of Fortune 500 hiring, so it is the highest-leverage ATS to add.
+
+## Scope
+
+- `/scan` Workday: new fetcher, new `verifySlug` branch, new `portals.yml` schema variant.
+- `/apply` Workday: full end-to-end account creation, login, multi-step form navigation, submit, confirmation detection.
+- Update `CLAUDE.md` to allow account creation (see Invariant Change below).
+- Update `docs/ats-support.md` and `CHANGELOG.md`.
+
+Out of scope: SuccessFactors, Taleo, generic Workday multi-language beyond the tenant's default language (the classifier already handles FR/EN at the field level).
+
+## Invariant change
+
+`CLAUDE.md` currently says *"Never bypass a login or evade anti-bot measures."* This blocks Workday entirely because Workday requires an account per tenant before listing any application form.
+
+The invariant becomes:
+
+> Never bypass a login you don't own. Account creation with the user's own credentials is allowed and expected for ATSes that require it (e.g., Workday). Captcha solving and email verification loops remain user-driven — `/apply` stops and asks the user to complete them manually.
+
+The adjacent invariants are unchanged:
+- Never solve a captcha.
+- Never submit without filled + verified required fields.
+- Never invent experience.
+- Stop on ambiguity.
+
+## Architecture
+
+Two independent subsystems, linked only by `platform: workday` in `config/portals.yml`.
+
+### Scan subsystem
+
+Single new fetcher: `src/scan/ats/workday.mjs`.
+
+```
+fetchWorkday(url, companyName) → Offer[]
+verifyWorkdaySlug(url) → { ok: boolean, reason?: string }
+```
+
+Workday exposes a public JSON API for job listings at:
+
+```
+POST https://{tenant}.wd{pod}.myworkdayjobs.com/wday/cxs/{tenant}/{site}/jobs
+Content-Type: application/json
+Body: { "appliedFacets": {}, "limit": 20, "offset": 0, "searchText": "" }
+```
+
+The response contains `jobPostings[]` with `title`, `externalPath`, `locationsText`, `postedOn`, `bulletFields`. The fetcher paginates by incrementing `offset` until `jobPostings.length < limit`. Each posting maps to the existing `Offer` contract, with `url = https://{tenant}.wd{pod}.myworkdayjobs.com{externalPath}`, `platform: 'workday'`.
+
+The URL parser in `workday.mjs` extracts `tenant`, `pod`, and `site` from the `portals.yml` URL field and is reused by both `fetchWorkday` and `verifyWorkdaySlug`. `verifyWorkdaySlug` sends a single-page jobs request and returns `ok: true` if the response has a valid body and any `jobPostings` (or zero postings without a 404), `ok: false` otherwise.
+
+`src/scan/verify-company.mjs` (the dispatcher added in PR #7) gains a `workday` branch routing to `verifyWorkdaySlug`. `getSupportedHosts()` gains `*.myworkdayjobs.com`.
+
+### Apply subsystem
+
+New module `src/apply/workday/`:
+
+```
+src/apply/workday/
+  index.mjs          - entry point, called from src/apply/index.mjs when platform === 'workday'
+  state-machine.mjs  - main loop, step detection, handler dispatch
+  account.mjs        - signup/login flow, credential generation
+  session.mjs        - login-wall detection, captcha detection, resume-from-state
+  steps/
+    my-information.mjs
+    my-experience.mjs
+    application-questions.mjs
+    voluntary-disclosures.mjs
+    self-identify.mjs
+    review.mjs
+    generic.mjs      - fallback, delegates to existing classifier
+```
+
+New shared utility: `src/lib/workday-accounts.mjs` (YAML I/O for credential file).
+
+`src/apply/index.mjs` gains an early dispatch at the top: if the detected platform is `workday`, call `src/apply/workday/index.mjs` and return. All other platforms continue through the existing single-page classifier path.
+
+## Data flow
+
+### Scan
+
+1. `/scan` reads `config/portals.yml`.
+2. For each entry with `platform: workday`, parse `url` → `{tenant, pod, site}`.
+3. Call `fetchWorkday(url, company)` → `Offer[]`.
+4. Dedup via existing `scan-history.tsv`, append new rows to `data/pipeline.md`.
+
+No change to `pipeline.md` format or downstream consumers.
+
+### Apply
+
+```
+/apply <workday-url>
+  │
+  ├─ detect platform = workday → delegate to workday/index.mjs
+  │
+  ├─ parse tenant from URL
+  ├─ load config/workday-accounts.yml
+  │
+  ├─ navigate to URL, click "Apply" button
+  │
+  ├─ if login wall:
+  │    ├─ no account stored → signup:
+  │    │    ├─ generate email = {user.local}+{tenant}@{user.domain}
+  │    │    ├─ generate password = crypto.randomBytes(24).toString('base64url')
+  │    │    ├─ write account entry immediately (email_verified: false)
+  │    │    ├─ fill signup form, submit
+  │    │    ├─ if captcha → throw WorkdayCaptchaError (STOP)
+  │    │    └─ throw WorkdayEmailVerificationPendingError (STOP)
+  │    │       "Check your inbox and click the Workday verification link, then rerun /apply"
+  │    │
+  │    └─ account stored → login:
+  │         ├─ fill email + password, submit
+  │         ├─ if captcha → throw WorkdayCaptchaError
+  │         ├─ if "email not verified" → throw WorkdayEmailVerificationPendingError
+  │         └─ if invalid creds → throw WorkdayLoginError
+  │
+  ├─ on first successful login, set email_verified: true in yaml
+  │
+  ├─ state machine loop:
+  │    while currentStep !== 'review':
+  │      step = detectStep(page.url, page.dom)
+  │      handler = steps[step] ?? steps.generic
+  │      await handler(page, profile, cv)
+  │      await clickNext(page)
+  │      if captchaDetected(page) → throw WorkdayCaptchaError
+  │      if unknownBlocker(page) → throw WorkdayUnknownStepError
+  │
+  ├─ review page: extract summary, clickSubmit
+  │
+  └─ existing confirmation detector → applications.md + apply-log.jsonl
+```
+
+Each thrown error carries a `resumeHint` string. The `/apply` CLI catches these errors, prints the hint, and exits non-zero. Re-running `/apply <url>` resumes from current state because the Chrome session persists cookies and Workday preserves the draft server-side.
+
+## Credential storage
+
+New file: `config/workday-accounts.yml` (gitignored, created on demand).
+
+```yaml
+accounts:
+  - tenant: totalenergies
+    email: user+totalenergies@example.com
+    password: "xK9mP...base64url"
+    created_at: 2026-04-11T22:40:00Z
+    email_verified: true
+  - tenant: sanofi
+    email: user+sanofi@example.com
+    password: "zQ2nR...base64url"
+    created_at: 2026-04-11T22:45:00Z
+    email_verified: false
+```
+
+Plaintext, gitignored, same directory as the rest of `config/` (which already holds PII). Upgrade path to an encrypted file or OS keyring is preserved behind `src/lib/workday-accounts.mjs`.
+
+Email generation: take `email` from `config/candidate-profile.yml`, split on `@`, inject `+{tenant}` before the `@`. Relies on sub-addressing (works on Gmail, Fastmail, ProtonMail). Password generation: `crypto.randomBytes(24).toString('base64url')` → 32 chars, URL-safe.
+
+Atomic writes: write to `workday-accounts.yml.tmp`, `fs.rename` into place. A single-process lock file guards concurrent `/apply` runs.
+
+## Step detection
+
+`detectStep(url, dom)` uses a two-layer approach:
+
+1. **URL regex** — Workday URLs contain step markers like `/myInformation`, `/myExperience`, `/voluntaryDisclosures`, `/review`. A lookup table maps these to step names.
+2. **DOM marker fallback** — if URL is ambiguous (some tenants use generic URLs), check for known H1 text or data-automation-id attributes (`data-automation-id="myExperience-SectionTitle"`).
+
+If neither layer matches, return `generic`. If the generic handler cannot find any fillable field either, throw `WorkdayUnknownStepError` with the current URL and a DOM dump path.
+
+## Error handling
+
+Typed error classes in `src/apply/workday/errors.mjs`, following the `UploadError` pattern:
+
+| Error | When | Resume hint |
+|---|---|---|
+| `WorkdayLoginError` | Invalid creds | "Stored password rejected. Delete `config/workday-accounts.yml` entry for {tenant} and rerun." |
+| `WorkdayCaptchaError` | Captcha DOM detected | "Captcha on {tenant}. Solve it manually in Chrome, then rerun /apply {url}." |
+| `WorkdayEmailVerificationPendingError` | New signup or unverified login | "Check your inbox for the Workday verification email, click the link, then rerun /apply {url}." |
+| `WorkdayUnknownStepError` | No handler matched, generic failed | "Unknown step at {url}. DOM dumped to {path}. Open an issue or add a handler." |
+| `WorkdaySignupBlockedError` | Signup form explicitly refuses | "Signup refused (likely domain rejection). Manually create the account in Chrome, then rerun." |
+
+## Testing
+
+| Test file | What it covers |
+|---|---|
+| `tests/scan/ats/workday.test.mjs` | URL parser, `fetchWorkday` mapping against captured JSON fixtures from 2-3 real tenants, pagination |
+| `tests/scan/verify-company.test.mjs` (extended) | Workday dispatch branch |
+| `tests/apply/workday/state-machine.test.mjs` | `detectStep()` against captured HTML fixtures for each known step |
+| `tests/apply/workday/account.test.mjs` | Email/password generation, deterministic with seeded RNG |
+| `tests/lib/workday-accounts.test.mjs` | YAML read/write roundtrip, atomic write, lock file |
+| `tests/apply/workday/errors.test.mjs` | Error class hierarchy, resumeHint format |
+
+No E2E Workday test runs in CI — no public test tenant exists. Manual smoke test procedure documented in `docs/testing.md` under a new "Workday manual checks" section.
+
+PII gate: `scripts/check-no-pii.sh` already ignores `config/`. `workday-accounts.yml` is covered by that existing rule.
+
+## Documentation updates
+
+- `docs/ats-support.md` — new Workday row: scan ✅, apply ✅ (with caveats), auth: account per tenant.
+- `docs/apply-workflow.md` — new section "Workday multi-step flow".
+- `docs/extending.md` — reference the Workday state machine as the canonical example of a multi-step ATS.
+- `CHANGELOG.md` — `feat(scan): add Workday fetcher`, `feat(apply): add Workday state machine`.
+- `CLAUDE.md` — invariant change per "Invariant change" section above.
+- `.claude/commands/onboard.md` — WebSearch template for Workday URLs when discovering target companies.
+
+## Out of scope / future work
+
+- SuccessFactors, Taleo, iCIMS — same design pattern can be reused but not implemented here.
+- Encrypted credential storage (age, keyring).
+- Auto-resume after email verification (would require IMAP).
+- Workday pages that require a specific locale beyond tenant default.
+- Batch `/apply` across multiple Workday tenants in one run.

--- a/docs/superpowers/specs/2026-04-11-workday-pr8-fix-design.md
+++ b/docs/superpowers/specs/2026-04-11-workday-pr8-fix-design.md
@@ -1,0 +1,119 @@
+# Workday PR #8 fix — design
+
+**Date:** 2026-04-11
+**Branch:** `feat/scan-workday`
+**PR:** [#8](https://github.com/LeoLaborie/claude-apply/pull/8)
+**Trigger:** code review on PR #8 found two real bugs (confidence ≥ 80).
+
+## Problem
+
+The Workday `/scan` support added in PR #8 has two correctness bugs that the existing test suite did not catch:
+
+1. **`fetchWorkday` is not wired into the scan dispatcher.** `src/scan/index.mjs` defines a static `DISPATCH` map (`{ lever, greenhouse, ashby }`) and PR #8 never added a `workday` entry. Any Workday company in `portals.yml` falls through to the `'no fetcher'` branch at `src/scan/index.mjs:53-55` and silently produces zero offers. The dispatcher path of `verifyCompany` was extended (it uses dynamic import), but the scan path was not.
+
+2. **`detectPlatform`'s Workday regex does not strip the locale segment.** Commit `592a9de` fixed `parseWorkdayUrl` in `src/scan/ats/workday.mjs` to handle URLs with `/{locale}/` (e.g. `/en-US/`), but the parallel regex in `src/scan/ats-detect.mjs:11` was not updated. For a real-world URL like `https://totalenergies.wd3.myworkdayjobs.com/en-US/TotalEnergies_careers`, `detectPlatform` captures `…/en-US` as the slug, and the downstream `verifySlug` / `fetchWorkday` calls then re-parse a malformed slug — either failing to match or hitting the wrong API endpoint (`.../cxs/totalenergies/en-US/jobs`).
+
+The deeper issue is that there is **no end-to-end integration test** exercising a Workday company through `fetchCompanyOffers` in `src/scan/index.mjs`. PR #8's tests cover `parseWorkdayUrl`, `fetchWorkday`, `verifySlug`, and `detectPlatform` in isolation, but never in composition. Either bug would have been caught immediately by such a test.
+
+## Goals
+
+- Make Workday companies actually produce offers when scanned.
+- Make `detectPlatform` handle locale-prefixed Workday URLs consistently with `parseWorkdayUrl`.
+- Add an integration test that exercises the full scan path for Workday, so this class of regression cannot recur silently.
+
+## Non-goals
+
+- Refactoring `verifyCompany` or unifying the dispatch mechanisms between scan and verify.
+- Centralising the Workday regex into a single source of truth (a tempting follow-up, but out of scope for a PR-#8 fix).
+- CHANGELOG update — the existing PR #8 CHANGELOG entry already advertises Workday scan support; this is a pre-merge fix, not a user-visible behaviour change.
+- Touching `verifySlug`'s `count` field semantics or the `body: ''` decision — both were flagged at lower confidence in review and are intentional/deferred.
+
+## Design
+
+### Section 1 — `src/scan/index.mjs`: wire Workday into `DISPATCH`
+
+Add an import alongside the existing fetcher imports:
+
+```js
+import { fetchWorkday } from './ats/workday.mjs';
+```
+
+Add the entry to the `DISPATCH` map:
+
+```js
+const DISPATCH = {
+  lever: fetchLever,
+  greenhouse: fetchGreenhouse,
+  ashby: fetchAshby,
+  workday: fetchWorkday,
+};
+```
+
+The signature is compatible: `fetchCompanyOffers` calls `fn(det.slug, company.name)` and `fetchWorkday(slug, company)` accepts the full URL as its first argument (it re-parses via `parseWorkdayUrl`). No call-site changes needed.
+
+### Section 2 — `src/scan/ats-detect.mjs`: handle locale prefix in detection
+
+Mirror the optional locale group from `parseWorkdayUrl` into the `PATTERNS` regex:
+
+```js
+{
+  platform: 'workday',
+  re: /^(https?:\/\/[^.]+\.wd\d+\.myworkdayjobs\.com(?:\/[a-z]{2}-[A-Z]{2})?\/[^\/?#]+)/i,
+},
+```
+
+The capture group still includes the entire URL prefix (locale segment included when present). This is intentional — `parseWorkdayUrl`, called downstream by both `fetchWorkday` and `verifySlug`, already strips the locale, so the captured slug remains a valid input for both.
+
+### Section 3 — Integration test
+
+Add an integration-style test that exercises `fetchCompanyOffers` end-to-end for Workday. Two strategies are possible; pick whichever fits the existing `tests/scan/scan.test.mjs` style best:
+
+- **Option A** — extend `tests/scan/scan.test.mjs` with a Workday case using the shared `installSequentialMockFetch` helper introduced in PR #8. Reuses the existing scan-test scaffolding (portals.yml + profile fixtures).
+- **Option B** — new file `tests/scan/scan-workday.test.mjs` calling `fetchCompanyOffers` directly with a synthetic `company` object. Smaller scope, no need to mock the full pipeline writers.
+
+The implementation plan will pick one based on what `scan.test.mjs` actually looks like; both satisfy the requirement.
+
+**Test scenarios (both must be present):**
+
+1. **Bare URL:** `https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers`
+   Mock the Workday API to return the existing fixture (`workday-totalenergies-page1.json`). Assert:
+   - `result.error === null`
+   - `result.platform === 'workday'`
+   - `result.offers.length > 0`
+   - First offer has expected `url`, `title`, `company` fields.
+
+   This case fails today with `error: 'no fetcher'` — would have caught Bug #1.
+
+2. **Locale-prefixed URL:** `https://totalenergies.wd3.myworkdayjobs.com/en-US/TotalEnergies_careers`
+   Same fixture, same assertions.
+
+   This case fails today because `detectPlatform` returns a malformed slug — would have caught Bug #2.
+
+The test must use the existing fixtures (no new fixture files) and the existing `installSequentialMockFetch` helper.
+
+### Section 4 — Delivery
+
+- **One commit** on `feat/scan-workday`:
+  `fix(scan): wire Workday into DISPATCH and handle locale URLs`
+  Body: short explanation citing the two bugs and that they were caught by code review on PR #8.
+- **Pre-push validation** (must all pass):
+  - `npm test`
+  - `npm run lint`
+  - `npm run check:pii`
+  - `npm run format` (apply formatting if needed)
+- **Force-push** to update PR #8. Safe because the branch is unmerged and only the author has it.
+- **No CHANGELOG update** — PR #8's existing entry already covers Workday support; this is an internal pre-merge fix.
+- **No follow-up comment on the PR.** The new diff and the resolved review comment speak for themselves.
+
+## Risks and trade-offs
+
+- **Force-push.** Standard for an unmerged feature branch with a single author. No external dependents.
+- **Capturing the locale in the slug.** The slug for a locale-prefixed Workday URL becomes `https://tenant.wdN.myworkdayjobs.com/en-US/site` — visibly different from the bare-URL form for the same portal. Dedup uses `offer.url` (the per-job URL), not the slug, so this does not cause duplicate rows in `pipeline.md` / `scan-history.tsv`. The `--only <slug>` CLI flag would need a user to know the exact form to use, but that flag is a power-user convenience and not a correctness path. Acceptable for this fix; a follow-up could normalise.
+- **Two regexes still in two places.** The fix mirrors the locale group rather than centralising, so a future Workday URL variant (e.g. `/{locale}/{tenant}/{site}`) could re-introduce drift. Documented as a known follow-up; not blocking.
+- **Integration test brittleness.** Mocking `fetch` for the full scan loop is more setup than a unit test, but PR #8 already introduced `installSequentialMockFetch` for exactly this kind of multi-call mock, so the scaffolding cost is low.
+
+## Success criteria
+
+- `npm test` passes with the two new integration scenarios green.
+- Manually tracing a Workday company through `fetchCompanyOffers` returns `error: null` and a non-empty `offers` array, for both bare and locale-prefixed URLs.
+- The PR #8 review comment's two issues are resolved by the diff (no further reviewer action required).

--- a/src/scan/ats-detect.mjs
+++ b/src/scan/ats-detect.mjs
@@ -6,6 +6,10 @@ const PATTERNS = [
   { platform: 'greenhouse', re: /^https?:\/\/(?:job-boards|boards)\.greenhouse\.io\/([^\/?#]+)/i },
   { platform: 'ashby', re: /^https?:\/\/jobs\.ashbyhq\.com\/([^\/?#]+)/i },
   { platform: 'workable', re: /^https?:\/\/apply\.workable\.com\/([^\/?#]+)/i },
+  {
+    platform: 'workday',
+    re: /^(https?:\/\/[^.]+\.wd\d+\.myworkdayjobs\.com\/[^\/?#]+)/i,
+  },
 ];
 
 export function detectPlatform(careersUrl) {
@@ -17,13 +21,14 @@ export function detectPlatform(careersUrl) {
   return null;
 }
 
-const VERIFIABLE_PLATFORMS = new Set(['lever', 'greenhouse', 'ashby']);
+const VERIFIABLE_PLATFORMS = new Set(['lever', 'greenhouse', 'ashby', 'workday']);
 
 const SUPPORTED_HOSTS = [
   'https://jobs.lever.co/*',
   'https://boards.greenhouse.io/*',
   'https://job-boards.greenhouse.io/*',
   'https://jobs.ashbyhq.com/*',
+  'https://*.myworkdayjobs.com/*',
 ];
 
 export function getSupportedHosts() {

--- a/src/scan/ats-detect.mjs
+++ b/src/scan/ats-detect.mjs
@@ -8,7 +8,7 @@ const PATTERNS = [
   { platform: 'workable', re: /^https?:\/\/apply\.workable\.com\/([^\/?#]+)/i },
   {
     platform: 'workday',
-    re: /^(https?:\/\/[^.]+\.wd\d+\.myworkdayjobs\.com\/[^\/?#]+)/i,
+    re: /^(https?:\/\/[^.]+\.wd\d+\.myworkdayjobs\.com(?:\/[a-z]{2}-[A-Z]{2})?\/[^\/?#]+)/i,
   },
 ];
 

--- a/src/scan/ats/workday.mjs
+++ b/src/scan/ats/workday.mjs
@@ -2,7 +2,8 @@
 // Endpoint: POST https://{tenant}.wd{N}.myworkdayjobs.com/wday/cxs/{tenant}/{site}/jobs
 // Returns Offer[] conforming to the Offer contract.
 
-const WORKDAY_URL_RE = /^https?:\/\/([^.]+)\.(wd\d+)\.myworkdayjobs\.com\/([^\/?#]+)(?:\/|\?|#|$)/i;
+const WORKDAY_URL_RE =
+  /^https?:\/\/([^.]+)\.(wd\d+)\.myworkdayjobs\.com(?:\/[a-z]{2}-[A-Z]{2})?\/([^\/?#]+)(?:\/|\?|#|$)/i;
 
 export function parseWorkdayUrl(url) {
   if (typeof url !== 'string') {

--- a/src/scan/ats/workday.mjs
+++ b/src/scan/ats/workday.mjs
@@ -2,8 +2,7 @@
 // Endpoint: POST https://{tenant}.wd{N}.myworkdayjobs.com/wday/cxs/{tenant}/{site}/jobs
 // Returns Offer[] conforming to the Offer contract.
 
-const WORKDAY_URL_RE =
-  /^https?:\/\/([^.]+)\.(wd\d+)\.myworkdayjobs\.com\/([^\/?#]+)(?:\/|\?|#|$)/i;
+const WORKDAY_URL_RE = /^https?:\/\/([^.]+)\.(wd\d+)\.myworkdayjobs\.com\/([^\/?#]+)(?:\/|\?|#|$)/i;
 
 export function parseWorkdayUrl(url) {
   if (typeof url !== 'string') {

--- a/src/scan/ats/workday.mjs
+++ b/src/scan/ats/workday.mjs
@@ -1,0 +1,17 @@
+// Fetcher for Workday-hosted job boards.
+// Endpoint: POST https://{tenant}.wd{N}.myworkdayjobs.com/wday/cxs/{tenant}/{site}/jobs
+// Returns Offer[] conforming to the Offer contract.
+
+const WORKDAY_URL_RE =
+  /^https?:\/\/([^.]+)\.(wd\d+)\.myworkdayjobs\.com\/([^\/?#]+)(?:\/|\?|#|$)/i;
+
+export function parseWorkdayUrl(url) {
+  if (typeof url !== 'string') {
+    throw new Error('parseWorkdayUrl: not a Workday URL (input is not a string)');
+  }
+  const m = url.match(WORKDAY_URL_RE);
+  if (!m) {
+    throw new Error(`parseWorkdayUrl: not a Workday URL: ${url}`);
+  }
+  return { tenant: m[1].toLowerCase(), pod: m[2].toLowerCase(), site: m[3] };
+}

--- a/src/scan/ats/workday.mjs
+++ b/src/scan/ats/workday.mjs
@@ -15,3 +15,50 @@ export function parseWorkdayUrl(url) {
   }
   return { tenant: m[1].toLowerCase(), pod: m[2].toLowerCase(), site: m[3] };
 }
+
+const DEFAULT_PAGE_SIZE = 20;
+
+function buildJobUrl({ tenant, pod, site }, externalPath) {
+  return `https://${tenant}.${pod}.myworkdayjobs.com/en-US/${site}${externalPath}`;
+}
+
+async function postJobs({ tenant, pod, site }, { limit, offset }) {
+  const url = `https://${tenant}.${pod}.myworkdayjobs.com/wday/cxs/${tenant}/${site}/jobs`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'User-Agent': 'claude-apply-scan/1.0',
+    },
+    body: JSON.stringify({ appliedFacets: {}, limit, offset, searchText: '' }),
+  });
+  if (!res.ok) {
+    throw new Error(`Workday API ${tenant}/${site}: HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function fetchWorkday(url, companyName, opts = {}) {
+  const parts = parseWorkdayUrl(url);
+  const pageSize = opts.pageSize ?? DEFAULT_PAGE_SIZE;
+  const offers = [];
+  let offset = 0;
+  while (true) {
+    const page = await postJobs(parts, { limit: pageSize, offset });
+    const postings = Array.isArray(page?.jobPostings) ? page.jobPostings : [];
+    for (const p of postings) {
+      offers.push({
+        url: buildJobUrl(parts, p.externalPath || ''),
+        title: p.title || '',
+        company: companyName,
+        location: p.locationsText || '',
+        body: '',
+        platform: 'workday',
+      });
+    }
+    if (postings.length < pageSize) break;
+    offset += pageSize;
+  }
+  return offers;
+}

--- a/src/scan/ats/workday.mjs
+++ b/src/scan/ats/workday.mjs
@@ -39,6 +39,31 @@ async function postJobs({ tenant, pod, site }, { limit, offset }) {
   return res.json();
 }
 
+export async function verifySlug(url) {
+  let parts;
+  try {
+    parts = parseWorkdayUrl(url);
+  } catch (err) {
+    return { ok: false, reason: err.message };
+  }
+  const endpoint = `https://${parts.tenant}.${parts.pod}.myworkdayjobs.com/wday/cxs/${parts.tenant}/${parts.site}/jobs`;
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'User-Agent': 'claude-apply-verify/1.0',
+    },
+    body: JSON.stringify({ appliedFacets: {}, limit: 1, offset: 0, searchText: '' }),
+  });
+  if (!res.ok) {
+    return { ok: false, status: res.status, reason: `HTTP ${res.status}` };
+  }
+  const data = await res.json();
+  const count = Array.isArray(data?.jobPostings) ? data.jobPostings.length : 0;
+  return { ok: true, count };
+}
+
 export async function fetchWorkday(url, companyName, opts = {}) {
   const parts = parseWorkdayUrl(url);
   const pageSize = opts.pageSize ?? DEFAULT_PAGE_SIZE;

--- a/src/scan/index.mjs
+++ b/src/scan/index.mjs
@@ -21,6 +21,7 @@ import { detectPlatform } from './ats-detect.mjs';
 import { fetchLever } from './ats/lever.mjs';
 import { fetchGreenhouse } from './ats/greenhouse.mjs';
 import { fetchAshby } from './ats/ashby.mjs';
+import { fetchWorkday } from './ats/workday.mjs';
 import { runPrefilter } from '../lib/prefilter-rules.mjs';
 import { appendFilteredOut } from '../lib/jsonl-writer.mjs';
 import { readPipelineMd, appendOffer, writePipelineMd } from '../lib/pipeline-md.mjs';
@@ -33,6 +34,7 @@ const DISPATCH = {
   lever: fetchLever,
   greenhouse: fetchGreenhouse,
   ashby: fetchAshby,
+  workday: fetchWorkday,
 };
 
 function reasonToStatus(reason) {

--- a/tests/fixtures/workday-totalenergies-page1.json
+++ b/tests/fixtures/workday-totalenergies-page1.json
@@ -1,0 +1,29 @@
+{
+  "total": 23,
+  "jobPostings": [
+    {
+      "title": "Data Engineer - Paris",
+      "externalPath": "/job/Paris/Data-Engineer---Paris_R12345",
+      "locationsText": "Paris, France",
+      "postedOn": "Posted 2 Days Ago",
+      "bulletFields": ["R12345", "2 Days Ago"],
+      "jobRequisitionId": "R12345"
+    },
+    {
+      "title": "Senior Software Engineer - Platform",
+      "externalPath": "/job/Courbevoie/Senior-Software-Engineer---Platform_R12346",
+      "locationsText": "Courbevoie, France",
+      "postedOn": "Posted 5 Days Ago",
+      "bulletFields": ["R12346", "5 Days Ago"],
+      "jobRequisitionId": "R12346"
+    },
+    {
+      "title": "Staff Data Scientist",
+      "externalPath": "/job/Remote/Staff-Data-Scientist_R12347",
+      "locationsText": "Remote - France",
+      "postedOn": "Posted Yesterday",
+      "bulletFields": ["R12347", "Yesterday"],
+      "jobRequisitionId": "R12347"
+    }
+  ]
+}

--- a/tests/fixtures/workday-totalenergies-page2.json
+++ b/tests/fixtures/workday-totalenergies-page2.json
@@ -1,0 +1,13 @@
+{
+  "total": 23,
+  "jobPostings": [
+    {
+      "title": "Cloud Infrastructure Engineer",
+      "externalPath": "/job/Paris/Cloud-Infrastructure-Engineer_R12348",
+      "locationsText": "Paris, France",
+      "postedOn": "Posted 10 Days Ago",
+      "bulletFields": ["R12348", "10 Days Ago"],
+      "jobRequisitionId": "R12348"
+    }
+  ]
+}

--- a/tests/scan/ats-detect.test.mjs
+++ b/tests/scan/ats-detect.test.mjs
@@ -63,3 +63,24 @@ test('getSupportedHosts — includes myworkdayjobs wildcard', () => {
   const hosts = getSupportedHosts();
   assert.ok(hosts.some((h) => h.includes('myworkdayjobs.com')));
 });
+
+test('detectPlatform — Workday URL avec préfixe locale (en-US, fr-FR) reste valide', () => {
+  // Workday surfaces locale-prefixed URLs in the browser address bar.
+  // The captured slug must contain the real site segment so that
+  // parseWorkdayUrl downstream can resolve {tenant, pod, site} correctly.
+  const enUS = detectPlatform(
+    'https://totalenergies.wd3.myworkdayjobs.com/en-US/TotalEnergies_careers'
+  );
+  assert.equal(enUS.platform, 'workday');
+  assert.ok(
+    enUS.slug.includes('TotalEnergies_careers'),
+    `expected slug to retain site segment, got: ${enUS.slug}`
+  );
+
+  const frFR = detectPlatform('https://capgemini.wd5.myworkdayjobs.com/fr-FR/CapgeminiCareers');
+  assert.equal(frFR.platform, 'workday');
+  assert.ok(
+    frFR.slug.includes('CapgeminiCareers'),
+    `expected slug to retain site segment, got: ${frFR.slug}`
+  );
+});

--- a/tests/scan/ats-detect.test.mjs
+++ b/tests/scan/ats-detect.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { detectPlatform } from '../../src/scan/ats-detect.mjs';
+import { detectPlatform, getSupportedHosts } from '../../src/scan/ats-detect.mjs';
 
 test('detectPlatform — Lever URL → {lever, slug}', () => {
   assert.deepEqual(detectPlatform('https://jobs.lever.co/mistral'), {
@@ -46,4 +46,20 @@ test('detectPlatform — URL inconnue retourne null', () => {
   assert.equal(detectPlatform('https://careers.datadoghq.com'), null);
   assert.equal(detectPlatform('https://openai.com/careers'), null);
   assert.equal(detectPlatform(''), null);
+});
+
+test('detectPlatform — recognises Workday URL and returns full URL as slug', () => {
+  const r = detectPlatform('https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers');
+  assert.equal(r.platform, 'workday');
+  assert.equal(r.slug, 'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers');
+});
+
+test('detectPlatform — recognises Workday URL on pod wd5', () => {
+  const r = detectPlatform('https://capgemini.wd5.myworkdayjobs.com/CapgeminiCareers');
+  assert.equal(r.platform, 'workday');
+});
+
+test('getSupportedHosts — includes myworkdayjobs wildcard', () => {
+  const hosts = getSupportedHosts();
+  assert.ok(hosts.some((h) => h.includes('myworkdayjobs.com')));
 });

--- a/tests/scan/ats-workday.test.mjs
+++ b/tests/scan/ats-workday.test.mjs
@@ -50,6 +50,20 @@ test('parseWorkdayUrl — throws on Workday URL missing site', () => {
   );
 });
 
+test('parseWorkdayUrl — strips en-US locale prefix from URL', () => {
+  const { tenant, pod, site } = parseWorkdayUrl(
+    'https://totalenergies.wd3.myworkdayjobs.com/en-US/TotalEnergies_careers'
+  );
+  assert.equal(tenant, 'totalenergies');
+  assert.equal(pod, 'wd3');
+  assert.equal(site, 'TotalEnergies_careers');
+});
+
+test('parseWorkdayUrl — strips fr-FR locale prefix', () => {
+  const { site } = parseWorkdayUrl('https://sanofi.wd3.myworkdayjobs.com/fr-FR/SanofiCareers');
+  assert.equal(site, 'SanofiCareers');
+});
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const fx1Path = path.join(__dirname, '..', 'fixtures', 'workday-totalenergies-page1.json');
 const fx2Path = path.join(__dirname, '..', 'fixtures', 'workday-totalenergies-page2.json');

--- a/tests/scan/ats-workday.test.mjs
+++ b/tests/scan/ats-workday.test.mjs
@@ -1,0 +1,51 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseWorkdayUrl } from '../../src/scan/ats/workday.mjs';
+
+test('parseWorkdayUrl — extracts tenant, pod, site from valid URL', () => {
+  const { tenant, pod, site } = parseWorkdayUrl(
+    'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers',
+  );
+  assert.equal(tenant, 'totalenergies');
+  assert.equal(pod, 'wd3');
+  assert.equal(site, 'TotalEnergies_careers');
+});
+
+test('parseWorkdayUrl — handles trailing slash', () => {
+  const { tenant, pod, site } = parseWorkdayUrl(
+    'https://sanofi.wd3.myworkdayjobs.com/SanofiCareers/',
+  );
+  assert.equal(tenant, 'sanofi');
+  assert.equal(pod, 'wd3');
+  assert.equal(site, 'SanofiCareers');
+});
+
+test('parseWorkdayUrl — handles pod wd5', () => {
+  const { pod } = parseWorkdayUrl(
+    'https://capgemini.wd5.myworkdayjobs.com/CapgeminiCareers',
+  );
+  assert.equal(pod, 'wd5');
+});
+
+test('parseWorkdayUrl — ignores query string and fragment', () => {
+  const { tenant, pod, site } = parseWorkdayUrl(
+    'https://schneider.wd3.myworkdayjobs.com/Global?foo=bar#section',
+  );
+  assert.equal(tenant, 'schneider');
+  assert.equal(pod, 'wd3');
+  assert.equal(site, 'Global');
+});
+
+test('parseWorkdayUrl — throws on non-Workday URL', () => {
+  assert.throws(
+    () => parseWorkdayUrl('https://jobs.lever.co/stripe'),
+    /not a Workday URL/,
+  );
+});
+
+test('parseWorkdayUrl — throws on Workday URL missing site', () => {
+  assert.throws(
+    () => parseWorkdayUrl('https://totalenergies.wd3.myworkdayjobs.com/'),
+    /not a Workday URL/,
+  );
+});

--- a/tests/scan/ats-workday.test.mjs
+++ b/tests/scan/ats-workday.test.mjs
@@ -1,6 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseWorkdayUrl } from '../../src/scan/ats/workday.mjs';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach } from 'node:test';
+import { installMockFetch } from '../helpers.mjs';
+import { parseWorkdayUrl, fetchWorkday } from '../../src/scan/ats/workday.mjs';
 
 test('parseWorkdayUrl — extracts tenant, pod, site from valid URL', () => {
   const { tenant, pod, site } = parseWorkdayUrl(
@@ -48,4 +53,39 @@ test('parseWorkdayUrl — throws on Workday URL missing site', () => {
     () => parseWorkdayUrl('https://totalenergies.wd3.myworkdayjobs.com/'),
     /not a Workday URL/,
   );
+});
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fx1Path = path.join(__dirname, '..', 'fixtures', 'workday-totalenergies-page1.json');
+const fx2Path = path.join(__dirname, '..', 'fixtures', 'workday-totalenergies-page2.json');
+
+let restore;
+afterEach(() => {
+  if (restore) restore();
+});
+
+test('fetchWorkday — single page, maps postings to Offer contract', async () => {
+  const fixture = JSON.parse(fs.readFileSync(fx1Path, 'utf8'));
+  restore = installMockFetch({
+    'https://totalenergies.wd3.myworkdayjobs.com/wday/cxs/totalenergies/TotalEnergies_careers/jobs':
+      fixture,
+  });
+
+  const offers = await fetchWorkday(
+    'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers',
+    'TotalEnergies',
+    { pageSize: 50 }, // > total, so only one call
+  );
+
+  assert.equal(offers.length, 3);
+  const o = offers[0];
+  assert.equal(o.title, 'Data Engineer - Paris');
+  assert.equal(
+    o.url,
+    'https://totalenergies.wd3.myworkdayjobs.com/en-US/TotalEnergies_careers/job/Paris/Data-Engineer---Paris_R12345',
+  );
+  assert.equal(o.company, 'TotalEnergies');
+  assert.equal(o.location, 'Paris, France');
+  assert.equal(o.platform, 'workday');
+  assert.equal(typeof o.body, 'string');
 });

--- a/tests/scan/ats-workday.test.mjs
+++ b/tests/scan/ats-workday.test.mjs
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach } from 'node:test';
 import { installMockFetch } from '../helpers.mjs';
-import { parseWorkdayUrl, fetchWorkday } from '../../src/scan/ats/workday.mjs';
+import { parseWorkdayUrl, fetchWorkday, verifySlug } from '../../src/scan/ats/workday.mjs';
 
 test('parseWorkdayUrl — extracts tenant, pod, site from valid URL', () => {
   const { tenant, pod, site } = parseWorkdayUrl(
@@ -161,4 +161,51 @@ test('fetchWorkday — throws on HTTP error', async () => {
       ),
     /HTTP 500/,
   );
+});
+
+test('verifySlug — returns ok with count on valid response', async () => {
+  const page1 = JSON.parse(fs.readFileSync(fx1Path, 'utf8'));
+  restore = installMockFetch({
+    'https://totalenergies.wd3.myworkdayjobs.com/wday/cxs/totalenergies/TotalEnergies_careers/jobs':
+      page1,
+  });
+
+  const r = await verifySlug(
+    'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers',
+  );
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 3);
+});
+
+test('verifySlug — returns ok with count 0 on empty response', async () => {
+  restore = installMockFetch({
+    'https://sanofi.wd3.myworkdayjobs.com/wday/cxs/sanofi/SanofiCareers/jobs': {
+      total: 0,
+      jobPostings: [],
+    },
+  });
+
+  const r = await verifySlug('https://sanofi.wd3.myworkdayjobs.com/SanofiCareers');
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 0);
+});
+
+test('verifySlug — returns ko on HTTP 404', async () => {
+  restore = installMockFetch({
+    'https://missing.wd3.myworkdayjobs.com/wday/cxs/missing/Nope/jobs': {
+      status: 404,
+      body: {},
+    },
+  });
+
+  const r = await verifySlug('https://missing.wd3.myworkdayjobs.com/Nope');
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 404);
+  assert.match(r.reason, /HTTP 404/);
+});
+
+test('verifySlug — returns ko on non-Workday URL', async () => {
+  const r = await verifySlug('https://jobs.lever.co/stripe');
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /not a Workday URL/);
 });

--- a/tests/scan/ats-workday.test.mjs
+++ b/tests/scan/ats-workday.test.mjs
@@ -89,3 +89,76 @@ test('fetchWorkday — single page, maps postings to Offer contract', async () =
   assert.equal(o.platform, 'workday');
   assert.equal(typeof o.body, 'string');
 });
+
+function installSequentialMockFetch(url, responses) {
+  const original = globalThis.fetch;
+  let i = 0;
+  globalThis.fetch = async (reqUrl) => {
+    const key = typeof reqUrl === 'string' ? reqUrl : reqUrl.toString();
+    if (key !== url) throw new Error(`sequentialMock: unexpected URL ${key}`);
+    if (i >= responses.length) throw new Error(`sequentialMock: exhausted (called ${i + 1} times)`);
+    const body = responses[i++];
+    return {
+      ok: true,
+      status: 200,
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    };
+  };
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+test('fetchWorkday — paginates until a partial page is returned', async () => {
+  const page1 = JSON.parse(fs.readFileSync(fx1Path, 'utf8'));
+  const page2 = JSON.parse(fs.readFileSync(fx2Path, 'utf8'));
+  restore = installSequentialMockFetch(
+    'https://totalenergies.wd3.myworkdayjobs.com/wday/cxs/totalenergies/TotalEnergies_careers/jobs',
+    [page1, page2],
+  );
+
+  const offers = await fetchWorkday(
+    'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers',
+    'TotalEnergies',
+    { pageSize: 3 }, // page1 has 3 (full), page2 has 1 (partial → stop)
+  );
+
+  assert.equal(offers.length, 4);
+  assert.equal(offers[0].title, 'Data Engineer - Paris');
+  assert.equal(offers[3].title, 'Cloud Infrastructure Engineer');
+});
+
+test('fetchWorkday — stops on first empty page', async () => {
+  restore = installSequentialMockFetch(
+    'https://sanofi.wd3.myworkdayjobs.com/wday/cxs/sanofi/SanofiCareers/jobs',
+    [{ total: 0, jobPostings: [] }],
+  );
+
+  const offers = await fetchWorkday(
+    'https://sanofi.wd3.myworkdayjobs.com/SanofiCareers',
+    'Sanofi',
+    { pageSize: 20 },
+  );
+
+  assert.equal(offers.length, 0);
+});
+
+test('fetchWorkday — throws on HTTP error', async () => {
+  restore = installMockFetch({
+    'https://broken.wd3.myworkdayjobs.com/wday/cxs/broken/BrokenSite/jobs': {
+      status: 500,
+      body: { error: 'nope' },
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      fetchWorkday(
+        'https://broken.wd3.myworkdayjobs.com/BrokenSite',
+        'Broken',
+        { pageSize: 20 },
+      ),
+    /HTTP 500/,
+  );
+});

--- a/tests/scan/ats-workday.test.mjs
+++ b/tests/scan/ats-workday.test.mjs
@@ -9,7 +9,7 @@ import { parseWorkdayUrl, fetchWorkday, verifySlug } from '../../src/scan/ats/wo
 
 test('parseWorkdayUrl — extracts tenant, pod, site from valid URL', () => {
   const { tenant, pod, site } = parseWorkdayUrl(
-    'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers',
+    'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers'
   );
   assert.equal(tenant, 'totalenergies');
   assert.equal(pod, 'wd3');
@@ -18,7 +18,7 @@ test('parseWorkdayUrl — extracts tenant, pod, site from valid URL', () => {
 
 test('parseWorkdayUrl — handles trailing slash', () => {
   const { tenant, pod, site } = parseWorkdayUrl(
-    'https://sanofi.wd3.myworkdayjobs.com/SanofiCareers/',
+    'https://sanofi.wd3.myworkdayjobs.com/SanofiCareers/'
   );
   assert.equal(tenant, 'sanofi');
   assert.equal(pod, 'wd3');
@@ -26,15 +26,13 @@ test('parseWorkdayUrl — handles trailing slash', () => {
 });
 
 test('parseWorkdayUrl — handles pod wd5', () => {
-  const { pod } = parseWorkdayUrl(
-    'https://capgemini.wd5.myworkdayjobs.com/CapgeminiCareers',
-  );
+  const { pod } = parseWorkdayUrl('https://capgemini.wd5.myworkdayjobs.com/CapgeminiCareers');
   assert.equal(pod, 'wd5');
 });
 
 test('parseWorkdayUrl — ignores query string and fragment', () => {
   const { tenant, pod, site } = parseWorkdayUrl(
-    'https://schneider.wd3.myworkdayjobs.com/Global?foo=bar#section',
+    'https://schneider.wd3.myworkdayjobs.com/Global?foo=bar#section'
   );
   assert.equal(tenant, 'schneider');
   assert.equal(pod, 'wd3');
@@ -42,16 +40,13 @@ test('parseWorkdayUrl — ignores query string and fragment', () => {
 });
 
 test('parseWorkdayUrl — throws on non-Workday URL', () => {
-  assert.throws(
-    () => parseWorkdayUrl('https://jobs.lever.co/stripe'),
-    /not a Workday URL/,
-  );
+  assert.throws(() => parseWorkdayUrl('https://jobs.lever.co/stripe'), /not a Workday URL/);
 });
 
 test('parseWorkdayUrl — throws on Workday URL missing site', () => {
   assert.throws(
     () => parseWorkdayUrl('https://totalenergies.wd3.myworkdayjobs.com/'),
-    /not a Workday URL/,
+    /not a Workday URL/
   );
 });
 
@@ -74,7 +69,7 @@ test('fetchWorkday — single page, maps postings to Offer contract', async () =
   const offers = await fetchWorkday(
     'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers',
     'TotalEnergies',
-    { pageSize: 50 }, // > total, so only one call
+    { pageSize: 50 } // > total, so only one call
   );
 
   assert.equal(offers.length, 3);
@@ -82,7 +77,7 @@ test('fetchWorkday — single page, maps postings to Offer contract', async () =
   assert.equal(o.title, 'Data Engineer - Paris');
   assert.equal(
     o.url,
-    'https://totalenergies.wd3.myworkdayjobs.com/en-US/TotalEnergies_careers/job/Paris/Data-Engineer---Paris_R12345',
+    'https://totalenergies.wd3.myworkdayjobs.com/en-US/TotalEnergies_careers/job/Paris/Data-Engineer---Paris_R12345'
   );
   assert.equal(o.company, 'TotalEnergies');
   assert.equal(o.location, 'Paris, France');
@@ -115,13 +110,13 @@ test('fetchWorkday — paginates until a partial page is returned', async () => 
   const page2 = JSON.parse(fs.readFileSync(fx2Path, 'utf8'));
   restore = installSequentialMockFetch(
     'https://totalenergies.wd3.myworkdayjobs.com/wday/cxs/totalenergies/TotalEnergies_careers/jobs',
-    [page1, page2],
+    [page1, page2]
   );
 
   const offers = await fetchWorkday(
     'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers',
     'TotalEnergies',
-    { pageSize: 3 }, // page1 has 3 (full), page2 has 1 (partial → stop)
+    { pageSize: 3 } // page1 has 3 (full), page2 has 1 (partial → stop)
   );
 
   assert.equal(offers.length, 4);
@@ -132,13 +127,13 @@ test('fetchWorkday — paginates until a partial page is returned', async () => 
 test('fetchWorkday — stops on first empty page', async () => {
   restore = installSequentialMockFetch(
     'https://sanofi.wd3.myworkdayjobs.com/wday/cxs/sanofi/SanofiCareers/jobs',
-    [{ total: 0, jobPostings: [] }],
+    [{ total: 0, jobPostings: [] }]
   );
 
   const offers = await fetchWorkday(
     'https://sanofi.wd3.myworkdayjobs.com/SanofiCareers',
     'Sanofi',
-    { pageSize: 20 },
+    { pageSize: 20 }
   );
 
   assert.equal(offers.length, 0);
@@ -154,12 +149,8 @@ test('fetchWorkday — throws on HTTP error', async () => {
 
   await assert.rejects(
     () =>
-      fetchWorkday(
-        'https://broken.wd3.myworkdayjobs.com/BrokenSite',
-        'Broken',
-        { pageSize: 20 },
-      ),
-    /HTTP 500/,
+      fetchWorkday('https://broken.wd3.myworkdayjobs.com/BrokenSite', 'Broken', { pageSize: 20 }),
+    /HTTP 500/
   );
 });
 
@@ -170,9 +161,7 @@ test('verifySlug — returns ok with count on valid response', async () => {
       page1,
   });
 
-  const r = await verifySlug(
-    'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers',
-  );
+  const r = await verifySlug('https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers');
   assert.equal(r.ok, true);
   assert.equal(r.count, 3);
 });

--- a/tests/scan/scan.test.mjs
+++ b/tests/scan/scan.test.mjs
@@ -107,6 +107,73 @@ test('runScan — e2e avec 2 companies mockées, écrit pipeline + history', asy
   assert.ok(filt.includes('Senior Engineer'));
 });
 
+test('runScan — Workday end-to-end (URL nue + URL avec locale)', async () => {
+  // Reuse the existing terminating-page fixture so we don't need pagination mocks.
+  const fxPath = path.join(REPO_ROOT, 'tests', 'fixtures', 'workday-totalenergies-page2.json');
+  const workdayBody = JSON.parse(fs.readFileSync(fxPath, 'utf8'));
+
+  const portalsConfig = {
+    title_filter: { positive: ['Engineer', 'Ingénieur'], negative: [] },
+    tracked_companies: [
+      {
+        name: 'TotalEnergies (bare)',
+        careers_url: 'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers',
+        enabled: true,
+      },
+      {
+        name: 'TotalEnergies (locale)',
+        careers_url: 'https://totalenergies.wd3.myworkdayjobs.com/en-US/TotalEnergies_careers',
+        enabled: true,
+      },
+    ],
+  };
+  const profile = { min_start_date: '2020-01-01', blacklist_companies: [] };
+
+  // Both companies hit the same Workday API endpoint (locale is stripped
+  // by parseWorkdayUrl). The fixture is a short page so fetchWorkday's
+  // pagination loop terminates after a single call per company.
+  const workdayEndpoint =
+    'https://totalenergies.wd3.myworkdayjobs.com/wday/cxs/totalenergies/TotalEnergies_careers/jobs';
+  const restore = installMockFetch({ [workdayEndpoint]: workdayBody });
+
+  const pipelinePath = path.join(tmp, 'pipeline.md');
+  const historyPath = path.join(tmp, 'scan-history.tsv');
+  const filteredPath = path.join(tmp, 'filtered-out.tsv');
+  const applicationsPath = path.join(tmp, 'applications.md');
+  fs.writeFileSync(applicationsPath, '# Apps\n');
+
+  const result = await runScan({
+    portalsConfig,
+    profile,
+    pipelinePath,
+    historyPath,
+    filteredPath,
+    applicationsPath,
+    dryRun: false,
+  });
+
+  restore();
+
+  // 2 companies × 1 job each (fixture has 1 jobPosting)
+  assert.equal(
+    result.raw,
+    2 * 1,
+    `expected raw = 2 (two companies × 1 job each), got ${result.raw}`
+  );
+
+  const errs = (result.errors || []).filter((e) =>
+    String(e.company || '').startsWith('TotalEnergies')
+  );
+  assert.equal(errs.length, 0, `expected no Workday errors, got: ${JSON.stringify(errs)}`);
+
+  // pipeline.md should mention TotalEnergies (proves offers were written).
+  const md = fs.readFileSync(pipelinePath, 'utf8');
+  assert.ok(
+    md.includes('TotalEnergies'),
+    'expected pipeline.md to contain at least one TotalEnergies offer'
+  );
+});
+
 test('scan CLI — missing candidate-profile.yml fails with ProfileMissingError', () => {
   const cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-cfg-'));
   const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-data-'));

--- a/tests/scan/verify-company.test.mjs
+++ b/tests/scan/verify-company.test.mjs
@@ -69,7 +69,7 @@ test('verifyCompany — dispatches Workday URL to workday.verifySlug', async () 
   });
   try {
     const r = await verifyCompany(
-      'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers',
+      'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers'
     );
     assert.equal(r.ok, true);
     assert.equal(r.count, 1);

--- a/tests/scan/verify-company.test.mjs
+++ b/tests/scan/verify-company.test.mjs
@@ -51,12 +51,29 @@ test('verifyCompany — plateforme sans verifySlug (workable) renvoie ok:false',
   assert.match(r.reason, /not supported/i);
 });
 
-test('getSupportedHosts — retourne les 4 hôtes ATS avec fetcher vérifiable', () => {
+test('getSupportedHosts — retourne les 5 hôtes ATS avec fetcher vérifiable', () => {
   const hosts = getSupportedHosts();
   assert.deepEqual(hosts.sort(), [
+    'https://*.myworkdayjobs.com/*',
     'https://boards.greenhouse.io/*',
     'https://job-boards.greenhouse.io/*',
     'https://jobs.ashbyhq.com/*',
     'https://jobs.lever.co/*',
   ]);
+});
+
+test('verifyCompany — dispatches Workday URL to workday.verifySlug', async () => {
+  const restore = installMockFetch({
+    'https://totalenergies.wd3.myworkdayjobs.com/wday/cxs/totalenergies/TotalEnergies_careers/jobs':
+      { total: 5, jobPostings: [{ title: 'Test', externalPath: '/job/x' }] },
+  });
+  try {
+    const r = await verifyCompany(
+      'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers',
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.count, 1);
+  } finally {
+    restore();
+  }
 });


### PR DESCRIPTION
## Summary

- New fetcher `src/scan/ats/workday.mjs` with `parseWorkdayUrl`, `fetchWorkday` (paginated), and `verifySlug`. Uses the public `POST /wday/cxs/{tenant}/{site}/jobs` API with JSON pagination.
- `src/scan/ats-detect.mjs` gains a Workday entry in `PATTERNS`, `workday` in `VERIFIABLE_PLATFORMS`, and `https://*.myworkdayjobs.com/*` in `SUPPORTED_HOSTS`. The existing `verifyCompany` dispatcher handles Workday with **zero code changes** because the regex captures the full URL as the `slug`, which is exactly what `workday.verifySlug(url)` expects.
- 16 unit tests covering URL parsing (incl. `en-US` / `fr-FR` locale prefix stripping), single-page mapping, multi-page pagination, empty pages, HTTP errors, non-Workday URL inputs, and the `verifyCompany` dispatch path.
- CHANGELOG entry under \`Unreleased\` → \`Added\`.

This is **Plan 1 of 3** from \`docs/superpowers/specs/2026-04-11-scan-and-apply-workday-design.md\`. \`/apply\` Workday support is intentionally deferred to plans 2 (pure helpers: accounts, step-detect) and 3 (\`apply-workday.md\` playbook + \`CLAUDE.md\` invariant change for account creation).

Unlocks scanning ~60% of CAC40 and a large share of Fortune 500 hiring.

## Test plan

- [x] \`npm test\` — 249/249 pass
- [x] \`npm run lint\` — clean
- [x] \`npm run check:pii\` — clean
- [ ] Manual: \`/scan\` on a \`config/portals.yml\` entry with \`platform: workday\` and a real CAC40 tenant URL appends rows to \`data/pipeline.md\`
- [ ] Manual: hit a real Workday tenant from a Node REPL and confirm the response shape matches the hand-crafted fixtures (Task 9 in the plan, optional smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)