### PR TITLE
feat(scan): per-company skip_required_any flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ data/
 # Brainstorming specs (personal, not project docs)
 docs/superpowers/
 
+# Git worktrees
+.worktrees/
+
 # Generated files
 dashboard.html
 *.log

--- a/docs/scan-workflow.md
+++ b/docs/scan-workflow.md
@@ -48,6 +48,19 @@ title_filter:
     - Manager
 ```
 
+### Per-company override: `skip_required_any`
+
+For companies where the domain is implicit in the name (e.g. Mistral AI, DeepMind), the `required_any` filter can be bypassed per-company:
+
+```yaml
+tracked_companies:
+  - name: Mistral AI
+    careers_url: https://jobs.lever.co/mistral
+    skip_required_any: true
+```
+
+When set, `positive` and `negative` filters still apply — only `required_any` is skipped.
+
 ## Deduplication
 
 `data/scan-history.tsv` is the source of truth. Every offer ever seen is recorded with its URL, title, company, and `first_seen` timestamp. On subsequent scans, known URLs are dropped before writing anything. `data/applications.md` is also consulted — if you already tracked an offer (manually or via `/apply`), it won't be re-added to the pipeline.

--- a/docs/superpowers/plans/2026-04-12-skip-required-any.md
+++ b/docs/superpowers/plans/2026-04-12-skip-required-any.md
@@ -1,0 +1,244 @@
+# skip_required_any Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow per-company bypass of the `required_any` title filter for AI-native companies where domain keywords are implicit in the company name.
+
+**Architecture:** A `skip_required_any: true` boolean on `portals.yml` company entries. The scan loop in `index.mjs` builds a per-company whitelist with `required_any: []` when the flag is set. `prefilter-rules.mjs` is untouched — `checkTitle` already treats empty `required_any` as a no-op.
+
+**Tech Stack:** Node 20, ESM, `node:test`
+
+---
+
+### Task 1: Add explicit test for `required_any: []` no-op behavior
+
+**Files:**
+- Modify: `tests/lib/prefilter-title.test.mjs` (after line 93)
+
+- [ ] **Step 1: Write the test**
+
+Add this test at the end of `tests/lib/prefilter-title.test.mjs`:
+
+```js
+test('checkTitle: empty required_any array is a no-op (skip_required_any support)', () => {
+  const wl = { positive: ['intern'], negative: [], required_any: [] };
+  assert.deepEqual(checkTitle({ title: 'Research Intern' }, wl), { pass: true });
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `node --test --test-name-pattern="empty required_any" tests/lib/prefilter-title.test.mjs`
+Expected: PASS (this is a regression guard for existing behavior, not TDD red-green)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/lib/prefilter-title.test.mjs
+git commit -m "test(scan): add regression guard for empty required_any no-op"
+```
+
+---
+
+### Task 2: Wire skip_required_any in the scan loop
+
+**Files:**
+- Modify: `src/scan/index.mjs:96,117,162`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add this test at the end of `tests/scan/scan.test.mjs`:
+
+```js
+test('runScan — skip_required_any bypasses required_any for flagged company', async () => {
+  const portalsConfig = {
+    title_filter: {
+      positive: ['Intern', 'Internship'],
+      negative: [],
+      required_any: ['ML', 'AI', 'Data'],
+    },
+    tracked_companies: [
+      {
+        name: 'Mistral AI',
+        careers_url: 'https://jobs.lever.co/mistral',
+        enabled: true,
+        skip_required_any: true,
+      },
+      {
+        name: 'Photoroom',
+        careers_url: 'https://jobs.ashbyhq.com/photoroom',
+        enabled: true,
+      },
+    ],
+  };
+  const profile = { min_start_date: '2026-08-24', blacklist_companies: [] };
+
+  const leverJson = [
+    {
+      hostedUrl: 'https://jobs.lever.co/mistral/job-a',
+      text: 'Research Engineer Intern',
+      categories: { location: 'Paris' },
+      descriptionPlain: 'Paris, France, September 2026.',
+    },
+  ];
+  const ashbyJson = {
+    jobs: [
+      {
+        jobUrl: 'https://jobs.ashbyhq.com/photoroom/job-b',
+        title: 'Research Engineer Intern',
+        location: 'Paris, France',
+        descriptionPlain: 'Paris France septembre 2026.',
+      },
+    ],
+  };
+
+  const restore = installMockFetch({
+    'https://api.lever.co/v0/postings/mistral?mode=json': leverJson,
+    'https://api.ashbyhq.com/posting-api/job-board/photoroom?includeCompensation=false': ashbyJson,
+  });
+
+  const pipelinePath = path.join(tmp, 'pipeline.md');
+  const historyPath = path.join(tmp, 'scan-history.tsv');
+  const filteredPath = path.join(tmp, 'filtered-out.tsv');
+  const applicationsPath = path.join(tmp, 'applications.md');
+  fs.writeFileSync(applicationsPath, '# Apps\n');
+
+  const result = await runScan({
+    portalsConfig,
+    profile,
+    pipelinePath,
+    historyPath,
+    filteredPath,
+    applicationsPath,
+    dryRun: false,
+  });
+
+  restore();
+
+  // Mistral offer passes (skip_required_any bypasses "ML/AI/Data" check)
+  // Photoroom offer fails (title has no ML/AI/Data keyword)
+  assert.equal(result.added.length, 1, `expected 1 added, got ${result.added.length}`);
+  assert.equal(result.added[0].company, 'Mistral AI');
+  assert.equal(result.filtered.skipped_title, 1, 'Photoroom offer should be filtered by required_any');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test --test-name-pattern="skip_required_any" tests/scan/scan.test.mjs`
+Expected: FAIL — both offers are filtered because `skip_required_any` is not yet wired.
+
+- [ ] **Step 3: Implement — change the scan loop to use indexed iteration and build per-company whitelist**
+
+In `src/scan/index.mjs`, make two changes:
+
+1. Change `Promise.all` result to preserve company config alongside results. Replace line 96:
+
+```js
+const fetchResults = await Promise.all(companies.map(fetchCompanyOffers));
+```
+
+with:
+
+```js
+const fetchResults = await Promise.all(
+  companies.map(async (c) => ({ ...(await fetchCompanyOffers(c)), _company: c }))
+);
+```
+
+2. Inside the offer loop (line 162), replace:
+
+```js
+        check = runPrefilter(offer, prefilterConfig);
+```
+
+with:
+
+```js
+        const effectiveWhitelist = result._company?.skip_required_any
+          ? { ...whitelist, required_any: [] }
+          : whitelist;
+        check = runPrefilter(offer, { ...prefilterConfig, whitelist: effectiveWhitelist });
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test --test-name-pattern="skip_required_any" tests/scan/scan.test.mjs`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `npm test`
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/scan/index.mjs tests/scan/scan.test.mjs
+git commit -m "feat(scan): wire skip_required_any per-company flag (closes #13)"
+```
+
+---
+
+### Task 3: Update docs and template
+
+**Files:**
+- Modify: `templates/portals.example.yml`
+- Modify: `docs/scan-workflow.md`
+
+- [ ] **Step 1: Update portals.example.yml**
+
+Add `skip_required_any: true` to the Mistral entry and a comment. Replace lines 10-12:
+
+```yaml
+  - name: Mistral AI
+    careers_url: https://jobs.lever.co/mistral
+    enabled: true
+```
+
+with:
+
+```yaml
+  - name: Mistral AI
+    careers_url: https://jobs.lever.co/mistral
+    enabled: true
+    # Domain is implicit in company name — skip required_any filter
+    skip_required_any: true
+```
+
+- [ ] **Step 2: Update docs/scan-workflow.md**
+
+After the title filter section (after line 49), add:
+
+```markdown
+
+### Per-company override: `skip_required_any`
+
+For companies where the domain is implicit in the name (e.g. Mistral AI, DeepMind), the `required_any` filter can be bypassed per-company:
+
+```yaml
+tracked_companies:
+  - name: Mistral AI
+    careers_url: https://jobs.lever.co/mistral
+    skip_required_any: true
+```
+
+When set, `positive` and `negative` filters still apply — only `required_any` is skipped.
+```
+
+- [ ] **Step 3: Run PII check**
+
+Run: `npm run check:pii`
+Expected: PASS
+
+- [ ] **Step 4: Run lint**
+
+Run: `npm run lint`
+Expected: PASS (or fix with `npm run format`)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add templates/portals.example.yml docs/scan-workflow.md
+git commit -m "docs: document skip_required_any flag in template and workflow"
+```

--- a/docs/superpowers/specs/2026-04-12-scan-progress-logs-design.md
+++ b/docs/superpowers/specs/2026-04-12-scan-progress-logs-design.md
@@ -1,0 +1,66 @@
+# Design: Scan Progress Logs (Issue #12)
+
+## Problem
+
+`runScan()` produces no output until the entire scan completes. When scanning 55 companies, users cannot tell whether the scan is running, stuck, or how far along it is.
+
+## Solution
+
+Add an optional `onProgress` callback to `runScan()`. The CLI wires it to `stderr`; tests can capture or ignore it.
+
+## Callback Signature
+
+```js
+onProgress({ index, total, company, platform, count, error })
+```
+
+| Field      | Type             | Description                                    |
+|------------|------------------|------------------------------------------------|
+| `index`    | `number`         | 1-based counter of completed companies         |
+| `total`    | `number`         | Total number of companies to scan              |
+| `company`  | `string`         | Company name                                   |
+| `platform` | `string \| null` | Detected ATS platform                          |
+| `count`    | `number`         | Number of raw offers fetched                   |
+| `error`    | `string \| null` | Error message if fetch failed, null on success |
+
+## Call Site
+
+The callback fires inside the existing `for (const result of fetchResults)` loop in `runScan()`, after the `Promise.all` resolves. Since iteration order matches the `companies` array order, the counter increments deterministically.
+
+## CLI Output Format (stderr)
+
+```
+[12/55] ✓ Mistral AI — 147 raw, 3 new
+[13/55] ✗ Datadog — fetch error: 403
+```
+
+- Success: `[index/total] ✓ company — N raw, M new`
+- Error: `[index/total] ✗ company — error message`
+- Active for both normal and `--json` modes (stderr does not pollute stdout)
+
+Note: `new` count requires tracking per-company new offers in the results loop, which is derived from offers that pass dedup and prefilter.
+
+## Concurrency
+
+The existing `Promise.all` parallel fetch is preserved. No change to scan performance.
+
+## What Does Not Change
+
+- `runScan()` return value shape
+- `formatSummary()` final output
+- Existing tests (no `onProgress` = no log)
+
+## Files Changed
+
+| File                           | Change                                                        |
+|--------------------------------|---------------------------------------------------------------|
+| `src/scan/index.mjs`          | Add `onProgress` to `runScan` opts, call in results loop, wire to stderr in `main()` |
+| `tests/scan/progress.test.mjs`| New test verifying callback args (index, total, company info) |
+
+## Tests
+
+A test passes a mock `onProgress` callback that accumulates calls into an array, then asserts:
+- Called once per company
+- `index` increments from 1 to `total`
+- `total` equals number of companies
+- Error companies have non-null `error` field

--- a/docs/superpowers/specs/2026-04-12-skip-required-any-design.md
+++ b/docs/superpowers/specs/2026-04-12-skip-required-any-design.md
@@ -1,0 +1,53 @@
+# Design: per-company `skip_required_any` flag
+
+**Issue:** [#13 — feat(scan): Flag skip_required_any pour les entreprises AI-native](https://github.com/LeoLaborie/claude-apply/issues/13)
+
+**Problem:** Companies like Mistral AI are 100% AI-focused, so their job titles don't redundantly include "AI" or "ML". The global `required_any` filter in `portals.yml` rejects valid offers because the domain keyword is implicit in the company name.
+
+**Solution:** A per-company `skip_required_any: true` boolean in `portals.yml` that bypasses the `required_any` check for that company's offers, while keeping `positive` and `negative` filters intact.
+
+## Config change
+
+New optional field on `tracked_companies` entries:
+
+```yaml
+tracked_companies:
+  - name: Mistral AI
+    careers_url: https://jobs.lever.co/mistral
+    skip_required_any: true   # domain is implicit — skip required_any filter
+```
+
+Default: `false` (no behavior change for existing entries).
+
+## Code change
+
+**`src/scan/index.mjs` ~line 160–162** — before calling `runPrefilter`, build a per-company whitelist when the flag is set:
+
+```js
+const companyWhitelist = company.skip_required_any
+  ? { ...whitelist, required_any: [] }
+  : whitelist;
+check = runPrefilter(offer, { ...prefilterConfig, whitelist: companyWhitelist });
+```
+
+`checkTitle` (line 125) already treats an empty `required_any` array as a no-op via `Array.isArray(whitelist.required_any) && whitelist.required_any.length > 0`, so **no change to `prefilter-rules.mjs`**.
+
+## What does NOT change
+
+- `prefilter-rules.mjs` — untouched
+- `score/` and `apply/` — unaffected (flag only consumed by scan)
+- `positive` and `negative` filters — still applied for skip_required_any companies
+
+## Tests
+
+1. **Unit test** in `tests/lib/prefilter-title.test.mjs`: confirm `required_any: []` is a no-op (explicit regression guard — currently only implicitly covered).
+2. **Integration-level test**: verify the scan loop respects `skip_required_any` by passing a company config with the flag set and asserting the offer passes prefilter despite missing `required_any` keywords.
+
+## Docs
+
+- `templates/portals.example.yml`: add `skip_required_any: true` on Mistral entry with a comment.
+- `docs/scan-workflow.md`: add a paragraph in the "Title filter" section explaining the per-company override.
+
+## Scope
+
+~10 lines of production code, ~20 lines of tests, 2 doc updates. No new dependencies, no schema changes, no breaking changes.

--- a/docs/superpowers/specs/2026-04-12-workday-pagination-fix-design.md
+++ b/docs/superpowers/specs/2026-04-12-workday-pagination-fix-design.md
@@ -1,0 +1,56 @@
+# Fix Workday pagination timeout (#11)
+
+## Problème
+
+`fetchWorkday` pagine sans limite (`while(true)`, blocs de 20). Sur les gros boards (Sanofi : 1204 offres = 60 requêtes séquentielles), ça cause des timeouts (>4 min, seuil à 240s).
+
+## Solution : deux mécanismes complémentaires
+
+### 1. `searchText` côté API
+
+Avant de paginer, construire une chaîne à partir de `title_filter.positive` (ex: `"Intern Internship Stage Stagiaire"`) et l'envoyer dans le body POST Workday. L'API fait un OR implicite sur les termes, ce qui réduit drastiquement le volume retourné (de ~1200 à ~20-50 offres typiquement).
+
+Construction du `searchText` :
+- Joindre les entrées de `title_filter.positive` qui sont des mots simples (pas des regex `/…/`) avec des espaces.
+- Les entrées regex sont ignorées pour le `searchText` — elles continuent à être appliquées côté client via `runPrefilter`.
+- Si `positive` est vide ou absent, `searchText` reste `''` (comportement actuel, pas de filtre API).
+
+### 2. `maxOffers` cap
+
+Constante `MAX_OFFERS = 200` dans `workday.mjs`. La boucle de pagination s'arrête dès que `offers.length >= MAX_OFFERS`. Filet de sécurité si `searchText` ne filtre pas assez.
+
+## Changements fichier par fichier
+
+### `src/scan/ats/workday.mjs`
+
+- Ajouter `const MAX_OFFERS = 200`.
+- `postJobs` : accepter un paramètre `searchText` au lieu du `''` codé en dur.
+- `fetchWorkday` : accepter `opts.searchText`, le passer à `postJobs`. Ajouter la condition `offers.length >= MAX_OFFERS` comme condition de sortie de la boucle `while`.
+- Signature inchangée : `fetchWorkday(url, companyName, opts)`.
+
+### `src/scan/index.mjs`
+
+- Dans `fetchCompanyOffers`, quand `det.platform === 'workday'`, construire le `searchText` en joignant les mots simples de `whitelist.positive` avec des espaces.
+- Passer `{ searchText }` en 3e argument de `fetchWorkday`.
+- Les autres fetchers continuent à recevoir `(slug, companyName)` sans changement.
+
+## Cas limites
+
+| Cas | Comportement |
+|-----|-------------|
+| `title_filter.positive` vide ou absent | `searchText` = `''`, pas de filtre API. `maxOffers` protège. |
+| Entrées regex dans `positive` (ex: `"/^stage\\b/i"`) | Ignorées pour `searchText`, appliquées côté client par `runPrefilter`. |
+| Board avec < 200 offres | `maxOffers` n'intervient jamais, comportement identique à l'actuel. |
+| `maxOffers` atteint | Log un avertissement (console) pour signaler la troncature. |
+
+## Tests à ajouter/modifier
+
+- `fetchWorkday` avec `searchText` : vérifier que le body POST contient le bon `searchText`.
+- `fetchWorkday` avec `maxOffers` atteint : mock de pages pleines, vérifier l'arrêt à 200.
+- Construction du `searchText` dans le scanner : mots simples inclus, regex exclus, vide si pas de `positive`.
+
+## Hors scope
+
+- Config `maxOffers` par entreprise dans `portals.yml`.
+- Champ `search_text` custom par portail.
+- Modification des autres fetchers (Lever, Greenhouse, Ashby).

--- a/src/scan/index.mjs
+++ b/src/scan/index.mjs
@@ -94,6 +94,7 @@ export async function runScan(opts) {
     });
   }
 
+  const companyByName = new Map(companies.map((c) => [c.name, c]));
   const fetchResults = await Promise.all(companies.map(fetchCompanyOffers));
 
   const seen = loadSeenUrls(historyPath, applicationsPath);
@@ -162,6 +163,11 @@ export async function runScan(opts) {
     });
     raw += result.offers.length;
 
+    const companyConfig = companyByName.get(result.company);
+    const effectiveConfig = companyConfig?.skip_required_any
+      ? { ...prefilterConfig, whitelist: { ...whitelist, required_any: [] } }
+      : prefilterConfig;
+
     let companyNew = 0;
     for (const offer of result.offers) {
       if (seen.has(offer.url)) {
@@ -174,7 +180,7 @@ export async function runScan(opts) {
 
       let check;
       try {
-        check = runPrefilter(offer, prefilterConfig);
+        check = runPrefilter(offer, effectiveConfig);
       } catch (err) {
         filtered.skipped_other = (filtered.skipped_other || 0) + 1;
         errors.push({ company: offer.company, error: `prefilter: ${err.message}` });

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -10,6 +10,8 @@ tracked_companies:
   - name: Mistral AI
     careers_url: https://jobs.lever.co/mistral
     enabled: true
+    # Domain is implicit in company name — skip required_any filter
+    skip_required_any: true
   - name: Anthropic
     careers_url: https://jobs.lever.co/Anthropic
     enabled: true

--- a/tests/lib/prefilter-title.test.mjs
+++ b/tests/lib/prefilter-title.test.mjs
@@ -91,3 +91,8 @@ test('checkTitle: invalid regex escape hatch rejects cleanly without crashing', 
   assert.match(r.reason, /invalid title_filter term/);
   assert.match(r.reason, /\[unclosed/);
 });
+
+test('checkTitle: empty required_any array is a no-op (skip_required_any support)', () => {
+  const wl = { positive: ['intern'], negative: [], required_any: [] };
+  assert.deepEqual(checkTitle({ title: 'Research Intern' }, wl), { pass: true });
+});

--- a/tests/scan/scan.test.mjs
+++ b/tests/scan/scan.test.mjs
@@ -174,6 +174,78 @@ test('runScan — Workday end-to-end (URL nue + URL avec locale)', async () => {
   );
 });
 
+test('runScan — skip_required_any bypasses required_any for flagged company', async () => {
+  const portalsConfig = {
+    title_filter: {
+      positive: ['Intern', 'Internship'],
+      negative: [],
+      required_any: ['ML', 'AI', 'Data'],
+    },
+    tracked_companies: [
+      {
+        name: 'Mistral AI',
+        careers_url: 'https://jobs.lever.co/mistral',
+        enabled: true,
+        skip_required_any: true,
+      },
+      {
+        name: 'Photoroom',
+        careers_url: 'https://jobs.ashbyhq.com/photoroom',
+        enabled: true,
+      },
+    ],
+  };
+  const profile = { min_start_date: '2026-08-24', blacklist_companies: [] };
+
+  const leverJson = [
+    {
+      hostedUrl: 'https://jobs.lever.co/mistral/job-a',
+      text: 'Research Engineer Intern',
+      categories: { location: 'Paris' },
+      descriptionPlain: 'Paris, France, September 2026.',
+    },
+  ];
+  const ashbyJson = {
+    jobs: [
+      {
+        jobUrl: 'https://jobs.ashbyhq.com/photoroom/job-b',
+        title: 'Research Engineer Intern',
+        location: 'Paris, France',
+        descriptionPlain: 'Paris France septembre 2026.',
+      },
+    ],
+  };
+
+  const restore = installMockFetch({
+    'https://api.lever.co/v0/postings/mistral?mode=json': leverJson,
+    'https://api.ashbyhq.com/posting-api/job-board/photoroom?includeCompensation=false': ashbyJson,
+  });
+
+  const pipelinePath = path.join(tmp, 'pipeline.md');
+  const historyPath = path.join(tmp, 'scan-history.tsv');
+  const filteredPath = path.join(tmp, 'filtered-out.tsv');
+  const applicationsPath = path.join(tmp, 'applications.md');
+  fs.writeFileSync(applicationsPath, '# Apps\n');
+
+  const result = await runScan({
+    portalsConfig,
+    profile,
+    pipelinePath,
+    historyPath,
+    filteredPath,
+    applicationsPath,
+    dryRun: false,
+  });
+
+  restore();
+
+  // Mistral offer passes (skip_required_any bypasses "ML/AI/Data" check)
+  // Photoroom offer fails (title has no ML/AI/Data keyword)
+  assert.equal(result.added.length, 1, `expected 1 added, got ${result.added.length}`);
+  assert.equal(result.added[0].company, 'Mistral AI');
+  assert.equal(result.filtered.skipped_title, 1, 'Photoroom offer should be filtered by required_any');
+});
+
 test('scan CLI — missing candidate-profile.yml fails with ProfileMissingError', () => {
   const cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-cfg-'));
   const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-data-'));

--- a/tests/scan/scan.test.mjs
+++ b/tests/scan/scan.test.mjs
@@ -243,7 +243,11 @@ test('runScan — skip_required_any bypasses required_any for flagged company', 
   // Photoroom offer fails (title has no ML/AI/Data keyword)
   assert.equal(result.added.length, 1, `expected 1 added, got ${result.added.length}`);
   assert.equal(result.added[0].company, 'Mistral AI');
-  assert.equal(result.filtered.skipped_title, 1, 'Photoroom offer should be filtered by required_any');
+  assert.equal(
+    result.filtered.skipped_title,
+    1,
+    'Photoroom offer should be filtered by required_any'
+  );
 });
 
 test('scan CLI — missing candidate-profile.yml fails with ProfileMissingError', () => {


### PR DESCRIPTION
## Summary
- Add `skip_required_any: true` per-company flag in `portals.yml` for AI-native companies (Mistral, DeepMind, etc.) where domain keywords are implicit in the company name
- Scan loop builds a per-company whitelist with empty `required_any` when the flag is set — `positive` and `negative` filters still apply
- No changes to `prefilter-rules.mjs` — `checkTitle` already treats `required_any: []` as a no-op

Closes #13

## Test plan
- [x] Regression guard: `required_any: []` is a no-op (`prefilter-title.test.mjs`)
- [x] Integration: flagged company bypasses `required_any`, unflagged company is still filtered (`scan.test.mjs`)
- [x] Full suite: 284/284 pass
- [x] `npm run lint` — clean
- [x] `npm run check:pii` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)