### PR TITLE
fix(scan): positive geographic filtering on offer.location (issue #14)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ data/
 # Brainstorming specs (personal, not project docs)
 docs/superpowers/
 
+# Git worktrees
+.worktrees/
+
 # Generated files
 dashboard.html
 *.log

--- a/docs/superpowers/plans/2026-04-12-geo-filter-positive-matching.md
+++ b/docs/superpowers/plans/2026-04-12-geo-filter-positive-matching.md
@@ -1,0 +1,347 @@
+# Positive Geographic Filtering — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace negative-only regex location filtering with positive matching against user-defined `target_locations`, using the structured `offer.location` field that fetchers already provide.
+
+**Architecture:** `checkLocation(offer, targetLocations)` splits `offer.location` into segments, checks each against target keywords (case-insensitive substring). Falls back to existing regex heuristic when location is empty. `runPrefilter` receives `targetLocations` via config. `index.mjs` derives the list from profile.
+
+**Tech Stack:** Node 20+, `node:test`, ESM (.mjs)
+
+---
+
+### Task 1: Add failing tests for structured location matching
+
+**Files:**
+- Modify: `tests/lib/prefilter-rules.test.mjs`
+
+- [ ] **Step 1: Add tests for positive location matching with `targetLocations` param**
+
+Add these tests after the existing `checkLocation` block (line 38):
+
+```javascript
+// ---------- checkLocation with targetLocations ----------
+const targets = ['France', 'Paris', 'Remote'];
+
+test('checkLocation: pass "Paris, France" matches target "France"', () => {
+  const r = checkLocation({ location: 'Paris, France', title: 'Dev', body: '' }, targets);
+  assert.deepEqual(r, { pass: true });
+});
+
+test('checkLocation: reject "PRC, Shanghai" no target match', () => {
+  const r = checkLocation({ location: 'PRC, Shanghai', title: 'Dev', body: '' }, targets);
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /location/);
+});
+
+test('checkLocation: reject "Brazil - Sao Paulo"', () => {
+  const r = checkLocation({ location: 'Brazil - Sao Paulo', title: 'Dev', body: '' }, targets);
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /location/);
+});
+
+test('checkLocation: pass "Remote - France" geo segment matches', () => {
+  const r = checkLocation({ location: 'Remote - France', title: 'Dev', body: '' }, targets);
+  assert.deepEqual(r, { pass: true });
+});
+
+test('checkLocation: reject "Remote - US" geo segment no match', () => {
+  const r = checkLocation({ location: 'Remote - US', title: 'Dev', body: '' }, targets);
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /location/);
+});
+
+test('checkLocation: pass "Remote" alone (ambiguous, no geo qualifier)', () => {
+  const r = checkLocation({ location: 'Remote', title: 'Dev', body: '' }, targets);
+  assert.deepEqual(r, { pass: true });
+});
+
+test('checkLocation: reject "Taiwan-Hsinchu" hyphen separator', () => {
+  const r = checkLocation({ location: 'Taiwan-Hsinchu', title: 'Dev', body: '' }, targets);
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /location/);
+});
+
+test('checkLocation: pass "Paris, France / London, UK" one segment matches', () => {
+  const r = checkLocation(
+    { location: 'Paris, France / London, UK', title: 'Dev', body: '' },
+    targets,
+  );
+  assert.deepEqual(r, { pass: true });
+});
+```
+
+- [ ] **Step 2: Add tests for fallback when location is empty**
+
+```javascript
+// ---------- checkLocation fallback (empty location) ----------
+test('checkLocation: fallback pass body mentions Paris', () => {
+  const r = checkLocation({ location: '', title: 'Dev', body: 'Based in Paris office' }, targets);
+  assert.deepEqual(r, { pass: true });
+});
+
+test('checkLocation: fallback reject body mentions New York only', () => {
+  const r = checkLocation(
+    { location: '', title: 'FDSE', body: 'Based in New York City, USA only' },
+    targets,
+  );
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /location/);
+});
+
+test('checkLocation: fallback pass no signal (ambiguous)', () => {
+  const r = checkLocation({ location: '', title: 'Dev', body: 'Great team' }, targets);
+  assert.deepEqual(r, { pass: true });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd /home/leo/Documents/claude-apply-dev/.worktrees/fix-geo-filter && node --test tests/lib/prefilter-rules.test.mjs`
+
+Expected: New tests FAIL because `checkLocation` doesn't accept a second argument and doesn't read `offer.location`.
+
+- [ ] **Step 4: Commit failing tests**
+
+```bash
+git add tests/lib/prefilter-rules.test.mjs
+git commit -m "test(scan): add failing tests for positive location matching (issue #14)"
+```
+
+---
+
+### Task 2: Implement positive location matching in `checkLocation`
+
+**Files:**
+- Modify: `src/lib/prefilter-rules.mjs:9-28`
+
+- [ ] **Step 1: Add `splitLocationSegments` helper and rewrite `checkLocation`**
+
+Replace lines 9-28 in `src/lib/prefilter-rules.mjs` with:
+
+```javascript
+const LOCATION_SEG_RE = /\s*[-/,]\s*/;
+const REMOTE_RE = /^remote$/i;
+
+function splitLocationSegments(loc) {
+  return loc.split(LOCATION_SEG_RE).map((s) => s.trim()).filter(Boolean);
+}
+
+export function checkLocation(offer, targetLocations) {
+  const loc = offer.location || '';
+
+  // Structured location available — use positive matching
+  if (loc) {
+    const segments = splitLocationSegments(loc);
+    const geoSegments = segments.filter((s) => !REMOTE_RE.test(s));
+
+    if (geoSegments.length === 0) {
+      // Pure "Remote" with no geographic qualifier — ambiguous, pass
+      return { pass: true };
+    }
+
+    const match = geoSegments.some((seg) =>
+      (targetLocations || []).some((t) => seg.toLowerCase().includes(t.toLowerCase())),
+    );
+    if (match) return { pass: true };
+    return { pass: false, reason: `location: ${loc} not in target zones` };
+  }
+
+  // Fallback: no structured location — use regex heuristic on title + body
+  const title = offer.title || '';
+  const body = offer.body || '';
+  const titleHasForeign = LOCATION_FOREIGN_RE.test(title);
+  const titleHasFr = LOCATION_FR_RE.test(title);
+  if (titleHasForeign && !titleHasFr) {
+    return { pass: false, reason: 'location: foreign in title, no FR' };
+  }
+  const haystack = `${title} ${body}`;
+  if (LOCATION_FR_RE.test(haystack)) return { pass: true };
+  if (LOCATION_FOREIGN_RE.test(body)) return { pass: false, reason: 'location: foreign only' };
+  return { pass: true };
+}
+```
+
+- [ ] **Step 2: Run new tests to verify they pass**
+
+Run: `cd /home/leo/Documents/claude-apply-dev/.worktrees/fix-geo-filter && node --test tests/lib/prefilter-rules.test.mjs`
+
+Expected: All new tests PASS. Check that no existing tests broke.
+
+- [ ] **Step 3: Commit implementation**
+
+```bash
+git add src/lib/prefilter-rules.mjs
+git commit -m "fix(scan): positive location matching on offer.location (issue #14)"
+```
+
+---
+
+### Task 3: Update existing tests for new signature
+
+**Files:**
+- Modify: `tests/lib/prefilter-rules.test.mjs`
+
+The existing `checkLocation` tests (lines 12-38) call `checkLocation({ body, title })` without `targetLocations`. They should still work because the fallback kicks in when `offer.location` is empty/absent. But the `runPrefilter` integration tests need updating.
+
+- [ ] **Step 1: Update `runPrefilter` integration tests to pass `targetLocations`**
+
+Update the existing `runPrefilter` tests to include `targetLocations` in config:
+
+```javascript
+test('runPrefilter: court-circuit sur la première règle qui échoue', () => {
+  const offer = { title: 'Senior Dev', body: 'Paris', company: 'Foo', location: '' };
+  const config = {
+    minStartDate: '2026-08-24',
+    blacklist: [],
+    whitelist: wl,
+    targetLocations: ['France', 'Paris', 'Remote'],
+  };
+  const r = runPrefilter(offer, config);
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /negative|title/);
+});
+
+test('runPrefilter: pass offre valide', () => {
+  const offer = {
+    title: 'ML Engineer Intern',
+    body: 'Paris office, starting September 2026',
+    company: 'Mistral',
+    location: 'Paris, France',
+  };
+  const config = {
+    minStartDate: '2026-08-24',
+    blacklist: [],
+    whitelist: wl,
+    targetLocations: ['France', 'Paris', 'Remote'],
+  };
+  assert.deepEqual(runPrefilter(offer, config), { pass: true });
+});
+```
+
+- [ ] **Step 2: Wire `targetLocations` through `runPrefilter`**
+
+In `src/lib/prefilter-rules.mjs`, update `runPrefilter` (line 149):
+
+Change:
+```javascript
+() => checkLocation(offer),
+```
+To:
+```javascript
+() => checkLocation(offer, config.targetLocations),
+```
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cd /home/leo/Documents/claude-apply-dev/.worktrees/fix-geo-filter && npm test`
+
+Expected: All 282+ tests pass, 0 failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/prefilter-rules.mjs tests/lib/prefilter-rules.test.mjs
+git commit -m "fix(scan): wire targetLocations through runPrefilter (issue #14)"
+```
+
+---
+
+### Task 4: Build `targetLocations` from profile in `index.mjs`
+
+**Files:**
+- Modify: `src/scan/index.mjs:79-83`
+
+- [ ] **Step 1: Derive `targetLocations` and add to `prefilterConfig`**
+
+In `src/scan/index.mjs`, update the `prefilterConfig` construction (around line 79):
+
+Change:
+```javascript
+  const prefilterConfig = {
+    whitelist,
+    blacklist: profile.blacklist_companies || [],
+    minStartDate: profile.min_start_date || '2026-08-24',
+  };
+```
+
+To:
+```javascript
+  const targetLocations = profile.target_locations ||
+    [profile.country, profile.city, 'Remote'].filter(Boolean);
+  const prefilterConfig = {
+    whitelist,
+    blacklist: profile.blacklist_companies || [],
+    minStartDate: profile.min_start_date || '2026-08-24',
+    targetLocations,
+  };
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `cd /home/leo/Documents/claude-apply-dev/.worktrees/fix-geo-filter && npm test`
+
+Expected: All tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/scan/index.mjs
+git commit -m "fix(scan): derive targetLocations from profile in scan runner (issue #14)"
+```
+
+---
+
+### Task 5: Add `target_locations` to example profile template
+
+**Files:**
+- Modify: `templates/candidate-profile.example.yml`
+
+- [ ] **Step 1: Add `target_locations` field**
+
+Add after the `min_start_date` line (line 77):
+
+```yaml
+
+# --- Geographic targeting (optional) ---
+# Used by /scan to filter offers by location. Case-insensitive substring match.
+# When absent, derived from city + country above → ["France", "Paris", "Remote"].
+# target_locations:
+#   - France
+#   - Paris
+#   - Remote
+```
+
+- [ ] **Step 2: Run PII check and tests**
+
+Run: `cd /home/leo/Documents/claude-apply-dev/.worktrees/fix-geo-filter && npm run check:pii && npm test`
+
+Expected: PII gate clean, all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add templates/candidate-profile.example.yml
+git commit -m "docs: add target_locations field to example profile (issue #14)"
+```
+
+---
+
+### Task 6: Final verification
+
+- [ ] **Step 1: Run full suite + lint + PII gate**
+
+```bash
+cd /home/leo/Documents/claude-apply-dev/.worktrees/fix-geo-filter
+npm test && npm run lint && npm run check:pii
+```
+
+Expected: All green.
+
+- [ ] **Step 2: Review git log**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected: 5-6 commits, clean conventional commit messages, all referencing issue #14.

--- a/docs/superpowers/plans/2026-04-12-skip-required-any.md
+++ b/docs/superpowers/plans/2026-04-12-skip-required-any.md
@@ -1,0 +1,244 @@
+# skip_required_any Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow per-company bypass of the `required_any` title filter for AI-native companies where domain keywords are implicit in the company name.
+
+**Architecture:** A `skip_required_any: true` boolean on `portals.yml` company entries. The scan loop in `index.mjs` builds a per-company whitelist with `required_any: []` when the flag is set. `prefilter-rules.mjs` is untouched — `checkTitle` already treats empty `required_any` as a no-op.
+
+**Tech Stack:** Node 20, ESM, `node:test`
+
+---
+
+### Task 1: Add explicit test for `required_any: []` no-op behavior
+
+**Files:**
+- Modify: `tests/lib/prefilter-title.test.mjs` (after line 93)
+
+- [ ] **Step 1: Write the test**
+
+Add this test at the end of `tests/lib/prefilter-title.test.mjs`:
+
+```js
+test('checkTitle: empty required_any array is a no-op (skip_required_any support)', () => {
+  const wl = { positive: ['intern'], negative: [], required_any: [] };
+  assert.deepEqual(checkTitle({ title: 'Research Intern' }, wl), { pass: true });
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `node --test --test-name-pattern="empty required_any" tests/lib/prefilter-title.test.mjs`
+Expected: PASS (this is a regression guard for existing behavior, not TDD red-green)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/lib/prefilter-title.test.mjs
+git commit -m "test(scan): add regression guard for empty required_any no-op"
+```
+
+---
+
+### Task 2: Wire skip_required_any in the scan loop
+
+**Files:**
+- Modify: `src/scan/index.mjs:96,117,162`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add this test at the end of `tests/scan/scan.test.mjs`:
+
+```js
+test('runScan — skip_required_any bypasses required_any for flagged company', async () => {
+  const portalsConfig = {
+    title_filter: {
+      positive: ['Intern', 'Internship'],
+      negative: [],
+      required_any: ['ML', 'AI', 'Data'],
+    },
+    tracked_companies: [
+      {
+        name: 'Mistral AI',
+        careers_url: 'https://jobs.lever.co/mistral',
+        enabled: true,
+        skip_required_any: true,
+      },
+      {
+        name: 'Photoroom',
+        careers_url: 'https://jobs.ashbyhq.com/photoroom',
+        enabled: true,
+      },
+    ],
+  };
+  const profile = { min_start_date: '2026-08-24', blacklist_companies: [] };
+
+  const leverJson = [
+    {
+      hostedUrl: 'https://jobs.lever.co/mistral/job-a',
+      text: 'Research Engineer Intern',
+      categories: { location: 'Paris' },
+      descriptionPlain: 'Paris, France, September 2026.',
+    },
+  ];
+  const ashbyJson = {
+    jobs: [
+      {
+        jobUrl: 'https://jobs.ashbyhq.com/photoroom/job-b',
+        title: 'Research Engineer Intern',
+        location: 'Paris, France',
+        descriptionPlain: 'Paris France septembre 2026.',
+      },
+    ],
+  };
+
+  const restore = installMockFetch({
+    'https://api.lever.co/v0/postings/mistral?mode=json': leverJson,
+    'https://api.ashbyhq.com/posting-api/job-board/photoroom?includeCompensation=false': ashbyJson,
+  });
+
+  const pipelinePath = path.join(tmp, 'pipeline.md');
+  const historyPath = path.join(tmp, 'scan-history.tsv');
+  const filteredPath = path.join(tmp, 'filtered-out.tsv');
+  const applicationsPath = path.join(tmp, 'applications.md');
+  fs.writeFileSync(applicationsPath, '# Apps\n');
+
+  const result = await runScan({
+    portalsConfig,
+    profile,
+    pipelinePath,
+    historyPath,
+    filteredPath,
+    applicationsPath,
+    dryRun: false,
+  });
+
+  restore();
+
+  // Mistral offer passes (skip_required_any bypasses "ML/AI/Data" check)
+  // Photoroom offer fails (title has no ML/AI/Data keyword)
+  assert.equal(result.added.length, 1, `expected 1 added, got ${result.added.length}`);
+  assert.equal(result.added[0].company, 'Mistral AI');
+  assert.equal(result.filtered.skipped_title, 1, 'Photoroom offer should be filtered by required_any');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test --test-name-pattern="skip_required_any" tests/scan/scan.test.mjs`
+Expected: FAIL — both offers are filtered because `skip_required_any` is not yet wired.
+
+- [ ] **Step 3: Implement — change the scan loop to use indexed iteration and build per-company whitelist**
+
+In `src/scan/index.mjs`, make two changes:
+
+1. Change `Promise.all` result to preserve company config alongside results. Replace line 96:
+
+```js
+const fetchResults = await Promise.all(companies.map(fetchCompanyOffers));
+```
+
+with:
+
+```js
+const fetchResults = await Promise.all(
+  companies.map(async (c) => ({ ...(await fetchCompanyOffers(c)), _company: c }))
+);
+```
+
+2. Inside the offer loop (line 162), replace:
+
+```js
+        check = runPrefilter(offer, prefilterConfig);
+```
+
+with:
+
+```js
+        const effectiveWhitelist = result._company?.skip_required_any
+          ? { ...whitelist, required_any: [] }
+          : whitelist;
+        check = runPrefilter(offer, { ...prefilterConfig, whitelist: effectiveWhitelist });
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test --test-name-pattern="skip_required_any" tests/scan/scan.test.mjs`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `npm test`
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/scan/index.mjs tests/scan/scan.test.mjs
+git commit -m "feat(scan): wire skip_required_any per-company flag (closes #13)"
+```
+
+---
+
+### Task 3: Update docs and template
+
+**Files:**
+- Modify: `templates/portals.example.yml`
+- Modify: `docs/scan-workflow.md`
+
+- [ ] **Step 1: Update portals.example.yml**
+
+Add `skip_required_any: true` to the Mistral entry and a comment. Replace lines 10-12:
+
+```yaml
+  - name: Mistral AI
+    careers_url: https://jobs.lever.co/mistral
+    enabled: true
+```
+
+with:
+
+```yaml
+  - name: Mistral AI
+    careers_url: https://jobs.lever.co/mistral
+    enabled: true
+    # Domain is implicit in company name — skip required_any filter
+    skip_required_any: true
+```
+
+- [ ] **Step 2: Update docs/scan-workflow.md**
+
+After the title filter section (after line 49), add:
+
+```markdown
+
+### Per-company override: `skip_required_any`
+
+For companies where the domain is implicit in the name (e.g. Mistral AI, DeepMind), the `required_any` filter can be bypassed per-company:
+
+```yaml
+tracked_companies:
+  - name: Mistral AI
+    careers_url: https://jobs.lever.co/mistral
+    skip_required_any: true
+```
+
+When set, `positive` and `negative` filters still apply — only `required_any` is skipped.
+```
+
+- [ ] **Step 3: Run PII check**
+
+Run: `npm run check:pii`
+Expected: PASS
+
+- [ ] **Step 4: Run lint**
+
+Run: `npm run lint`
+Expected: PASS (or fix with `npm run format`)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add templates/portals.example.yml docs/scan-workflow.md
+git commit -m "docs: document skip_required_any flag in template and workflow"
+```

--- a/docs/superpowers/specs/2026-04-12-geo-filter-positive-matching-design.md
+++ b/docs/superpowers/specs/2026-04-12-geo-filter-positive-matching-design.md
@@ -1,0 +1,111 @@
+# Design: Positive Geographic Filtering (Issue #14)
+
+## Problem
+
+The current `checkLocation()` in `prefilter-rules.mjs` uses negative regex matching
+against title and body text. This fails for Workday offers (empty body) and misses
+non-Western location formats ("PRC, Shanghai", "Brazil - Sao Paulo", "Taiwan-Hsinchu").
+Result: 12/25 scored offers were out-of-scope geographically, wasting ~$0.36.
+
+Three root causes:
+1. `offer.location` (structured, always populated by fetchers) is never checked
+2. `LOCATION_FOREIGN_RE` doesn't cover Workday-specific formats
+3. No positive filtering — only a hardcoded blocklist of foreign cities/countries
+
+## Solution
+
+Replace negative-only regex with **positive matching against `target_locations`**,
+falling back to the current regex heuristic when structured location data is absent.
+
+## New Signature
+
+```javascript
+checkLocation(offer, targetLocations)
+// targetLocations: string[] e.g. ["France", "Paris", "Remote"]
+```
+
+## Logic Flow
+
+```
+1. If offer.location is non-empty:
+   a. Split location into segments on " - ", "/", ", "
+   b. Discard pure "Remote" segments (handled separately)
+   c. If geographic segments remain:
+      - Any segment matches a target (case-insensitive substring)? → PASS
+      - No match? → REJECT "location: <location> not in target zones"
+   d. If only "Remote" segments (no geo qualifier):
+      - "Remote" is in targetLocations? → PASS
+      - Otherwise → PASS (ambiguous, let scorer decide)
+
+2. If offer.location is empty, fallback to current regex on title + body:
+   a. Title has foreign match AND no FR match? → REJECT
+   b. FR match in title or body? → PASS
+   c. Foreign match in body only? → REJECT
+   d. No signal? → PASS (ambiguous)
+```
+
+### Remote Handling
+
+- `"Remote - France"` → segments ["Remote", "France"] → geo segment "France" matches target → PASS
+- `"Remote - US"` → segments ["Remote", "US"] → geo segment "US" matches no target → REJECT
+- `"Remote"` alone → no geo segments → PASS (ambiguous)
+
+## Configuration
+
+### In `candidate-profile.yml` (optional)
+
+```yaml
+# --- Geographic targeting (optional) ---
+target_locations:
+  - France
+  - Paris
+  - Remote
+```
+
+### Default Derivation
+
+When `target_locations` is absent, derived from existing profile fields:
+
+```javascript
+const targetLocations = profile.target_locations
+  || [profile.country, profile.city, 'Remote'].filter(Boolean);
+```
+
+For Alice Martin: `["France", "Paris", "Remote"]`.
+
+### Wiring
+
+`src/scan/index.mjs` builds `targetLocations` from the profile and passes it
+via `config.targetLocations` to `runPrefilter`, which forwards it to `checkLocation`.
+
+## Changes by File
+
+| File | Change |
+|------|--------|
+| `src/lib/prefilter-rules.mjs` | New `checkLocation(offer, targetLocations)` signature; positive matching on `offer.location` with segment splitting; fallback to existing regex; `runPrefilter` passes `config.targetLocations` |
+| `src/scan/index.mjs` | Build `targetLocations` from profile before calling `runPrefilter` |
+| `templates/candidate-profile.example.yml` | Add commented `target_locations` section |
+| `tests/lib/prefilter-rules.test.mjs` | New tests for structured location, remote handling, fallback |
+
+## Key Test Cases
+
+| # | location | targets | title/body | Expected | Why |
+|---|----------|---------|------------|----------|-----|
+| 1 | `"Paris, France"` | `["France"]` | — | PASS | Substring match on "France" |
+| 2 | `"PRC, Shanghai"` | `["France", "Remote"]` | — | REJECT | No segment matches targets |
+| 3 | `"Brazil - Sao Paulo"` | `["France"]` | — | REJECT | No segment matches |
+| 4 | `"Remote - France"` | `["France", "Remote"]` | — | PASS | Geo segment "France" matches |
+| 5 | `"Remote - US"` | `["France", "Remote"]` | — | REJECT | Geo segment "US" no match |
+| 6 | `"Remote"` | `["France", "Remote"]` | — | PASS | No geo qualifier, ambiguous |
+| 7 | `""` | `["France"]` | body: "Paris office" | PASS | Fallback regex finds FR |
+| 8 | `""` | `["France"]` | body: "New York City, USA only" | REJECT | Fallback regex finds foreign |
+| 9 | `""` | `["France"]` | body: "Great team" | PASS | Fallback: no signal, ambiguous |
+| 10 | `"Taiwan-Hsinchu"` | `["France"]` | — | REJECT | Segment split on "-", no match |
+| 11 | `"Paris, France / London, UK"` | `["France"]` | — | PASS | One segment matches |
+| 12 | — | (derived) | — | — | Verify default derivation from profile |
+
+## Non-Goals
+
+- Regex escape hatch for `target_locations` (YAGNI — add later if needed)
+- Scoring prompt changes (scorer already receives location metadata)
+- Changes to fetcher location extraction (already correct)

--- a/docs/superpowers/specs/2026-04-12-scan-progress-logs-design.md
+++ b/docs/superpowers/specs/2026-04-12-scan-progress-logs-design.md
@@ -1,0 +1,66 @@
+# Design: Scan Progress Logs (Issue #12)
+
+## Problem
+
+`runScan()` produces no output until the entire scan completes. When scanning 55 companies, users cannot tell whether the scan is running, stuck, or how far along it is.
+
+## Solution
+
+Add an optional `onProgress` callback to `runScan()`. The CLI wires it to `stderr`; tests can capture or ignore it.
+
+## Callback Signature
+
+```js
+onProgress({ index, total, company, platform, count, error })
+```
+
+| Field      | Type             | Description                                    |
+|------------|------------------|------------------------------------------------|
+| `index`    | `number`         | 1-based counter of completed companies         |
+| `total`    | `number`         | Total number of companies to scan              |
+| `company`  | `string`         | Company name                                   |
+| `platform` | `string \| null` | Detected ATS platform                          |
+| `count`    | `number`         | Number of raw offers fetched                   |
+| `error`    | `string \| null` | Error message if fetch failed, null on success |
+
+## Call Site
+
+The callback fires inside the existing `for (const result of fetchResults)` loop in `runScan()`, after the `Promise.all` resolves. Since iteration order matches the `companies` array order, the counter increments deterministically.
+
+## CLI Output Format (stderr)
+
+```
+[12/55] ✓ Mistral AI — 147 raw, 3 new
+[13/55] ✗ Datadog — fetch error: 403
+```
+
+- Success: `[index/total] ✓ company — N raw, M new`
+- Error: `[index/total] ✗ company — error message`
+- Active for both normal and `--json` modes (stderr does not pollute stdout)
+
+Note: `new` count requires tracking per-company new offers in the results loop, which is derived from offers that pass dedup and prefilter.
+
+## Concurrency
+
+The existing `Promise.all` parallel fetch is preserved. No change to scan performance.
+
+## What Does Not Change
+
+- `runScan()` return value shape
+- `formatSummary()` final output
+- Existing tests (no `onProgress` = no log)
+
+## Files Changed
+
+| File                           | Change                                                        |
+|--------------------------------|---------------------------------------------------------------|
+| `src/scan/index.mjs`          | Add `onProgress` to `runScan` opts, call in results loop, wire to stderr in `main()` |
+| `tests/scan/progress.test.mjs`| New test verifying callback args (index, total, company info) |
+
+## Tests
+
+A test passes a mock `onProgress` callback that accumulates calls into an array, then asserts:
+- Called once per company
+- `index` increments from 1 to `total`
+- `total` equals number of companies
+- Error companies have non-null `error` field

--- a/docs/superpowers/specs/2026-04-12-skip-required-any-design.md
+++ b/docs/superpowers/specs/2026-04-12-skip-required-any-design.md
@@ -1,0 +1,53 @@
+# Design: per-company `skip_required_any` flag
+
+**Issue:** [#13 — feat(scan): Flag skip_required_any pour les entreprises AI-native](https://github.com/LeoLaborie/claude-apply/issues/13)
+
+**Problem:** Companies like Mistral AI are 100% AI-focused, so their job titles don't redundantly include "AI" or "ML". The global `required_any` filter in `portals.yml` rejects valid offers because the domain keyword is implicit in the company name.
+
+**Solution:** A per-company `skip_required_any: true` boolean in `portals.yml` that bypasses the `required_any` check for that company's offers, while keeping `positive` and `negative` filters intact.
+
+## Config change
+
+New optional field on `tracked_companies` entries:
+
+```yaml
+tracked_companies:
+  - name: Mistral AI
+    careers_url: https://jobs.lever.co/mistral
+    skip_required_any: true   # domain is implicit — skip required_any filter
+```
+
+Default: `false` (no behavior change for existing entries).
+
+## Code change
+
+**`src/scan/index.mjs` ~line 160–162** — before calling `runPrefilter`, build a per-company whitelist when the flag is set:
+
+```js
+const companyWhitelist = company.skip_required_any
+  ? { ...whitelist, required_any: [] }
+  : whitelist;
+check = runPrefilter(offer, { ...prefilterConfig, whitelist: companyWhitelist });
+```
+
+`checkTitle` (line 125) already treats an empty `required_any` array as a no-op via `Array.isArray(whitelist.required_any) && whitelist.required_any.length > 0`, so **no change to `prefilter-rules.mjs`**.
+
+## What does NOT change
+
+- `prefilter-rules.mjs` — untouched
+- `score/` and `apply/` — unaffected (flag only consumed by scan)
+- `positive` and `negative` filters — still applied for skip_required_any companies
+
+## Tests
+
+1. **Unit test** in `tests/lib/prefilter-title.test.mjs`: confirm `required_any: []` is a no-op (explicit regression guard — currently only implicitly covered).
+2. **Integration-level test**: verify the scan loop respects `skip_required_any` by passing a company config with the flag set and asserting the offer passes prefilter despite missing `required_any` keywords.
+
+## Docs
+
+- `templates/portals.example.yml`: add `skip_required_any: true` on Mistral entry with a comment.
+- `docs/scan-workflow.md`: add a paragraph in the "Title filter" section explaining the per-company override.
+
+## Scope
+
+~10 lines of production code, ~20 lines of tests, 2 doc updates. No new dependencies, no schema changes, no breaking changes.

--- a/docs/superpowers/specs/2026-04-12-workday-pagination-fix-design.md
+++ b/docs/superpowers/specs/2026-04-12-workday-pagination-fix-design.md
@@ -1,0 +1,56 @@
+# Fix Workday pagination timeout (#11)
+
+## Problème
+
+`fetchWorkday` pagine sans limite (`while(true)`, blocs de 20). Sur les gros boards (Sanofi : 1204 offres = 60 requêtes séquentielles), ça cause des timeouts (>4 min, seuil à 240s).
+
+## Solution : deux mécanismes complémentaires
+
+### 1. `searchText` côté API
+
+Avant de paginer, construire une chaîne à partir de `title_filter.positive` (ex: `"Intern Internship Stage Stagiaire"`) et l'envoyer dans le body POST Workday. L'API fait un OR implicite sur les termes, ce qui réduit drastiquement le volume retourné (de ~1200 à ~20-50 offres typiquement).
+
+Construction du `searchText` :
+- Joindre les entrées de `title_filter.positive` qui sont des mots simples (pas des regex `/…/`) avec des espaces.
+- Les entrées regex sont ignorées pour le `searchText` — elles continuent à être appliquées côté client via `runPrefilter`.
+- Si `positive` est vide ou absent, `searchText` reste `''` (comportement actuel, pas de filtre API).
+
+### 2. `maxOffers` cap
+
+Constante `MAX_OFFERS = 200` dans `workday.mjs`. La boucle de pagination s'arrête dès que `offers.length >= MAX_OFFERS`. Filet de sécurité si `searchText` ne filtre pas assez.
+
+## Changements fichier par fichier
+
+### `src/scan/ats/workday.mjs`
+
+- Ajouter `const MAX_OFFERS = 200`.
+- `postJobs` : accepter un paramètre `searchText` au lieu du `''` codé en dur.
+- `fetchWorkday` : accepter `opts.searchText`, le passer à `postJobs`. Ajouter la condition `offers.length >= MAX_OFFERS` comme condition de sortie de la boucle `while`.
+- Signature inchangée : `fetchWorkday(url, companyName, opts)`.
+
+### `src/scan/index.mjs`
+
+- Dans `fetchCompanyOffers`, quand `det.platform === 'workday'`, construire le `searchText` en joignant les mots simples de `whitelist.positive` avec des espaces.
+- Passer `{ searchText }` en 3e argument de `fetchWorkday`.
+- Les autres fetchers continuent à recevoir `(slug, companyName)` sans changement.
+
+## Cas limites
+
+| Cas | Comportement |
+|-----|-------------|
+| `title_filter.positive` vide ou absent | `searchText` = `''`, pas de filtre API. `maxOffers` protège. |
+| Entrées regex dans `positive` (ex: `"/^stage\\b/i"`) | Ignorées pour `searchText`, appliquées côté client par `runPrefilter`. |
+| Board avec < 200 offres | `maxOffers` n'intervient jamais, comportement identique à l'actuel. |
+| `maxOffers` atteint | Log un avertissement (console) pour signaler la troncature. |
+
+## Tests à ajouter/modifier
+
+- `fetchWorkday` avec `searchText` : vérifier que le body POST contient le bon `searchText`.
+- `fetchWorkday` avec `maxOffers` atteint : mock de pages pleines, vérifier l'arrêt à 200.
+- Construction du `searchText` dans le scanner : mots simples inclus, regex exclus, vide si pas de `positive`.
+
+## Hors scope
+
+- Config `maxOffers` par entreprise dans `portals.yml`.
+- Champ `search_text` custom par portail.
+- Modification des autres fetchers (Lever, Greenhouse, Ashby).

--- a/src/lib/prefilter-rules.mjs
+++ b/src/lib/prefilter-rules.mjs
@@ -169,7 +169,7 @@ export function runPrefilter(offer, config) {
   const checks = [
     () => checkTitle(offer, config.whitelist),
     () => checkBlacklist(offer, config.blacklist),
-    () => checkLocation(offer),
+    () => checkLocation(offer, config.targetLocations),
     () => checkStartDate(offer, config.minStartDate),
   ];
   for (const fn of checks) {

--- a/src/lib/prefilter-rules.mjs
+++ b/src/lib/prefilter-rules.mjs
@@ -6,25 +6,48 @@ const LOCATION_FR_RE =
 const LOCATION_FOREIGN_RE =
   /\b(new york|nyc|london|berlin|munich|san francisco|sf bay|palo alto|tokyo|seoul|singapore|dubai|mena|morocco|sydney|australia|montreal|warsaw|poland|sweden|stockholm|netherlands|amsterdam|spain|madrid|barcelona|germany|luxembourg|italy|italian|milan|rome|austria|vienna|switzerland|zurich|geneva|denmark|copenhagen|norway|oslo|finland|helsinki|ireland|dublin|belgium|brussels|usa only|uk only|us citizens? only|green card|visa sponsorship not)\b/i;
 
-export function checkLocation(offer) {
+const LOCATION_SEG_RE = /\s*[-/,]\s*/;
+const REMOTE_RE = /^remote$/i;
+
+function splitLocationSegments(loc) {
+  return loc
+    .split(LOCATION_SEG_RE)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function checkLocation(offer, targetLocations) {
+  const loc = offer.location || '';
+
+  // Structured location available — use positive matching
+  if (loc) {
+    const segments = splitLocationSegments(loc);
+    const geoSegments = segments.filter((s) => !REMOTE_RE.test(s));
+
+    if (geoSegments.length === 0) {
+      // Pure "Remote" with no geographic qualifier — ambiguous, pass
+      return { pass: true };
+    }
+
+    const match = geoSegments.some((seg) =>
+      (targetLocations || []).some((t) => seg.toLowerCase().includes(t.toLowerCase())),
+    );
+    if (match) return { pass: true };
+    return { pass: false, reason: `location: ${loc} not in target zones` };
+  }
+
+  // Fallback: no structured location — use regex heuristic on title + body
   const title = offer.title || '';
   const body = offer.body || '';
-  // 1. If the title explicitly mentions a foreign-only location and no FR
-  //    location, reject immediately. This handles patterns like
-  //    "Role - Morocco" or "Account Executive - Netherlands" where the body
-  //    may incidentally mention France as a supported region.
   const titleHasForeign = LOCATION_FOREIGN_RE.test(title);
   const titleHasFr = LOCATION_FR_RE.test(title);
   if (titleHasForeign && !titleHasFr) {
     return { pass: false, reason: 'location: foreign in title, no FR' };
   }
-  // 2. FR mention anywhere (title or body) → pass. Hybrid titles like
-  //    "AI Scientist - Paris/London" fall into this branch.
   const haystack = `${title} ${body}`;
   if (LOCATION_FR_RE.test(haystack)) return { pass: true };
-  // 3. No FR signal found — if body has a foreign-only mention, reject.
   if (LOCATION_FOREIGN_RE.test(body)) return { pass: false, reason: 'location: foreign only' };
-  return { pass: true }; // ambiguous → pass
+  return { pass: true };
 }
 
 const MONTHS = {

--- a/src/lib/prefilter-rules.mjs
+++ b/src/lib/prefilter-rules.mjs
@@ -30,7 +30,7 @@ export function checkLocation(offer, targetLocations) {
     }
 
     const match = geoSegments.some((seg) =>
-      (targetLocations || []).some((t) => seg.toLowerCase().includes(t.toLowerCase())),
+      (targetLocations || []).some((t) => seg.toLowerCase().includes(t.toLowerCase()))
     );
     if (match) return { pass: true };
     return { pass: false, reason: `location: ${loc} not in target zones` };

--- a/src/scan/index.mjs
+++ b/src/scan/index.mjs
@@ -76,10 +76,13 @@ export async function runScan(opts) {
   } = opts;
 
   const whitelist = portalsConfig.title_filter || { positive: [], negative: [] };
+  const targetLocations =
+    profile.target_locations || [profile.country, profile.city, 'Remote'].filter(Boolean);
   const prefilterConfig = {
     whitelist,
     blacklist: profile.blacklist_companies || [],
     minStartDate: profile.min_start_date || '2026-08-24',
+    targetLocations,
   };
 
   let companies = (portalsConfig.tracked_companies || [])

--- a/templates/candidate-profile.example.yml
+++ b/templates/candidate-profile.example.yml
@@ -74,3 +74,11 @@ disability_status: null
 # Used by /scan and /score to filter out unwanted companies / too-early start dates.
 blacklist_companies: []
 min_start_date: '2026-08-24'
+
+# --- Geographic targeting (optional) ---
+# Used by /scan to filter offers by location. Case-insensitive substring match.
+# When absent, derived from city + country above → ["France", "Paris", "Remote"].
+# target_locations:
+#   - France
+#   - Paris
+#   - Remote

--- a/tests/lib/prefilter-rules.test.mjs
+++ b/tests/lib/prefilter-rules.test.mjs
@@ -37,6 +37,76 @@ test('checkLocation: pass ambigu (aucun signal)', () => {
   assert.deepEqual(checkLocation({ body: 'Great team great tech', title: 'Dev' }), { pass: true });
 });
 
+// ---------- checkLocation with targetLocations ----------
+const targets = ['France', 'Paris', 'Remote'];
+
+test('checkLocation: pass "Paris, France" matches target "France"', () => {
+  const r = checkLocation({ location: 'Paris, France', title: 'Dev', body: '' }, targets);
+  assert.deepEqual(r, { pass: true });
+});
+
+test('checkLocation: reject "PRC, Shanghai" no target match', () => {
+  const r = checkLocation({ location: 'PRC, Shanghai', title: 'Dev', body: '' }, targets);
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /location/);
+});
+
+test('checkLocation: reject "Brazil - Sao Paulo"', () => {
+  const r = checkLocation({ location: 'Brazil - Sao Paulo', title: 'Dev', body: '' }, targets);
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /location/);
+});
+
+test('checkLocation: pass "Remote - France" geo segment matches', () => {
+  const r = checkLocation({ location: 'Remote - France', title: 'Dev', body: '' }, targets);
+  assert.deepEqual(r, { pass: true });
+});
+
+test('checkLocation: reject "Remote - US" geo segment no match', () => {
+  const r = checkLocation({ location: 'Remote - US', title: 'Dev', body: '' }, targets);
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /location/);
+});
+
+test('checkLocation: pass "Remote" alone (ambiguous, no geo qualifier)', () => {
+  const r = checkLocation({ location: 'Remote', title: 'Dev', body: '' }, targets);
+  assert.deepEqual(r, { pass: true });
+});
+
+test('checkLocation: reject "Taiwan-Hsinchu" hyphen separator', () => {
+  const r = checkLocation({ location: 'Taiwan-Hsinchu', title: 'Dev', body: '' }, targets);
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /location/);
+});
+
+test('checkLocation: pass "Paris, France / London, UK" one segment matches', () => {
+  const r = checkLocation(
+    { location: 'Paris, France / London, UK', title: 'Dev', body: '' },
+    targets,
+  );
+  assert.deepEqual(r, { pass: true });
+});
+
+// ---------- checkLocation fallback (empty location) ----------
+test('checkLocation: fallback pass body mentions Paris', () => {
+  const r = checkLocation({ location: '', title: 'Dev', body: 'Based in Paris office' }, targets);
+  assert.deepEqual(r, { pass: true });
+});
+
+test('checkLocation: fallback reject body mentions New York only', () => {
+  const r = checkLocation(
+    { location: '', title: 'FDSE', body: 'Based in New York City, USA only' },
+    targets,
+  );
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /location/);
+});
+
+test('checkLocation: fallback pass no signal (ambiguous)', () => {
+  const r = checkLocation({ location: '', title: 'Dev', body: 'Great team' }, targets);
+  assert.deepEqual(r, { pass: true });
+});
+
 // ---------- checkStartDate ----------
 test('checkStartDate: pass si septembre 2026', () => {
   assert.deepEqual(checkStartDate({ body: 'Starting September 2026' }, '2026-08-24'), {

--- a/tests/lib/prefilter-rules.test.mjs
+++ b/tests/lib/prefilter-rules.test.mjs
@@ -82,7 +82,7 @@ test('checkLocation: reject "Taiwan-Hsinchu" hyphen separator', () => {
 test('checkLocation: pass "Paris, France / London, UK" one segment matches', () => {
   const r = checkLocation(
     { location: 'Paris, France / London, UK', title: 'Dev', body: '' },
-    targets,
+    targets
   );
   assert.deepEqual(r, { pass: true });
 });
@@ -96,7 +96,7 @@ test('checkLocation: fallback pass body mentions Paris', () => {
 test('checkLocation: fallback reject body mentions New York only', () => {
   const r = checkLocation(
     { location: '', title: 'FDSE', body: 'Based in New York City, USA only' },
-    targets,
+    targets
   );
   assert.equal(r.pass, false);
   assert.match(r.reason, /location/);

--- a/tests/lib/prefilter-rules.test.mjs
+++ b/tests/lib/prefilter-rules.test.mjs
@@ -171,8 +171,13 @@ test('checkBlacklist: reject case-insensitive', () => {
 
 // ---------- runPrefilter (intégration) ----------
 test('runPrefilter: court-circuit sur la première règle qui échoue', () => {
-  const offer = { title: 'Senior Dev', body: 'Paris', company: 'Foo' };
-  const config = { minStartDate: '2026-08-24', blacklist: [], whitelist: wl };
+  const offer = { title: 'Senior Dev', body: 'Paris', company: 'Foo', location: '' };
+  const config = {
+    minStartDate: '2026-08-24',
+    blacklist: [],
+    whitelist: wl,
+    targetLocations: ['France', 'Paris', 'Remote'],
+  };
   const r = runPrefilter(offer, config);
   assert.equal(r.pass, false);
   assert.match(r.reason, /negative|title/);
@@ -183,7 +188,13 @@ test('runPrefilter: pass offre valide', () => {
     title: 'ML Engineer Intern',
     body: 'Paris office, starting September 2026',
     company: 'Mistral',
+    location: 'Paris, France',
   };
-  const config = { minStartDate: '2026-08-24', blacklist: [], whitelist: wl };
+  const config = {
+    minStartDate: '2026-08-24',
+    blacklist: [],
+    whitelist: wl,
+    targetLocations: ['France', 'Paris', 'Remote'],
+  };
   assert.deepEqual(runPrefilter(offer, config), { pass: true });
 });

--- a/tests/scan/scan.test.mjs
+++ b/tests/scan/scan.test.mjs
@@ -128,7 +128,11 @@ test('runScan — Workday end-to-end (URL nue + URL avec locale)', async () => {
       },
     ],
   };
-  const profile = { min_start_date: '2020-01-01', blacklist_companies: [], target_locations: ['France', 'Paris', 'Remote'] };
+  const profile = {
+    min_start_date: '2020-01-01',
+    blacklist_companies: [],
+    target_locations: ['France', 'Paris', 'Remote'],
+  };
 
   // Both companies hit the same Workday API endpoint (locale is stripped
   // by parseWorkdayUrl). The fixture is a short page so fetchWorkday's

--- a/tests/scan/scan.test.mjs
+++ b/tests/scan/scan.test.mjs
@@ -35,6 +35,7 @@ test('runScan — e2e avec 2 companies mockées, écrit pipeline + history', asy
   const profile = {
     min_start_date: '2026-08-24',
     blacklist_companies: [],
+    target_locations: ['France', 'Paris', 'Remote'],
   };
 
   const leverJson = [
@@ -127,7 +128,7 @@ test('runScan — Workday end-to-end (URL nue + URL avec locale)', async () => {
       },
     ],
   };
-  const profile = { min_start_date: '2020-01-01', blacklist_companies: [] };
+  const profile = { min_start_date: '2020-01-01', blacklist_companies: [], target_locations: ['France', 'Paris', 'Remote'] };
 
   // Both companies hit the same Workday API endpoint (locale is stripped
   // by parseWorkdayUrl). The fixture is a short page so fetchWorkday's


### PR DESCRIPTION
## Summary
- `checkLocation(offer, targetLocations)` now does **positive matching** on `offer.location` — splits segments on `- / ,`, filters out "Remote", checks remaining geo segments against user-defined targets (case-insensitive substring)
- **Fallback** to existing regex heuristic (FR/foreign patterns on title+body) when `offer.location` is empty — zero regression for ATS without structured location
- `target_locations` config field (optional) in `candidate-profile.yml`; when absent, derived from `country` + `city` + `"Remote"`
- 11 new tests covering structured location, remote handling (with/without qualifier), and fallback path

## Why
12/25 scored offers were out-of-scope geographically ($0.36 wasted). Root cause: `checkLocation` never used the structured `offer.location` field that all fetchers already populate, and the negative regex missed Workday formats like "PRC, Shanghai" or "Brazil - Sao Paulo".

Closes #14

## Test plan
- [x] 293/293 tests pass (`npm test`)
- [x] Lint clean (`npm run lint`)
- [x] PII gate clean (`npm run check:pii`)
- [ ] Manual: run `/scan` and verify Workday offers with foreign locations are filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)