### PR TITLE
fix(scan): Workday pagination timeout — searchText + maxOffers cap (#11)

### DIFF
--- a/src/scan/ats/workday.mjs
+++ b/src/scan/ats/workday.mjs
@@ -86,7 +86,12 @@ export async function fetchWorkday(url, companyName, opts = {}) {
       });
     }
     if (postings.length < pageSize) break;
-    if (offers.length >= maxOffers) break;
+    if (offers.length >= maxOffers) {
+      console.warn(
+        `[workday] ${parts.tenant}/${parts.site}: stopped at ${offers.length} offers (maxOffers=${maxOffers})`
+      );
+      break;
+    }
     offset += pageSize;
   }
   return offers;

--- a/src/scan/ats/workday.mjs
+++ b/src/scan/ats/workday.mjs
@@ -23,7 +23,7 @@ function buildJobUrl({ tenant, pod, site }, externalPath) {
   return `https://${tenant}.${pod}.myworkdayjobs.com/en-US/${site}${externalPath}`;
 }
 
-async function postJobs({ tenant, pod, site }, { limit, offset }) {
+async function postJobs({ tenant, pod, site }, { limit, offset, searchText = '' }) {
   const url = `https://${tenant}.${pod}.myworkdayjobs.com/wday/cxs/${tenant}/${site}/jobs`;
   const res = await fetch(url, {
     method: 'POST',
@@ -32,7 +32,7 @@ async function postJobs({ tenant, pod, site }, { limit, offset }) {
       'Content-Type': 'application/json',
       'User-Agent': 'claude-apply-scan/1.0',
     },
-    body: JSON.stringify({ appliedFacets: {}, limit, offset, searchText: '' }),
+    body: JSON.stringify({ appliedFacets: {}, limit, offset, searchText }),
   });
   if (!res.ok) {
     throw new Error(`Workday API ${tenant}/${site}: HTTP ${res.status}`);
@@ -69,10 +69,11 @@ export async function fetchWorkday(url, companyName, opts = {}) {
   const parts = parseWorkdayUrl(url);
   const pageSize = opts.pageSize ?? DEFAULT_PAGE_SIZE;
   const maxOffers = opts.maxOffers ?? DEFAULT_MAX_OFFERS;
+  const searchText = opts.searchText ?? '';
   const offers = [];
   let offset = 0;
   while (true) {
-    const page = await postJobs(parts, { limit: pageSize, offset });
+    const page = await postJobs(parts, { limit: pageSize, offset, searchText });
     const postings = Array.isArray(page?.jobPostings) ? page.jobPostings : [];
     for (const p of postings) {
       offers.push({

--- a/src/scan/ats/workday.mjs
+++ b/src/scan/ats/workday.mjs
@@ -17,6 +17,7 @@ export function parseWorkdayUrl(url) {
 }
 
 const DEFAULT_PAGE_SIZE = 20;
+const DEFAULT_MAX_OFFERS = 200;
 
 function buildJobUrl({ tenant, pod, site }, externalPath) {
   return `https://${tenant}.${pod}.myworkdayjobs.com/en-US/${site}${externalPath}`;
@@ -67,6 +68,7 @@ export async function verifySlug(url) {
 export async function fetchWorkday(url, companyName, opts = {}) {
   const parts = parseWorkdayUrl(url);
   const pageSize = opts.pageSize ?? DEFAULT_PAGE_SIZE;
+  const maxOffers = opts.maxOffers ?? DEFAULT_MAX_OFFERS;
   const offers = [];
   let offset = 0;
   while (true) {
@@ -83,6 +85,7 @@ export async function fetchWorkday(url, companyName, opts = {}) {
       });
     }
     if (postings.length < pageSize) break;
+    if (offers.length >= maxOffers) break;
     offset += pageSize;
   }
   return offers;

--- a/src/scan/index.mjs
+++ b/src/scan/index.mjs
@@ -46,7 +46,12 @@ function reasonToStatus(reason) {
   return 'skipped_other';
 }
 
-async function fetchCompanyOffers(company) {
+function buildSearchText(positiveTerms) {
+  if (!Array.isArray(positiveTerms) || positiveTerms.length === 0) return '';
+  return positiveTerms.filter((t) => typeof t === 'string' && !t.startsWith('/')).join(' ');
+}
+
+async function fetchCompanyOffers(company, whitelist) {
   const det = detectPlatform(company.careers_url);
   if (!det) {
     return { company: company.name, platform: null, offers: [], error: 'platform not detected' };
@@ -56,7 +61,9 @@ async function fetchCompanyOffers(company) {
     return { company: company.name, platform: det.platform, offers: [], error: 'no fetcher' };
   }
   try {
-    const offers = await fn(det.slug, company.name);
+    const opts =
+      det.platform === 'workday' ? { searchText: buildSearchText(whitelist.positive) } : undefined;
+    const offers = opts ? await fn(det.slug, company.name, opts) : await fn(det.slug, company.name);
     return { company: company.name, platform: det.platform, offers, error: null };
   } catch (err) {
     return { company: company.name, platform: det.platform, offers: [], error: err.message };
@@ -98,7 +105,7 @@ export async function runScan(opts) {
   }
 
   const companyByName = new Map(companies.map((c) => [c.name, c]));
-  const fetchResults = await Promise.all(companies.map(fetchCompanyOffers));
+  const fetchResults = await Promise.all(companies.map((c) => fetchCompanyOffers(c, whitelist)));
 
   const seen = loadSeenUrls(historyPath, applicationsPath);
 

--- a/tests/scan/ats-workday.test.mjs
+++ b/tests/scan/ats-workday.test.mjs
@@ -213,6 +213,29 @@ test('verifySlug — returns ko on non-Workday URL', async () => {
   assert.match(r.reason, /not a Workday URL/);
 });
 
+test('fetchWorkday — passes searchText in POST body', async () => {
+  const original = globalThis.fetch;
+  let capturedBody = null;
+  globalThis.fetch = async (url, opts) => {
+    capturedBody = JSON.parse(opts.body);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ total: 0, jobPostings: [] }),
+      text: async () => '{}',
+    };
+  };
+  restore = () => {
+    globalThis.fetch = original;
+  };
+
+  await fetchWorkday('https://sanofi.wd3.myworkdayjobs.com/SanofiCareers', 'Sanofi', {
+    searchText: 'Intern Stage Stagiaire',
+  });
+
+  assert.equal(capturedBody.searchText, 'Intern Stage Stagiaire');
+});
+
 test('fetchWorkday — stops pagination when MAX_OFFERS reached', async () => {
   // Create a page of 5 postings (will be the pageSize)
   const fullPage = {

--- a/tests/scan/ats-workday.test.mjs
+++ b/tests/scan/ats-workday.test.mjs
@@ -212,3 +212,36 @@ test('verifySlug — returns ko on non-Workday URL', async () => {
   assert.equal(r.ok, false);
   assert.match(r.reason, /not a Workday URL/);
 });
+
+test('fetchWorkday — stops pagination when MAX_OFFERS reached', async () => {
+  // Create a page of 5 postings (will be the pageSize)
+  const fullPage = {
+    total: 999,
+    jobPostings: Array.from({ length: 5 }, (_, i) => ({
+      title: `Job ${i}`,
+      externalPath: `/job/Job-${i}_R${1000 + i}`,
+      locationsText: 'Paris',
+    })),
+  };
+
+  // Mock: return full pages indefinitely (simulate a huge board)
+  const original = globalThis.fetch;
+  let callCount = 0;
+  globalThis.fetch = async () => {
+    callCount++;
+    return { ok: true, status: 200, json: async () => fullPage, text: async () => '' };
+  };
+  restore = () => {
+    globalThis.fetch = original;
+  };
+
+  const offers = await fetchWorkday('https://big.wd3.myworkdayjobs.com/BigCorp', 'BigCorp', {
+    pageSize: 5,
+    maxOffers: 12,
+  });
+
+  // Should stop at 12 (or after the page that crosses 12), not loop forever
+  assert.ok(offers.length <= 15, `Expected <= 15 offers, got ${offers.length}`);
+  assert.ok(offers.length >= 12, `Expected >= 12 offers, got ${offers.length}`);
+  assert.ok(callCount <= 3, `Expected <= 3 fetch calls, got ${callCount}`);
+});

--- a/tests/scan/scan.test.mjs
+++ b/tests/scan/scan.test.mjs
@@ -259,6 +259,58 @@ test('runScan — skip_required_any bypasses required_any for flagged company', 
   );
 });
 
+test('runScan — passes searchText built from title_filter.positive to Workday fetcher', async () => {
+  let capturedBody = null;
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    if (typeof url === 'string' && url.includes('myworkdayjobs.com')) {
+      capturedBody = JSON.parse(opts.body);
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ total: 0, jobPostings: [] }),
+      text: async () => '{}',
+    };
+  };
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-searchtext-'));
+  fs.writeFileSync(path.join(tmpDir, 'pipeline.md'), '# Pipeline\n');
+  fs.writeFileSync(path.join(tmpDir, 'scan-history.tsv'), '');
+  fs.writeFileSync(path.join(tmpDir, 'filtered-out.tsv'), '');
+  fs.writeFileSync(path.join(tmpDir, 'applications.md'), '');
+
+  try {
+    await runScan({
+      portalsConfig: {
+        tracked_companies: [
+          {
+            name: 'TestCorp',
+            careers_url: 'https://testcorp.wd3.myworkdayjobs.com/TestCareers',
+            enabled: true,
+          },
+        ],
+        title_filter: {
+          positive: ['Intern', 'Stage', '/^stagiaire\\b/i'],
+          negative: [],
+        },
+      },
+      profile: { blacklist_companies: [] },
+      pipelinePath: path.join(tmpDir, 'pipeline.md'),
+      historyPath: path.join(tmpDir, 'scan-history.tsv'),
+      filteredPath: path.join(tmpDir, 'filtered-out.tsv'),
+      applicationsPath: path.join(tmpDir, 'applications.md'),
+      dryRun: true,
+    });
+
+    assert.ok(capturedBody, 'Expected a POST to Workday API');
+    assert.equal(capturedBody.searchText, 'Intern Stage');
+  } finally {
+    globalThis.fetch = original;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test('scan CLI — missing candidate-profile.yml fails with ProfileMissingError', () => {
   const cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-cfg-'));
   const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-data-'));

--- a/tests/scan/scan.test.mjs
+++ b/tests/scan/scan.test.mjs
@@ -311,6 +311,104 @@ test('runScan — passes searchText built from title_filter.positive to Workday 
   }
 });
 
+test('runScan — sends empty searchText when title_filter.positive is empty', async () => {
+  let capturedBody = null;
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    if (typeof url === 'string' && url.includes('myworkdayjobs.com')) {
+      capturedBody = JSON.parse(opts.body);
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ total: 0, jobPostings: [] }),
+      text: async () => '{}',
+    };
+  };
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-empty-'));
+  fs.writeFileSync(path.join(tmpDir, 'pipeline.md'), '# Pipeline\n');
+  fs.writeFileSync(path.join(tmpDir, 'scan-history.tsv'), '');
+  fs.writeFileSync(path.join(tmpDir, 'filtered-out.tsv'), '');
+  fs.writeFileSync(path.join(tmpDir, 'applications.md'), '');
+
+  try {
+    await runScan({
+      portalsConfig: {
+        tracked_companies: [
+          {
+            name: 'TestCorp',
+            careers_url: 'https://testcorp.wd3.myworkdayjobs.com/TestCareers',
+            enabled: true,
+          },
+        ],
+        title_filter: { positive: [], negative: [] },
+      },
+      profile: { blacklist_companies: [] },
+      pipelinePath: path.join(tmpDir, 'pipeline.md'),
+      historyPath: path.join(tmpDir, 'scan-history.tsv'),
+      filteredPath: path.join(tmpDir, 'filtered-out.tsv'),
+      applicationsPath: path.join(tmpDir, 'applications.md'),
+      dryRun: true,
+    });
+
+    assert.ok(capturedBody, 'Expected a POST to Workday API');
+    assert.equal(capturedBody.searchText, '');
+  } finally {
+    globalThis.fetch = original;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('runScan — sends empty searchText when all positive entries are regex', async () => {
+  let capturedBody = null;
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    if (typeof url === 'string' && url.includes('myworkdayjobs.com')) {
+      capturedBody = JSON.parse(opts.body);
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ total: 0, jobPostings: [] }),
+      text: async () => '{}',
+    };
+  };
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-regex-'));
+  fs.writeFileSync(path.join(tmpDir, 'pipeline.md'), '# Pipeline\n');
+  fs.writeFileSync(path.join(tmpDir, 'scan-history.tsv'), '');
+  fs.writeFileSync(path.join(tmpDir, 'filtered-out.tsv'), '');
+  fs.writeFileSync(path.join(tmpDir, 'applications.md'), '');
+
+  try {
+    await runScan({
+      portalsConfig: {
+        tracked_companies: [
+          {
+            name: 'TestCorp',
+            careers_url: 'https://testcorp.wd3.myworkdayjobs.com/TestCareers',
+            enabled: true,
+          },
+        ],
+        title_filter: { positive: ['/^stage\\b/i', '/intern/i'], negative: [] },
+      },
+      profile: { blacklist_companies: [] },
+      pipelinePath: path.join(tmpDir, 'pipeline.md'),
+      historyPath: path.join(tmpDir, 'scan-history.tsv'),
+      filteredPath: path.join(tmpDir, 'filtered-out.tsv'),
+      applicationsPath: path.join(tmpDir, 'applications.md'),
+      dryRun: true,
+    });
+
+    assert.ok(capturedBody, 'Expected a POST to Workday API');
+    assert.equal(capturedBody.searchText, '');
+  } finally {
+    globalThis.fetch = original;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test('scan CLI — missing candidate-profile.yml fails with ProfileMissingError', () => {
   const cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-cfg-'));
   const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-data-'));


### PR DESCRIPTION
## Summary

- **Server-side filtering**: build `searchText` from `title_filter.positive` (simple words only, regex excluded) and send it in the Workday API POST body — reduces returned offers from ~1200 to ~20-50 on large boards
- **Pagination cap**: `MAX_OFFERS = 200` hard limit stops the `while(true)` loop with a `console.warn` when reached — safety net against timeout
- **Edge cases covered**: empty positive list and all-regex positive list both fall back to `searchText = ''`

Fixes #11

## Test plan

- [x] `fetchWorkday` stops at `maxOffers` cap (mock infinite pages)
- [x] `fetchWorkday` passes `searchText` in POST body
- [x] Scanner builds `searchText` from `title_filter.positive`, excludes regex entries
- [x] Empty positive list → `searchText = ''`
- [x] All-regex positive list → `searchText = ''`
- [x] Full test suite passes (287 tests)
- [x] Prettier lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)