### PR TITLE
fix(ci): restore green main — format + test profile target_locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ docs/superpowers/
 
 # Git worktrees
 .worktrees/
+.claude/worktrees/
 
 # Generated files
 dashboard.html

--- a/src/apply/field-classifier.mjs
+++ b/src/apply/field-classifier.mjs
@@ -29,7 +29,11 @@ const RULES = [
     key: 'portfolio_upload',
     when: (f) =>
       f.type === 'file' &&
-      test_norm(/portfolio|work sample|travaux|\bbook\b|writing sample|echantillon/, f.label, f.name),
+      test_norm(
+        /portfolio|work sample|travaux|\bbook\b|writing sample|echantillon/,
+        f.label,
+        f.name
+      ),
   },
   {
     key: 'other_upload',

--- a/tests/scan/progress.test.mjs
+++ b/tests/scan/progress.test.mjs
@@ -54,7 +54,11 @@ test('onProgress is called once per company with correct shape', async () => {
       { name: 'Beta Inc', careers_url: 'https://jobs.ashbyhq.com/beta', enabled: true },
     ],
   };
-  const profile = { min_start_date: '2026-08-24', blacklist_companies: [] };
+  const profile = {
+    min_start_date: '2026-08-24',
+    blacklist_companies: [],
+    target_locations: ['Paris', 'France', 'Remote'],
+  };
 
   const calls = [];
   const onProgress = (info) => calls.push(info);
@@ -105,7 +109,11 @@ test('onProgress reports errors for failing companies', async () => {
       { name: 'Broken Co', careers_url: 'https://jobs.lever.co/broken', enabled: true },
     ],
   };
-  const profile = { min_start_date: '2026-08-24', blacklist_companies: [] };
+  const profile = {
+    min_start_date: '2026-08-24',
+    blacklist_companies: [],
+    target_locations: ['Paris', 'France', 'Remote'],
+  };
 
   const calls = [];
   const onProgress = (info) => calls.push(info);
@@ -145,7 +153,11 @@ test('no onProgress callback does not throw', async () => {
       { name: 'Quiet Co', careers_url: 'https://jobs.lever.co/quiet', enabled: true },
     ],
   };
-  const profile = { min_start_date: '2026-08-24', blacklist_companies: [] };
+  const profile = {
+    min_start_date: '2026-08-24',
+    blacklist_companies: [],
+    target_locations: ['Paris', 'France', 'Remote'],
+  };
 
   const applicationsPath = path.join(tmp, 'applications.md');
   fs.writeFileSync(applicationsPath, '# Apps\n');

--- a/tests/scan/scan.test.mjs
+++ b/tests/scan/scan.test.mjs
@@ -200,7 +200,11 @@ test('runScan — skip_required_any bypasses required_any for flagged company', 
       },
     ],
   };
-  const profile = { min_start_date: '2026-08-24', blacklist_companies: [] };
+  const profile = {
+    min_start_date: '2026-08-24',
+    blacklist_companies: [],
+    target_locations: ['Paris', 'France', 'Remote'],
+  };
 
   const leverJson = [
     {


### PR DESCRIPTION
## Summary

Main CI has been red for every PR today. Three unrelated issues:

1. **Prettier** flags `src/apply/field-classifier.mjs` (long regex line not wrapped since c893260).
2. **Tests** `progress.test.mjs` + `scan.test.mjs` predate 0ea83a8 which added `targetLocations` filtering. With no `profile.target_locations`, the filter defaults to `['Remote']` and every Paris fixture gets dropped, leaving `added.length === 0`.
3. **.gitignore**: `.claude/worktrees/` was not ignored (only `.worktrees/` was), so local worktrees leaked into prettier runs.

## Test plan

- [x] `npm test` — 325 / 325 pass
- [x] `npm run lint` on modified files — clean
- [x] `npm run check:pii` — clean

🤖 Generated with [Claude Code](https://claude.ai/code)