### PR TITLE
refactor(onboard): split /onboard into three chained sub-skills (#20)

### DIFF
--- a/.claude/commands/apply.md
+++ b/.claude/commands/apply.md
@@ -50,7 +50,7 @@ Do not try to apply with the example templates.
      3. Add https://<host>/*.
      4. Refresh the tab and re-run /apply.
 
-   See /onboard step 7.4 for the full list of hosts.
+   See /onboard:setup for the full list of hosts.
    ```
 
    Do not attempt to work around this — stopping on ambiguity is the invariant.

--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -5,310 +5,52 @@ argument-hint: [path-to-cv.pdf]
 
 # /onboard $ARGUMENTS
 
-You are guiding a **first-time user** through the end-to-end setup of `claude-apply`. Your job is to do the maximum for them: extract their CV, build the config files, find target companies, and run `setup.sh`. The user should only have to answer a small number of questions and approve the final company list.
+You are guiding a **first-time user** through the end-to-end setup of `claude-apply`. This command is an **orchestrator**: it detects existing state, then chains three focused sub-skills in sequence. Each sub-skill is also a slash command and can be rerun independently if one phase fails.
 
-**Hard rules for this flow** (these override any instinct to "just do it"):
+| Phase | Sub-skill            | Outputs                                                                    |
+| ----- | -------------------- | -------------------------------------------------------------------------- |
+| 1     | `/onboard:profile`   | `config/cv.md`, `config/cv.<lang>.pdf`, `config/candidate-profile.yml`     |
+| 2     | `/onboard:companies` | `config/portals.yml`                                                       |
+| 3     | `/onboard:setup`     | `node_modules/`, CDP Chrome profile, `chrome-apply` alias, Chrome on :9222 |
 
-- **Never invent PII.** Every field in `config/candidate-profile.yml` must come from the CV or from an explicit user answer. Leave it `null` if neither is available.
-- **Never commit anything.** All files you write live under `config/` or `data/`, both gitignored. Do not `git add` or `git commit`.
-- **Never skip approval of the company list.** Present it, wait for confirmation, then write `portals.yml`.
-- **Stop on ambiguity.** If the CV is unreadable, the PDF path is wrong, WebSearch returns nothing useful, or a user answer is inconsistent — stop and ask.
+**Hard rules** (override any instinct to "just do it"):
+
+- **Never invent PII.** Every field in `config/candidate-profile.yml` must come from the CV or an explicit user answer. `null` is always a valid answer.
+- **Never commit anything.** Everything you write lives under `config/` or `data/`, both gitignored. No `git add`, no `git commit`.
+- **Never write `portals.yml` without explicit user approval** of the final company list.
+- **Stop on ambiguity.** Unreadable CV, contradictory answers, WebSearch returns nothing useful, login wall on a verified URL → stop and ask.
+
+The sub-skills contain the detailed hard rules for their own phase. You must follow them fully.
 
 ## 0. Detect existing state
 
-1. Check whether `config/candidate-profile.yml` already exists. If yes, ask the user: "An existing profile was found. Do you want to (a) **abort** and keep it, (b) **rerun onboarding and overwrite** it, or (c) **only regenerate portals.yml**?" Act accordingly.
-2. Check whether `node_modules/` exists (`setup.sh` in step 4 will skip the install if present).
-3. Check whether the `chrome-apply` alias is already in `~/.zshrc` or `~/.bashrc` (`setup.sh` in step 4 will skip the rc append if present).
+1. If `config/candidate-profile.yml` already exists, ask the user: "An existing profile was found. Do you want to (a) **abort** and keep it, (b) **rerun onboarding and overwrite** it, or (c) **only regenerate `portals.yml`**?"
+   - **(a) abort** → stop here.
+   - **(b) rerun** → run all three phases below.
+   - **(c) portals only** → skip phase 1, run phase 2, then skip phase 3 (Chrome is already set up from a previous run). If `node_modules/` is missing, run `bash scripts/setup.sh --yes --no-clone-chrome-profile` first.
+2. If `config/candidate-profile.yml` does **not** exist, run all three phases.
 
-## 1. Ask for the CV
+## 1. Phase 1 — profile (`/onboard:profile`)
 
-If `$ARGUMENTS` is a path to a PDF file that exists, use it. Otherwise, ask the user:
+Follow the instructions in `.claude/commands/onboard/profile.md` end-to-end. Pass `$ARGUMENTS` through as the CV path if the user provided one.
 
-> "Please provide the absolute path to your CV PDF (or drop the file in the conversation). I'll extract everything I can from it."
+Phase 1 writes `config/cv.md`, `config/cv.<lang>.pdf`, `config/candidate-profile.yml`, and `data/.onboard-state.json`. Do not proceed until the profile validates against `validateProfile`.
 
-Once you have the path:
+## 2. Phase 2 — companies (`/onboard:companies`)
 
-1. Verify the file exists and is a PDF (`file <path>` via Bash, or check the extension + first bytes).
-2. Read it with the `Read` tool (Claude Code reads PDFs natively).
-3. Extract as much as possible:
-   - **Identity**: first name, last name, email, phone, LinkedIn URL, GitHub URL, personal website.
-   - **Address**: city (country only if explicit on the CV).
-   - **Education**: each entry with school, degree, field, start, end, graduation year, 1-line description.
-   - **Experiences**: each entry with company, title, start, end, description (keep 3–5 lines max per entry).
-   - **Languages**: list with `{code, level}` — levels in CEFR (A1…C2) or `native`.
-4. If any of these are genuinely missing from the CV, mark them for the question block in step 3.
+Follow the instructions in `.claude/commands/onboard/companies.md` end-to-end.
 
-## 2. Write `config/cv.md`
+Phase 2 reads `data/.onboard-state.json` for the user's job-type and domain answers, builds `title_filter`, runs WebSearch + `verifyCompany`, gets the user's approval on the final list, and writes `config/portals.yml`. Do not proceed until the file is written.
 
-Create `config/cv.md` as a clean markdown version of the CV. This file is read by `/score` and the cover-letter generator — it should be faithful to the PDF but flow as markdown (no tables, use headers `##` for sections). Do not paraphrase or embellish.
+## 3. Phase 3 — setup (`/onboard:setup`)
 
-Copy the PDF itself to `config/cv.<lang>.pdf` (detect language from the CV content — usually `fr` or `en`). Use this path in `candidate-profile.yml`.
+Follow the instructions in `.claude/commands/onboard/setup.md` end-to-end.
 
-## 3. Ask everything missing — in ONE block
-
-Use **`AskUserQuestion`** once with all the fields you could not extract, grouped logically. Typical questions:
-
-**Job search**
-
-- **Job type**: internship / apprenticeship / entry-level / mid-level / senior / other
-- **Target start date**: (ISO date)
-- **Duration** (if internship/apprenticeship): months
-- **Target role / domain keywords**: free text — this drives both `title_filter` (step 5) and company discovery (step 6). Example: "AI/ML engineering", "backend Python", "devtools", "data engineering".
-
-**Location & remote**
-
-- **Locations**: cities or regions, comma-separated
-- **Remote preference**: onsite / hybrid / remote
-
-**Admin**
-
-- **Date of birth**: (some forms require it; may skip if user refuses)
-- **Nationality**
-- **Work authorization**: free text (e.g. "EU citizen — no sponsorship needed")
-- **Requires visa sponsorship**: yes / no
-
-**Setup choices**
-
-- **Clone your existing Chrome profile** into the dedicated CDP profile (cookies, extensions)? yes / no
-- **Cover letter auto-generation**: enable now? yes / no (default no)
-
-Leave anything the user declines to answer as `null`. Do **not** loop back with follow-up questions unless the user's answer is internally inconsistent (e.g. "internship" + "senior level").
-
-## 4. Run `setup.sh` with the right flags
-
-**This step must happen before profile validation and company verification** — both rely on `node_modules` (for `js-yaml` in the profile schema, and for `node src/scan/index.mjs`). Running `setup.sh` here also sets up the Chrome CDP profile and shell alias while we already have the user's answers from step 3.
-
-Based on the user's Chrome-profile clone answer, run one of:
-
-```bash
-bash scripts/setup.sh --yes --clone-chrome-profile       # if user said yes
-bash scripts/setup.sh --yes --no-clone-chrome-profile    # if user said no
-```
-
-This will: install npm deps if missing (`npm ci` / `npm install`), create the CDP profile (empty or cloned), append the `chrome-apply` alias to the user's shell rc (timestamped backup), and copy any missing templates into `config/` (harmless — you will overwrite `candidate-profile.yml` and `portals.yml` in the next steps; `cv.md` already exists from step 2 so it is skipped).
-
-If the user is in an unusual shell setup, add `--no-rc` and print the alias to them manually.
-
-## 5. Build `config/candidate-profile.yml`
-
-Assemble one **flat** YAML file — no nested `identity:` / `address:` / `availability:` subtrees. Every field must appear at the top level. The schema is defined in `src/lib/candidate-profile.schema.mjs` — read it to see the exact required and optional keys.
-
-Sources:
-
-- Fields extracted from the CV (step 1): `first_name`, `last_name`, `email`, `phone`, `linkedin_url`, `github_url`, `city`, `country`, `school`, `degree`, `graduation_year`, `education[]`, `experiences[]`, `languages[]`.
-- Answers from the question block (step 3): `availability_start`, `internship_duration_months`, `work_authorization`, `requires_sponsorship`, `auto_apply_min_score`, optionally `blacklist_companies` and `min_start_date`.
-- CV PDF paths from step 2: `cv_fr_path` and `cv_en_path` (absolute paths inside `config/`).
-- EEO fields default to `null` unless the user explicitly provided a value: `gender`, `ethnicity`, `veteran_status`, `disability_status`.
-
-Do NOT generate `config/profile.yml` or `config/profile-condensed.md`. Those files are no longer read by any command — `/score` reads `config/cv.md` directly.
-
-Validate the file by importing `validateProfile` from `src/lib/candidate-profile.schema.mjs` and running it on the parsed YAML. If `ok: false`, show the errors to the user, ask the missing/invalid fields, and retry — do not write an invalid profile.
-
-Also build **`title_filter`** for `portals.yml` from the job type answer. The scanner expects three keys — `positive` (title must contain at least one), `negative` (title must not contain any), and the optional `required_any` (secondary filter, applied on top):
-
-| Job type       | `positive` keywords                                                                            |
-| -------------- | ---------------------------------------------------------------------------------------------- |
-| internship     | `Intern`, `Interns`, `Internship`, `Internships`, `Stage`, `Stages`, `Stagiaire`, `Stagiaires` |
-| apprenticeship | `Apprentice`, `Apprenticeship`, `Alternance`, `Alternant`, `Alternante`                        |
-| entry-level    | `Junior`, `Entry`, `Graduate`, `New Grad`                                                      |
-| mid-level      | (leave empty — let the domain drive the filter via `required_any`)                             |
-| senior         | `Senior`, `Staff`, `Principal`, `Lead`                                                         |
-
-If the user gave specific role/domain keywords in step 3 (e.g. "Machine Learning", "Backend"), put them in `required_any` so offers must match both the job type _and_ the domain. Keep `negative: []` unless the user explicitly ruled something out (e.g. senior user excluding `Intern`).
-
-## 6. Discover ~30 target companies
-
-This is the most fragile step. Read it twice before starting.
-
-**Constraint**: `src/scan/` supports **Lever**, **Greenhouse**, **Ashby**, and **Workday**. Every company you add to `portals.yml` must have a `careers_url` matching one of these hosts:
-
-- `https://jobs.lever.co/<slug>`
-- `https://boards.greenhouse.io/<slug>` or `https://job-boards.greenhouse.io/<slug>`
-- `https://jobs.ashbyhq.com/<slug>`
-- `https://<tenant>.wd<N>.myworkdayjobs.com/<slug>` (use the slug registry — see 5.1b below)
-
-### 5.1 Build a candidate list via WebSearch
-
-Use the `WebSearch` tool (load it via `ToolSearch` if not already loaded). Run queries targeted at the user's domain + locations, crossed with the ATS host:
-
-```
-site:jobs.lever.co "<domain keyword>" <location>
-site:boards.greenhouse.io "<domain keyword>" <location>
-site:jobs.ashbyhq.com "<domain keyword>" <location>
-site:myworkdayjobs.com "<domain keyword>" <location>
-```
-
-Run **at least 8 queries** (2 per ATS, varying the keyword/location). Collect unique `{company, careers_url}` pairs from the results. Target ~50 candidates at this stage to leave room for verification dropouts.
-
-If the domain is very niche and WebSearch returns fewer than 15 candidates total, ask the user for hints ("Any companies you already have in mind?") and add them.
-
-### 5.1b Workday slug registry lookup
-
-For companies identified as potential Workday tenants (e.g. large corporates not on Lever/Greenhouse/Ashby), check the local slug registry before giving up:
-
-```bash
-node -e "
-  import { loadSlugRegistry, lookupWorkdaySlug } from './src/scan/ats/workday-slugs.mjs';
-  const reg = loadSlugRegistry('data/known-workday-slugs.json');
-  const r = lookupWorkdaySlug(reg, 'Airbus');
-  if (r) console.log('https://' + r.tenant + '.' + r.pod + '.myworkdayjobs.com/' + r.slug);
-  else console.log('NOT_FOUND');
-"
-```
-
-If the registry returns a match, construct the full URL and add it to the candidate list for verification in step 5.2. If the registry file does not exist (`data/known-workday-slugs.json`), skip this step silently — the user has not set up a registry yet.
-
-### 5.2 Verify each URL via the ATS API
-
-`curl -sfI` on the public careers page is **not** authoritative — Ashby for example returns `200` on the careers HTML even when the JSON board does not exist (e.g. `dust-tt`). The only honest check is to call the same JSON endpoint `/scan` will use.
-
-For each candidate company, call `verifyCompany(careers_url)` from `src/scan/ats-detect.mjs`. Run it inline via `node -e`:
-
-```bash
-node -e "
-  import('./src/scan/ats-detect.mjs').then(async m => {
-    const r = await m.verifyCompany('https://jobs.lever.co/mistral');
-    console.log(JSON.stringify(r));
-  });
-"
-```
-
-Response shape:
-
-- `{ ok: true, count: N }` → slug is live, `N` offers currently on the board. Keep the company. If `count` is 0, flag it for the user to sanity-check ("board exists but empty — check slug spelling").
-- `{ ok: false, status, reason }` → drop the company. If you get a transient failure (5xx, network error), retry **once** with a 2 s backoff before dropping.
-
-Add a 100 ms delay between verifications to be polite to the APIs (30 companies × 100 ms ≈ 3 s extra).
-
-Also drop any candidate that is a clear duplicate (same org, multiple slugs).
-
-### 5.3 Trim to ~30 and present for approval
-
-Keep the top ~30 by relevance to the user's domain (your judgement). Present them as a compact table to the user:
-
-```
-Company           ATS          Careers URL
-──────────────────────────────────────────────
-Mistral AI        lever        https://jobs.lever.co/mistral
-Anthropic         lever        https://jobs.lever.co/Anthropic
-...
-```
-
-Then ask: **"Here are 30 companies I found. Should I write them to `config/portals.yml`, or do you want me to remove/add any?"**
-
-Apply the user's edits (remove X, add Y with URL Z, etc.) and loop until they approve. Only then write `config/portals.yml` with:
-
-- `tracked_companies:` — the approved list, each entry `{ name, careers_url, enabled: true }`
-- `title_filter:` — built in step 5 (`positive`, `negative`, optional `required_any`)
-
-## 7. Launch Chrome and finalize
-
-You can automate almost everything that's left. The user should only have to click "Add to Chrome" on the extension page (the Chrome Web Store does not expose a programmatic install API).
-
-### 7.1 Check if CDP is already up
-
-Probe the debug port:
-
-```bash
-curl -sf http://127.0.0.1:9222/json/version
-```
-
-- **If it responds with JSON**: Chrome is already running in CDP mode (user launched `chrome-apply` before). Skip to 7.3.
-- **Otherwise**: proceed to 7.2.
-
-### 7.2 Launch Chrome in background
-
-You do **not** need `source ~/.bashrc` — the `chrome-apply` alias is a convenience for the user's terminal. You can invoke the real command directly. Detect the Chrome binary and CDP profile path (same logic as `scripts/setup.sh`):
-
-- **Linux**: binary = first of `google-chrome`, `google-chrome-stable`, `chromium`, `chromium-browser`; profile = `$HOME/.config/google-chrome-claude-apply`.
-- **macOS**: binary = `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`; profile = `$HOME/Library/Application Support/Google/Chrome-claude-apply`.
-
-Launch Chrome with the CDP flag and open the extension page directly. **Use `run_in_background: true`** on the Bash tool — Chrome is a long-running GUI process and you must not block on it:
-
-```bash
-"<chrome_bin>" \
-  --user-data-dir="<cdp_profile>" \
-  --remote-debugging-port=9222 \
-  "https://chromewebstore.google.com/search/claude-in-chrome"
-```
-
-Then poll the CDP port for up to 8 seconds (4 probes of 2s), waiting for it to come up:
-
-```bash
-for i in 1 2 3 4; do
-  sleep 2
-  if curl -sf http://127.0.0.1:9222/json/version > /dev/null; then
-    echo "CDP up after ${i} probes"
-    exit 0
-  fi
-done
-exit 1
-```
-
-- **If CDP comes up**: great, continue to 7.3.
-- **If not** (8s elapsed): Chrome may have failed to start. Check the background task output for errors. Fall back to telling the user to run `chrome-apply` manually and print the summary from 7.3 anyway.
-
-### 7.4 Grant extension host permissions
-
-The `claude-in-chrome` extension requires per-host permission for every ATS domain it touches. Chrome does **not** expose a programmatic grant — the user must click. Without this, `/apply` fails on the first `find` call with "Extension manifest must request permission to access the respective host".
-
-Derive the list of hosts from the single source of truth — don't hard-code it:
-
-```bash
-node -e "
-  import('./src/scan/ats-detect.mjs').then(m => {
-    for (const h of m.getSupportedHosts()) console.log('  - ' + h);
-  });
-"
-```
-
-Print this exact instruction block to the user, substituting the host list from the command above:
-
-```
-After you click "Add to Chrome" and approve the install:
-
-  1. Click the puzzle-piece icon in Chrome's toolbar.
-  2. Find "claude-in-chrome" → three-dot menu → "This can read and
-     change site data" → "On specific sites".
-  3. Add each of these hosts (one by one):
-       <host list from getSupportedHosts() above>
-  4. If prompted during install, also allow
-     https://chromewebstore.google.com/*.
-```
-
-Do **not** continue past 7.3 until the user confirms the permissions are granted. If you skip this, `/apply` will fail the first time it is run.
-
-### 7.3 Final summary
-
-Print a clean summary. The only manual step left is clicking "Add to Chrome" on the extension page that should now be open:
-
-```
-✅ Onboarding complete.
-
-Files written:
-  • config/cv.md
-  • config/cv.<lang>.pdf
-  • config/candidate-profile.yml
-  • config/portals.yml  (30 companies)
-
-Chrome launched in CDP mode (port 9222) with the claude-in-chrome
-extension page open.
-
-One last manual step:
-  → Click "Add to Chrome" on the page that just opened,
-    then confirm the install dialog.
-
-Then you can run:
-  /scan                # fetch new offers into data/pipeline.md
-  /score <url>         # LLM-evaluate an offer
-  /apply <url>         # automated form fill + submit
-```
-
-**Do not run `/scan` or `/apply` yourself** — the user still needs to install the extension manually. Your onboarding stops here.
+Phase 3 runs `scripts/setup.sh`, launches Chrome in CDP mode, and prints the extension install + host permission instructions. It ends with the final summary — do **not** run `/scan` or `/apply` yourself afterwards.
 
 ## Absolute rules (recap)
 
-- **One question block** — never pepper the user with follow-ups.
+- **One question block per phase** — never pepper the user with follow-ups.
 - **Approve before writing `portals.yml`** — always.
 - **Validate the profile** before writing it — never write an invalid YAML.
 - **Never guess PII** — `null` is always a valid answer.

--- a/.claude/commands/onboard/companies.md
+++ b/.claude/commands/onboard/companies.md
@@ -1,0 +1,116 @@
+---
+description: Onboarding phase 2 — discover ~30 target companies via WebSearch, verify their ATS boards, get user approval, and write config/portals.yml
+---
+
+# /onboard:companies
+
+You are running **phase 2 of onboarding**: build `config/portals.yml`. At the end, the file contains ~30 verified companies (`tracked_companies`) plus the `title_filter` derived from the user's job-type and domain answers.
+
+**Hard rules**
+
+- **Never write `portals.yml` without explicit user approval** of the final list.
+- **Only keep companies whose ATS board is live** — verified via `verifyCompany`, not via `curl -I` on the careers HTML.
+- **Stop on ambiguity.** WebSearch returns nothing useful, the user's domain keywords are unclear, a slug redirects to a login wall → stop and ask.
+
+This skill assumes `config/candidate-profile.yml` already exists (written by `/onboard:profile`). If not, tell the user to run `/onboard:profile` first.
+
+## 1. Load inputs
+
+Read `data/.onboard-state.json` (written by `/onboard:profile`) to get `job_type`, `target_role`, `locations`. If the file is missing — the user is running this skill standalone — ask once for these three fields via `AskUserQuestion`.
+
+## 2. Build `title_filter`
+
+The scanner expects three keys — `positive` (title must contain at least one), `negative` (title must not contain any), and optional `required_any` (secondary filter on top).
+
+| Job type       | `positive` keywords                                                                            |
+| -------------- | ---------------------------------------------------------------------------------------------- |
+| internship     | `Intern`, `Interns`, `Internship`, `Internships`, `Stage`, `Stages`, `Stagiaire`, `Stagiaires` |
+| apprenticeship | `Apprentice`, `Apprenticeship`, `Alternance`, `Alternant`, `Alternante`                        |
+| entry-level    | `Junior`, `Entry`, `Graduate`, `New Grad`                                                      |
+| mid-level      | (leave empty — let the domain drive the filter via `required_any`)                             |
+| senior         | `Senior`, `Staff`, `Principal`, `Lead`                                                         |
+
+Put domain keywords from `target_role` into `required_any` so offers must match both the job type _and_ the domain. Keep `negative: []` unless the user explicitly ruled something out.
+
+## 3. Discover candidates via WebSearch
+
+`src/scan/` supports **Lever**, **Greenhouse**, **Ashby**, and **Workday**. Every `careers_url` must match one of these hosts:
+
+- `https://jobs.lever.co/<slug>`
+- `https://boards.greenhouse.io/<slug>` or `https://job-boards.greenhouse.io/<slug>`
+- `https://jobs.ashbyhq.com/<slug>`
+- `https://<tenant>.wd<N>.myworkdayjobs.com/<slug>`
+
+Use the `WebSearch` tool (load it via `ToolSearch` if not yet available). Run queries crossing the user's domain + locations with each ATS host:
+
+```
+site:jobs.lever.co "<domain keyword>" <location>
+site:boards.greenhouse.io "<domain keyword>" <location>
+site:jobs.ashbyhq.com "<domain keyword>" <location>
+site:myworkdayjobs.com "<domain keyword>" <location>
+```
+
+Run **at least 8 queries** (2 per ATS, varying the keyword/location). Collect unique `{company, careers_url}` pairs. Target ~50 candidates at this stage to leave room for verification dropouts.
+
+If WebSearch returns fewer than 15 candidates total, ask the user for hints ("Any companies you already have in mind?") and add them.
+
+## 4. Workday slug registry lookup
+
+For candidates that are likely Workday tenants (large corporates not on Lever/Greenhouse/Ashby), check the local registry before giving up:
+
+```bash
+node -e "
+  import { loadSlugRegistry, lookupWorkdaySlug } from './src/scan/ats/workday-slugs.mjs';
+  const reg = loadSlugRegistry('data/known-workday-slugs.json');
+  const r = lookupWorkdaySlug(reg, 'Airbus');
+  if (r) console.log('https://' + r.tenant + '.' + r.pod + '.myworkdayjobs.com/' + r.slug);
+  else console.log('NOT_FOUND');
+"
+```
+
+If the registry file does not exist (`data/known-workday-slugs.json`), skip this step silently.
+
+## 5. Verify each URL via the ATS API
+
+`curl -sfI` on the public careers page is **not** authoritative — Ashby for example returns `200` on the careers HTML even when the JSON board does not exist (e.g. `dust-tt`). Call the same JSON endpoint `/scan` will use, via `verifyCompany` from `src/scan/ats-detect.mjs`:
+
+```bash
+node -e "
+  import('./src/scan/ats-detect.mjs').then(async m => {
+    const r = await m.verifyCompany('https://jobs.lever.co/mistral');
+    console.log(JSON.stringify(r));
+  });
+"
+```
+
+Response shape:
+
+- `{ ok: true, count: N }` → slug is live. Keep the company. If `count` is 0, flag it for sanity-check.
+- `{ ok: false, status, reason }` → drop. On transient failures (5xx, network error), retry **once** after a 2 s backoff before dropping.
+
+Add a 100 ms delay between verifications to be polite to the APIs.
+
+Drop any candidate that is a clear duplicate (same org, multiple slugs).
+
+## 6. Trim to ~30 and get approval
+
+Keep the top ~30 by relevance to the user's domain. Present a compact table:
+
+```
+Company           ATS          Careers URL
+──────────────────────────────────────────────
+Mistral AI        lever        https://jobs.lever.co/mistral
+Anthropic         lever        https://jobs.lever.co/Anthropic
+...
+```
+
+Ask: **"Here are 30 companies I found. Should I write them to `config/portals.yml`, or do you want me to remove/add any?"**
+
+Apply the user's edits (remove X, add Y with URL Z) and loop until they approve. Only then write `config/portals.yml`:
+
+- `tracked_companies:` — the approved list, each entry `{ name, careers_url, enabled: true }`
+- `title_filter:` — built in step 2 (`positive`, `negative`, optional `required_any`)
+
+## 7. Done
+
+Report briefly: `config/portals.yml` written with N companies and the computed title_filter. If called from the `/onboard` orchestrator, control returns there. Otherwise tell the user to run `/onboard:setup` next.

--- a/.claude/commands/onboard/profile.md
+++ b/.claude/commands/onboard/profile.md
@@ -1,0 +1,109 @@
+---
+description: Onboarding phase 1 — extract CV, ask the user the missing fields, and write config/cv.md + config/candidate-profile.yml
+argument-hint: [path-to-cv.pdf]
+---
+
+# /onboard:profile $ARGUMENTS
+
+You are running **phase 1 of onboarding**: build the candidate profile. At the end of this skill, `config/cv.md`, `config/cv.<lang>.pdf`, and `config/candidate-profile.yml` exist and validate against the schema.
+
+**Hard rules**
+
+- **Never invent PII.** Every field must come from the CV or an explicit user answer. Unknown → `null`.
+- **Never `git commit`.** Everything you write is under `config/` (gitignored).
+- **Stop on ambiguity.** Unreadable PDF, contradictory answers, wrong path → stop and ask.
+
+This skill can be run standalone or from the `/onboard` orchestrator. It is idempotent — rerunning overwrites.
+
+## 1. Locate the CV PDF
+
+If `$ARGUMENTS` is a path to an existing PDF, use it. Otherwise ask:
+
+> "Please provide the absolute path to your CV PDF (or drop the file in the conversation). I'll extract everything I can from it."
+
+Verify the file exists and is a PDF, then read it with the `Read` tool (Claude Code reads PDFs natively). Extract:
+
+- **Identity**: first name, last name, email, phone, LinkedIn URL, GitHub URL, personal website.
+- **Address**: city (country only if explicit).
+- **Education**: each entry with school, degree, field, start, end, graduation year, 1-line description.
+- **Experiences**: each entry with company, title, start, end, description (3–5 lines max).
+- **Languages**: list with `{code, level}` — levels in CEFR (A1…C2) or `native`.
+
+Anything genuinely missing becomes a question in step 3.
+
+## 2. Write `config/cv.md` and copy the PDF
+
+Create `config/cv.md` as a clean markdown version of the CV. This file is read by `/score` and the cover-letter generator — faithful to the PDF, flowing markdown (no tables, `##` for sections). Do not paraphrase or embellish.
+
+Detect the language from the CV content (usually `fr` or `en`) and copy the source PDF to `config/cv.<lang>.pdf`. Use this absolute path as `cv_fr_path` or `cv_en_path` later.
+
+## 3. One question block
+
+Use **`AskUserQuestion`** once with everything you could not extract, grouped logically. Do not loop back with follow-ups unless the user's answer is internally inconsistent.
+
+**Job search**
+
+- **Job type**: internship / apprenticeship / entry-level / mid-level / senior / other
+- **Target start date** (ISO date)
+- **Duration** (if internship/apprenticeship): months
+- **Target role / domain keywords**: free text — drives both `title_filter` and company discovery (phase 2). Example: "AI/ML engineering", "backend Python", "devtools".
+
+**Location & remote**
+
+- **Locations**: cities or regions, comma-separated
+- **Remote preference**: onsite / hybrid / remote
+
+**Admin**
+
+- **Date of birth** (may skip if user refuses)
+- **Nationality**
+- **Work authorization** — free text (e.g. "EU citizen — no sponsorship needed")
+- **Requires visa sponsorship**: yes / no
+
+**Setup choices** (used later by `/onboard:setup`)
+
+- **Clone your existing Chrome profile** into the CDP profile? yes / no
+- **Cover letter auto-generation**: enable now? yes / no (default no)
+
+Anything the user declines → `null`.
+
+## 4. Ensure npm dependencies are installed
+
+The schema validator and the YAML writer need `node_modules`. Install lightly if missing — `/onboard:setup` runs the full `scripts/setup.sh` later and will skip the install since it is idempotent:
+
+```bash
+[[ -d node_modules ]] || npm install
+```
+
+## 5. Write `config/candidate-profile.yml`
+
+Assemble one **flat** YAML file — no nested `identity:` / `address:` / `availability:` subtrees. Every field at the top level. The schema is defined in `src/lib/candidate-profile.schema.mjs` — read it for the exact required and optional keys.
+
+Sources:
+
+- Extracted from the CV: `first_name`, `last_name`, `email`, `phone`, `linkedin_url`, `github_url`, `city`, `country`, `school`, `degree`, `graduation_year`, `education[]`, `experiences[]`, `languages[]`.
+- From the question block: `availability_start`, `internship_duration_months`, `work_authorization`, `requires_sponsorship`, `auto_apply_min_score`, optionally `blacklist_companies` and `min_start_date`.
+- From step 2: `cv_fr_path` and `cv_en_path`.
+- EEO fields default to `null` unless explicitly provided: `gender`, `ethnicity`, `veteran_status`, `disability_status`.
+
+Do NOT write `config/profile.yml` or `config/profile-condensed.md` — those files are no longer read by any command (`/score` reads `config/cv.md` directly).
+
+Validate before writing by importing `validateProfile` from `src/lib/candidate-profile.schema.mjs` and running it on the in-memory object. If `ok: false`, show the errors, ask for the missing/invalid fields, retry — never write an invalid profile.
+
+## 6. Persist onboarding state for the next phase
+
+Write the job-search answers to `data/.onboard-state.json` so `/onboard:companies` and `/onboard:setup` can pick them up without re-asking. `data/` is gitignored.
+
+```json
+{
+  "job_type": "internship|apprenticeship|entry-level|mid-level|senior|other",
+  "target_role": "free-text domain keywords",
+  "locations": ["Paris", "Remote EU"],
+  "remote_preference": "onsite|hybrid|remote",
+  "clone_chrome_profile": true
+}
+```
+
+## 7. Done
+
+Report briefly: `config/cv.md`, `config/cv.<lang>.pdf`, `config/candidate-profile.yml`, `data/.onboard-state.json` written and validated. If you were called from the `/onboard` orchestrator, control returns there. Otherwise tell the user to run `/onboard:companies` next.

--- a/.claude/commands/onboard/setup.md
+++ b/.claude/commands/onboard/setup.md
@@ -1,0 +1,135 @@
+---
+description: Onboarding phase 3 — run scripts/setup.sh, launch Chrome in CDP mode, and guide the user through the extension install and host permissions
+---
+
+# /onboard:setup
+
+You are running **phase 3 of onboarding**: finalize the environment. At the end, `node_modules/` is installed, the CDP Chrome profile exists, the `chrome-apply` alias is in the user's shell rc, Chrome is running on port 9222, and the user has been told exactly which hosts to grant to the `claude-in-chrome` extension.
+
+**Hard rules**
+
+- **Do not run `/scan` or `/apply`** yourself at the end — the user still needs to install the extension manually.
+- **Do not proceed past the extension instructions** until the user confirms the permissions are granted.
+- **Use `run_in_background: true`** when launching Chrome. Chrome is a long-running GUI process and must not block the tool call.
+
+This skill is safe to rerun — `setup.sh` is idempotent.
+
+## 1. Load the clone-profile answer
+
+Read `data/.onboard-state.json` (written by `/onboard:profile`) to get `clone_chrome_profile`. If the file is missing or the field is absent, ask the user once:
+
+> "Clone your existing Chrome profile (cookies, extensions) into the dedicated CDP profile? yes / no"
+
+## 2. Run `scripts/setup.sh`
+
+Run one of:
+
+```bash
+bash scripts/setup.sh --yes --clone-chrome-profile       # if user said yes
+bash scripts/setup.sh --yes --no-clone-chrome-profile    # if user said no
+```
+
+This will: install npm deps if missing (`npm ci` / `npm install`), create the CDP Chrome profile (empty or cloned), append the `chrome-apply` alias to the user's shell rc (with a timestamped backup), and copy any missing templates into `config/` (harmless — `cv.md`, `candidate-profile.yml`, and `portals.yml` already exist from the earlier phases and are skipped).
+
+If the user is in an unusual shell setup, add `--no-rc` and print the alias to them manually. Run `bash scripts/setup.sh --help` for all flags.
+
+## 3. Check if CDP is already up
+
+Probe the debug port:
+
+```bash
+curl -sf http://127.0.0.1:9222/json/version
+```
+
+- **Responds with JSON** → Chrome is already in CDP mode (user launched `chrome-apply` before). Skip to step 5.
+- **No response** → continue to step 4.
+
+## 4. Launch Chrome in CDP mode (background)
+
+You do **not** need `source ~/.bashrc`. Detect the Chrome binary and profile path the same way `scripts/setup.sh` does:
+
+- **Linux**: binary = first of `google-chrome`, `google-chrome-stable`, `chromium`, `chromium-browser`; profile = `$HOME/.config/google-chrome-claude-apply`.
+- **macOS**: binary = `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`; profile = `$HOME/Library/Application Support/Google/Chrome-claude-apply`.
+
+Launch Chrome with the CDP flag and open the extension page directly. **Use `run_in_background: true`**:
+
+```bash
+"<chrome_bin>" \
+  --user-data-dir="<cdp_profile>" \
+  --remote-debugging-port=9222 \
+  "https://chromewebstore.google.com/search/claude-in-chrome"
+```
+
+Poll the CDP port for up to 8 seconds (4 probes × 2 s):
+
+```bash
+for i in 1 2 3 4; do
+  sleep 2
+  if curl -sf http://127.0.0.1:9222/json/version > /dev/null; then
+    echo "CDP up after ${i} probes"
+    exit 0
+  fi
+done
+exit 1
+```
+
+- **CDP up** → continue to step 5.
+- **Not up after 8 s** → inspect the background task output, tell the user to run `chrome-apply` manually, and still print the summary from step 6.
+
+## 5. Print the extension permission instructions
+
+The `claude-in-chrome` extension needs per-host permission for every ATS domain. Chrome does **not** expose a programmatic grant — the user must click. Without this, `/apply` fails on the first `find` call with _"Extension manifest must request permission to access the respective host"_.
+
+Derive the list from the single source of truth — do not hard-code it:
+
+```bash
+node -e "
+  import('./src/scan/ats-detect.mjs').then(m => {
+    for (const h of m.getSupportedHosts()) console.log('  - ' + h);
+  });
+"
+```
+
+Print this exact instruction block, substituting the host list:
+
+```
+After you click "Add to Chrome" and approve the install:
+
+  1. Click the puzzle-piece icon in Chrome's toolbar.
+  2. Find "claude-in-chrome" → three-dot menu → "This can read and
+     change site data" → "On specific sites".
+  3. Add each of these hosts (one by one):
+       <host list from getSupportedHosts() above>
+  4. If prompted during install, also allow
+     https://chromewebstore.google.com/*.
+```
+
+**Wait for the user to confirm permissions are granted** before continuing.
+
+## 6. Final summary
+
+Print a clean summary:
+
+```
+✅ Onboarding complete.
+
+Files written:
+  • config/cv.md
+  • config/cv.<lang>.pdf
+  • config/candidate-profile.yml
+  • config/portals.yml  (N companies)
+
+Chrome launched in CDP mode (port 9222) with the claude-in-chrome
+extension page open.
+
+One last manual step:
+  → Click "Add to Chrome" on the page that just opened,
+    then confirm the install dialog.
+
+Then you can run:
+  /scan                # fetch new offers into data/pipeline.md
+  /score <url>         # LLM-evaluate an offer
+  /apply <url>         # automated form fill + submit
+```
+
+**Do not run `/scan` or `/apply` yourself** — the user still needs to install the extension manually. Your onboarding stops here.


### PR DESCRIPTION
## Summary

Closes #20. Splits the 317-line `/onboard` command into a short orchestrator plus three focused sub-skills, each runnable independently when a phase fails.

- `/onboard:profile` — CV extraction + question block + `config/candidate-profile.yml`
- `/onboard:companies` — WebSearch + `verifyCompany` + approval + `config/portals.yml`
- `/onboard:setup` — `scripts/setup.sh` + Chrome CDP + extension host permissions

State travels between phases via `data/.onboard-state.json` (gitignored). The orchestrator keeps the existing state-detection guard (abort / rerun / portals-only) and the top-level hard rules.

Also fixes the inconsistent step numbering the issue flagged (5.1/5.2/5.3 inside step 6, and 7.1/7.2/7.4/7.3) and updates the stale `See /onboard step 7.4` reference in `.claude/commands/apply.md` to `See /onboard:setup`.

## Test plan

- [x] `npm test` — 325/325
- [x] `npm run lint` — Prettier clean
- [x] `npm run check:pii` — no PII
- [ ] Manual: trigger `/onboard:profile` standalone on a fresh checkout
- [ ] Manual: trigger `/onboard:companies` with an existing profile
- [ ] Manual: trigger `/onboard:setup` with both existing and missing CDP state

🤖 Generated with [Claude Code](https://claude.com/claude-code)