### PR TITLE
fix(scan): Workday searchText AND semantics (#34)

### DIFF
--- a/src/scan/ats/workday.mjs
+++ b/src/scan/ats/workday.mjs
@@ -69,30 +69,44 @@ export async function fetchWorkday(url, companyName, opts = {}) {
   const parts = parseWorkdayUrl(url);
   const pageSize = opts.pageSize ?? DEFAULT_PAGE_SIZE;
   const maxOffers = opts.maxOffers ?? DEFAULT_MAX_OFFERS;
-  const searchText = opts.searchText ?? '';
-  const offers = [];
-  let offset = 0;
-  while (true) {
-    const page = await postJobs(parts, { limit: pageSize, offset, searchText });
-    const postings = Array.isArray(page?.jobPostings) ? page.jobPostings : [];
-    for (const p of postings) {
-      offers.push({
-        url: buildJobUrl(parts, p.externalPath || ''),
-        title: p.title || '',
-        company: companyName,
-        location: p.locationsText || '',
-        body: '',
-        platform: 'workday',
-      });
+  const terms =
+    Array.isArray(opts.searchTerms) && opts.searchTerms.length > 0 ? opts.searchTerms : [''];
+
+  const byUrl = new Map();
+  let capped = false;
+
+  outer: for (const searchText of terms) {
+    let offset = 0;
+    while (true) {
+      const page = await postJobs(parts, { limit: pageSize, offset, searchText });
+      const postings = Array.isArray(page?.jobPostings) ? page.jobPostings : [];
+      for (const p of postings) {
+        const offerUrl = buildJobUrl(parts, p.externalPath || '');
+        if (!byUrl.has(offerUrl)) {
+          byUrl.set(offerUrl, {
+            url: offerUrl,
+            title: p.title || '',
+            company: companyName,
+            location: p.locationsText || '',
+            body: '',
+            platform: 'workday',
+          });
+        }
+        if (byUrl.size >= maxOffers) {
+          capped = true;
+          break;
+        }
+      }
+      if (capped || postings.length < pageSize) break;
+      offset += pageSize;
     }
-    if (postings.length < pageSize) break;
-    if (offers.length >= maxOffers) {
+    if (capped) {
       console.warn(
-        `[workday] ${parts.tenant}/${parts.site}: stopped at ${offers.length} offers (maxOffers=${maxOffers})`
+        `[workday] ${parts.tenant}/${parts.site}: stopped at ${byUrl.size} offers (maxOffers=${maxOffers})`
       );
-      break;
+      break outer;
     }
-    offset += pageSize;
   }
-  return offers;
+
+  return [...byUrl.values()];
 }

--- a/src/scan/index.mjs
+++ b/src/scan/index.mjs
@@ -46,9 +46,9 @@ function reasonToStatus(reason) {
   return 'skipped_other';
 }
 
-function buildSearchText(positiveTerms) {
-  if (!Array.isArray(positiveTerms) || positiveTerms.length === 0) return '';
-  return positiveTerms.filter((t) => typeof t === 'string' && !t.startsWith('/')).join(' ');
+function buildSearchTerms(positiveTerms) {
+  if (!Array.isArray(positiveTerms) || positiveTerms.length === 0) return [];
+  return positiveTerms.filter((t) => typeof t === 'string' && !t.startsWith('/'));
 }
 
 async function fetchCompanyOffers(company, whitelist) {
@@ -62,7 +62,9 @@ async function fetchCompanyOffers(company, whitelist) {
   }
   try {
     const opts =
-      det.platform === 'workday' ? { searchText: buildSearchText(whitelist.positive) } : undefined;
+      det.platform === 'workday'
+        ? { searchTerms: buildSearchTerms(whitelist.positive) }
+        : undefined;
     const offers = opts ? await fn(det.slug, company.name, opts) : await fn(det.slug, company.name);
     return { company: company.name, platform: det.platform, offers, error: null };
   } catch (err) {

--- a/tests/scan/ats-workday.test.mjs
+++ b/tests/scan/ats-workday.test.mjs
@@ -213,46 +213,96 @@ test('verifySlug — returns ko on non-Workday URL', async () => {
   assert.match(r.reason, /not a Workday URL/);
 });
 
-test('fetchWorkday — passes searchText in POST body', async () => {
+test('fetchWorkday — issues one POST per searchTerm and dedupes by url', async () => {
   const original = globalThis.fetch;
-  let capturedBody = null;
+  const bodies = [];
   globalThis.fetch = async (url, opts) => {
-    capturedBody = JSON.parse(opts.body);
+    const body = JSON.parse(opts.body);
+    bodies.push(body);
+    const unique = body.searchText === 'Intern' ? 'U1' : 'U2';
     return {
       ok: true,
       status: 200,
-      json: async () => ({ total: 0, jobPostings: [] }),
-      text: async () => '{}',
+      json: async () => ({
+        total: 2,
+        jobPostings: [
+          { title: 'Shared', externalPath: '/job/shared', locationsText: 'Paris' },
+          {
+            title: `${body.searchText} only`,
+            externalPath: `/job/${unique}`,
+            locationsText: 'Paris',
+          },
+        ],
+      }),
+      text: async () => '',
     };
   };
   restore = () => {
     globalThis.fetch = original;
   };
 
-  await fetchWorkday('https://sanofi.wd3.myworkdayjobs.com/SanofiCareers', 'Sanofi', {
-    searchText: 'Intern Stage Stagiaire',
+  const offers = await fetchWorkday(
+    'https://sanofi.wd3.myworkdayjobs.com/SanofiCareers',
+    'Sanofi',
+    { searchTerms: ['Intern', 'Stage'], pageSize: 20 }
+  );
+
+  assert.equal(bodies.length, 2);
+  assert.deepEqual(
+    bodies.map((b) => b.searchText),
+    ['Intern', 'Stage']
+  );
+  assert.equal(offers.length, 3);
+  const urls = offers.map((o) => o.url).sort();
+  assert.deepEqual(urls, [
+    'https://sanofi.wd3.myworkdayjobs.com/en-US/SanofiCareers/job/U1',
+    'https://sanofi.wd3.myworkdayjobs.com/en-US/SanofiCareers/job/U2',
+    'https://sanofi.wd3.myworkdayjobs.com/en-US/SanofiCareers/job/shared',
+  ]);
+});
+
+test('fetchWorkday — empty searchTerms falls back to single empty-search request', async () => {
+  const original = globalThis.fetch;
+  const bodies = [];
+  globalThis.fetch = async (url, opts) => {
+    bodies.push(JSON.parse(opts.body));
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ total: 0, jobPostings: [] }),
+      text: async () => '',
+    };
+  };
+  restore = () => {
+    globalThis.fetch = original;
+  };
+
+  await fetchWorkday('https://acme.wd3.myworkdayjobs.com/AcmeCareers', 'Acme', {
+    searchTerms: [],
+    pageSize: 20,
   });
 
-  assert.equal(capturedBody.searchText, 'Intern Stage Stagiaire');
+  assert.equal(bodies.length, 1);
+  assert.equal(bodies[0].searchText, '');
 });
 
 test('fetchWorkday — stops pagination when MAX_OFFERS reached', async () => {
-  // Create a page of 5 postings (will be the pageSize)
-  const fullPage = {
-    total: 999,
-    jobPostings: Array.from({ length: 5 }, (_, i) => ({
-      title: `Job ${i}`,
-      externalPath: `/job/Job-${i}_R${1000 + i}`,
-      locationsText: 'Paris',
-    })),
-  };
-
-  // Mock: return full pages indefinitely (simulate a huge board)
+  // Mock: return full pages indefinitely (simulate a huge board),
+  // with unique externalPaths per call so dedup-by-url doesn't interfere.
   const original = globalThis.fetch;
   let callCount = 0;
   globalThis.fetch = async () => {
     callCount++;
-    return { ok: true, status: 200, json: async () => fullPage, text: async () => '' };
+    const base = (callCount - 1) * 5;
+    const page = {
+      total: 999,
+      jobPostings: Array.from({ length: 5 }, (_, i) => ({
+        title: `Job ${base + i}`,
+        externalPath: `/job/Job-${base + i}_R${1000 + base + i}`,
+        locationsText: 'Paris',
+      })),
+    };
+    return { ok: true, status: 200, json: async () => page, text: async () => '' };
   };
   restore = () => {
     globalThis.fetch = original;

--- a/tests/scan/scan.test.mjs
+++ b/tests/scan/scan.test.mjs
@@ -259,12 +259,12 @@ test('runScan — skip_required_any bypasses required_any for flagged company', 
   );
 });
 
-test('runScan — passes searchText built from title_filter.positive to Workday fetcher', async () => {
-  let capturedBody = null;
+test('runScan — issues one Workday POST per positive term', async () => {
+  const capturedBodies = [];
   const original = globalThis.fetch;
   globalThis.fetch = async (url, opts) => {
     if (typeof url === 'string' && url.includes('myworkdayjobs.com')) {
-      capturedBody = JSON.parse(opts.body);
+      capturedBodies.push(JSON.parse(opts.body));
     }
     return {
       ok: true,
@@ -303,8 +303,11 @@ test('runScan — passes searchText built from title_filter.positive to Workday 
       dryRun: true,
     });
 
-    assert.ok(capturedBody, 'Expected a POST to Workday API');
-    assert.equal(capturedBody.searchText, 'Intern Stage');
+    assert.equal(capturedBodies.length, 2);
+    assert.deepEqual(
+      capturedBodies.map((b) => b.searchText),
+      ['Intern', 'Stage']
+    );
   } finally {
     globalThis.fetch = original;
     fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- **Root cause**: PR #28 joined `title_filter.positive` with spaces into a single `searchText`, but Workday ANDs space-separated tokens. `"Intern Internship Stage Stagiaire"` matched nothing, so every Workday tenant returned 0 or 1 offer during `/scan`.
- **Fix**: `fetchWorkday` now accepts `searchTerms: string[]` and issues one paginated request per term, deduping offers by URL via a `Map`. The global `maxOffers` cap from #28 still applies across terms.
- **Verified live**: `"Intern Internship Stage Stagiaire"` against NVIDIA → `total=0`; `"Intern"` alone → `total=880`.

Closes #34.

## Test plan

- [x] New test: `fetchWorkday` issues one POST per term and dedupes shared URLs
- [x] New test: empty `searchTerms` falls back to a single empty-search request
- [x] Updated test: `runScan` issues one Workday POST per positive term (non-regex)
- [x] Existing `maxOffers` cap test updated to use unique paths (regression-proofed against the new dedup)
- [x] Full suite: 360/360 passing
- [x] Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)