### PR TITLE
fix(onboard): rename /onboard to /apply-onboard (#35)

### DIFF
--- a/.claude/commands/apply-onboard.md
+++ b/.claude/commands/apply-onboard.md
@@ -1,17 +1,17 @@
 ---
-description: First-time setup — extract the user's CV, build config files, discover ~30 target companies, and run setup.sh non-interactively
+description: First-time setup for claude-apply — extract the user's CV, build config files, discover ~30 target companies, and run setup.sh non-interactively
 argument-hint: [path-to-cv.pdf]
 ---
 
-# /onboard $ARGUMENTS
+# /apply-onboard $ARGUMENTS
 
 You are guiding a **first-time user** through the end-to-end setup of `claude-apply`. This command is an **orchestrator**: it detects existing state, then chains three focused sub-skills in sequence. Each sub-skill is also a slash command and can be rerun independently if one phase fails.
 
-| Phase | Sub-skill            | Outputs                                                                    |
-| ----- | -------------------- | -------------------------------------------------------------------------- |
-| 1     | `/onboard:profile`   | `config/cv.md`, `config/cv.<lang>.pdf`, `config/candidate-profile.yml`     |
-| 2     | `/onboard:companies` | `config/portals.yml`                                                       |
-| 3     | `/onboard:setup`     | `node_modules/`, CDP Chrome profile, `chrome-apply` alias, Chrome on :9222 |
+| Phase | Sub-skill                  | Outputs                                                                    |
+| ----- | -------------------------- | -------------------------------------------------------------------------- |
+| 1     | `/apply-onboard:profile`   | `config/cv.md`, `config/cv.<lang>.pdf`, `config/candidate-profile.yml`     |
+| 2     | `/apply-onboard:companies` | `config/portals.yml`                                                       |
+| 3     | `/apply-onboard:setup`     | `node_modules/`, CDP Chrome profile, `chrome-apply` alias, Chrome on :9222 |
 
 **Hard rules** (override any instinct to "just do it"):
 
@@ -30,21 +30,21 @@ The sub-skills contain the detailed hard rules for their own phase. You must fol
    - **(c) portals only** → skip phase 1, run phase 2, then skip phase 3 (Chrome is already set up from a previous run). If `node_modules/` is missing, run `bash scripts/setup.sh --yes --no-clone-chrome-profile` first.
 2. If `config/candidate-profile.yml` does **not** exist, run all three phases.
 
-## 1. Phase 1 — profile (`/onboard:profile`)
+## 1. Phase 1 — profile (`/apply-onboard:profile`)
 
-Follow the instructions in `.claude/commands/onboard/profile.md` end-to-end. Pass `$ARGUMENTS` through as the CV path if the user provided one.
+Follow the instructions in `.claude/commands/apply-onboard/profile.md` end-to-end. Pass `$ARGUMENTS` through as the CV path if the user provided one.
 
 Phase 1 writes `config/cv.md`, `config/cv.<lang>.pdf`, `config/candidate-profile.yml`, and `data/.onboard-state.json`. Do not proceed until the profile validates against `validateProfile`.
 
-## 2. Phase 2 — companies (`/onboard:companies`)
+## 2. Phase 2 — companies (`/apply-onboard:companies`)
 
-Follow the instructions in `.claude/commands/onboard/companies.md` end-to-end.
+Follow the instructions in `.claude/commands/apply-onboard/companies.md` end-to-end.
 
 Phase 2 reads `data/.onboard-state.json` for the user's job-type and domain answers, builds `title_filter`, runs WebSearch + `verifyCompany`, gets the user's approval on the final list, and writes `config/portals.yml`. Do not proceed until the file is written.
 
-## 3. Phase 3 — setup (`/onboard:setup`)
+## 3. Phase 3 — setup (`/apply-onboard:setup`)
 
-Follow the instructions in `.claude/commands/onboard/setup.md` end-to-end.
+Follow the instructions in `.claude/commands/apply-onboard/setup.md` end-to-end.
 
 Phase 3 runs `scripts/setup.sh`, launches Chrome in CDP mode, and prints the extension install + host permission instructions. It ends with the final summary — do **not** run `/scan` or `/apply` yourself afterwards.
 

--- a/.claude/commands/apply-onboard/companies.md
+++ b/.claude/commands/apply-onboard/companies.md
@@ -2,7 +2,7 @@
 description: Onboarding phase 2 — discover ~30 target companies via WebSearch, verify their ATS boards, get user approval, and write config/portals.yml
 ---
 
-# /onboard:companies
+# /apply-onboard:companies
 
 You are running **phase 2 of onboarding**: build `config/portals.yml`. At the end, the file contains ~30 verified companies (`tracked_companies`) plus the `title_filter` derived from the user's job-type and domain answers.
 
@@ -12,11 +12,11 @@ You are running **phase 2 of onboarding**: build `config/portals.yml`. At the en
 - **Only keep companies whose ATS board is live** — verified via `verifyCompany`, not via `curl -I` on the careers HTML.
 - **Stop on ambiguity.** WebSearch returns nothing useful, the user's domain keywords are unclear, a slug redirects to a login wall → stop and ask.
 
-This skill assumes `config/candidate-profile.yml` already exists (written by `/onboard:profile`). If not, tell the user to run `/onboard:profile` first.
+This skill assumes `config/candidate-profile.yml` already exists (written by `/apply-onboard:profile`). If not, tell the user to run `/apply-onboard:profile` first.
 
 ## 1. Load inputs
 
-Read `data/.onboard-state.json` (written by `/onboard:profile`) to get `job_type`, `target_role`, `locations`. If the file is missing — the user is running this skill standalone — ask once for these three fields via `AskUserQuestion`.
+Read `data/.onboard-state.json` (written by `/apply-onboard:profile`) to get `job_type`, `target_role`, `locations`. If the file is missing — the user is running this skill standalone — ask once for these three fields via `AskUserQuestion`.
 
 ## 2. Build `title_filter`
 
@@ -113,4 +113,4 @@ Apply the user's edits (remove X, add Y with URL Z) and loop until they approve.
 
 ## 7. Done
 
-Report briefly: `config/portals.yml` written with N companies and the computed title_filter. If called from the `/onboard` orchestrator, control returns there. Otherwise tell the user to run `/onboard:setup` next.
+Report briefly: `config/portals.yml` written with N companies and the computed title_filter. If called from the `/apply-onboard` orchestrator, control returns there. Otherwise tell the user to run `/apply-onboard:setup` next.

--- a/.claude/commands/apply-onboard/profile.md
+++ b/.claude/commands/apply-onboard/profile.md
@@ -3,7 +3,7 @@ description: Onboarding phase 1 — extract CV, ask the user the missing fields,
 argument-hint: [path-to-cv.pdf]
 ---
 
-# /onboard:profile $ARGUMENTS
+# /apply-onboard:profile $ARGUMENTS
 
 You are running **phase 1 of onboarding**: build the candidate profile. At the end of this skill, `config/cv.md`, `config/cv.<lang>.pdf`, and `config/candidate-profile.yml` exist and validate against the schema.
 
@@ -13,7 +13,7 @@ You are running **phase 1 of onboarding**: build the candidate profile. At the e
 - **Never `git commit`.** Everything you write is under `config/` (gitignored).
 - **Stop on ambiguity.** Unreadable PDF, contradictory answers, wrong path → stop and ask.
 
-This skill can be run standalone or from the `/onboard` orchestrator. It is idempotent — rerunning overwrites.
+This skill can be run standalone or from the `/apply-onboard` orchestrator. It is idempotent — rerunning overwrites.
 
 ## 1. Locate the CV PDF
 
@@ -60,7 +60,7 @@ Use **`AskUserQuestion`** once with everything you could not extract, grouped lo
 - **Work authorization** — free text (e.g. "EU citizen — no sponsorship needed")
 - **Requires visa sponsorship**: yes / no
 
-**Setup choices** (used later by `/onboard:setup`)
+**Setup choices** (used later by `/apply-onboard:setup`)
 
 - **Clone your existing Chrome profile** into the CDP profile? yes / no
 - **Cover letter auto-generation**: enable now? yes / no (default no)
@@ -69,7 +69,7 @@ Anything the user declines → `null`.
 
 ## 4. Ensure npm dependencies are installed
 
-The schema validator and the YAML writer need `node_modules`. Install lightly if missing — `/onboard:setup` runs the full `scripts/setup.sh` later and will skip the install since it is idempotent:
+The schema validator and the YAML writer need `node_modules`. Install lightly if missing — `/apply-onboard:setup` runs the full `scripts/setup.sh` later and will skip the install since it is idempotent:
 
 ```bash
 [[ -d node_modules ]] || npm install
@@ -92,7 +92,7 @@ Validate before writing by importing `validateProfile` from `src/lib/candidate-p
 
 ## 6. Persist onboarding state for the next phase
 
-Write the job-search answers to `data/.onboard-state.json` so `/onboard:companies` and `/onboard:setup` can pick them up without re-asking. `data/` is gitignored.
+Write the job-search answers to `data/.onboard-state.json` so `/apply-onboard:companies` and `/apply-onboard:setup` can pick them up without re-asking. `data/` is gitignored.
 
 ```json
 {
@@ -106,4 +106,4 @@ Write the job-search answers to `data/.onboard-state.json` so `/onboard:companie
 
 ## 7. Done
 
-Report briefly: `config/cv.md`, `config/cv.<lang>.pdf`, `config/candidate-profile.yml`, `data/.onboard-state.json` written and validated. If you were called from the `/onboard` orchestrator, control returns there. Otherwise tell the user to run `/onboard:companies` next.
+Report briefly: `config/cv.md`, `config/cv.<lang>.pdf`, `config/candidate-profile.yml`, `data/.onboard-state.json` written and validated. If you were called from the `/apply-onboard` orchestrator, control returns there. Otherwise tell the user to run `/apply-onboard:companies` next.

--- a/.claude/commands/apply-onboard/setup.md
+++ b/.claude/commands/apply-onboard/setup.md
@@ -2,7 +2,7 @@
 description: Onboarding phase 3 — run scripts/setup.sh, launch Chrome in CDP mode, and guide the user through the extension install and host permissions
 ---
 
-# /onboard:setup
+# /apply-onboard:setup
 
 You are running **phase 3 of onboarding**: finalize the environment. At the end, `node_modules/` is installed, the CDP Chrome profile exists, the `chrome-apply` alias is in the user's shell rc, Chrome is running on port 9222, and the user has been told exactly which hosts to grant to the `claude-in-chrome` extension.
 
@@ -16,7 +16,7 @@ This skill is safe to rerun — `setup.sh` is idempotent.
 
 ## 1. Load the clone-profile answer
 
-Read `data/.onboard-state.json` (written by `/onboard:profile`) to get `clone_chrome_profile`. If the file is missing or the field is absent, ask the user once:
+Read `data/.onboard-state.json` (written by `/apply-onboard:profile`) to get `clone_chrome_profile`. If the file is missing or the field is absent, ask the user once:
 
 > "Clone your existing Chrome profile (cookies, extensions) into the dedicated CDP profile? yes / no"
 

--- a/.claude/commands/apply.md
+++ b/.claude/commands/apply.md
@@ -11,7 +11,7 @@ You will apply automatically to the offer at `$ARGUMENTS`. Follow this playbook 
 
 Before anything else, check that `config/candidate-profile.yml` exists. If it does not, **stop** and tell the user:
 
-> "No config found. Run `/onboard` first — it will extract your CV, build the profile, and prepare the target companies."
+> "No config found. Run `/apply-onboard` first — it will extract your CV, build the profile, and prepare the target companies."
 
 Do not try to apply with the example templates.
 
@@ -50,7 +50,7 @@ Do not try to apply with the example templates.
      3. Add https://<host>/*.
      4. Refresh the tab and re-run /apply.
 
-   See /onboard:setup for the full list of hosts.
+   See /apply-onboard:setup for the full list of hosts.
    ```
 
    Do not attempt to work around this — stopping on ambiguity is the invariant.

--- a/.claude/commands/scan.md
+++ b/.claude/commands/scan.md
@@ -11,7 +11,7 @@ Run the ATS scanner over the companies in `config/portals.yml` and append new of
 
 Before running the scanner, check that `config/candidate-profile.yml` **and** `config/portals.yml` exist. If either is missing, **stop** and tell the user:
 
-> "No config found. Run `/onboard` first — it will extract your CV, build the configs, and find ~30 target companies for you."
+> "No config found. Run `/apply-onboard` first — it will extract your CV, build the configs, and find ~30 target companies for you."
 
 Do not try to run the scanner against the example templates.
 

--- a/.claude/commands/score.md
+++ b/.claude/commands/score.md
@@ -11,7 +11,7 @@ Fetch the offer at `$ARGUMENTS`, build a prompt that compares it against `config
 
 Before running the scorer, check that `config/candidate-profile.yml` **and** `config/cv.md` exist. If either is missing, **stop** and tell the user:
 
-> "No config found. Run `/onboard` first — it will extract your CV and build the profile."
+> "No config found. Run `/apply-onboard` first — it will extract your CV and build the profile."
 
 ## Prerequisites
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING**: the onboarding slash command is now `/apply-onboard` (previously `/onboard`), with sub-commands `/apply-onboard:profile`, `/apply-onboard:companies`, `/apply-onboard:setup`. The rename avoids a collision with the `onboard` skill shipped by the `frontend-design` Claude Code plugin, which was shadowing the project command and rendering the documented entry point unusable (issue #35). First-run guards in `/scan`, `/score`, and `/apply` now point at `/apply-onboard`.
 - **BREAKING**: `portals.yml` `title_filter` terms now match whole words, case-insensitive (was: case-insensitive substring). `intern` no longer rejects `International`, but also no longer matches `Interns`/`Internship` — add explicit plural variants, or use the new `/regex/flags` escape hatch for full control.
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,9 +33,9 @@ The three stages are independent and communicate only via files in `data/`: `sca
 
 ## First-time setup
 
-**If `config/candidate-profile.yml` does not exist, the user is a first-time user — run `/onboard`.** That slash command handles everything: CV PDF extraction, building `config/cv.md` + `candidate-profile.yml`, discovering ~30 target companies via WebSearch, and running `scripts/setup.sh` non-interactively with the right flags. Read `.claude/commands/onboard.md` before starting.
+**If `config/candidate-profile.yml` does not exist, the user is a first-time user — run `/apply-onboard`.** That slash command handles everything: CV PDF extraction, building `config/cv.md` + `candidate-profile.yml`, discovering ~30 target companies via WebSearch, and running `scripts/setup.sh` non-interactively with the right flags. Read `.claude/commands/apply-onboard.md` before starting. (The command is namespaced `apply-onboard` rather than `onboard` to avoid colliding with the `onboard` skill from the `frontend-design` plugin — see issue #35.)
 
-The `/scan`, `/score`, and `/apply` commands each have a first-run guard that redirects the user to `/onboard` if the config is missing. Do not try to work around the guard by copying templates manually.
+The `/scan`, `/score`, and `/apply` commands each have a first-run guard that redirects the user to `/apply-onboard` if the config is missing. Do not try to work around the guard by copying templates manually.
 
 `scripts/setup.sh` accepts `--yes`, `--clone-chrome-profile`, `--no-clone-chrome-profile`, and `--no-rc` for non-interactive runs. Run `bash scripts/setup.sh --help` for details. Re-running is always safe — every step is idempotent.
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT_DIR"
 
-# Flags for non-interactive runs (used by /onboard).
+# Flags for non-interactive runs (used by /apply-onboard).
 #   --yes                       assume yes, never prompt
 #   --clone-chrome-profile      clone the default Chrome profile
 #   --no-clone-chrome-profile   create an empty Chrome profile

--- a/src/lib/load-profile.mjs
+++ b/src/lib/load-profile.mjs
@@ -21,7 +21,7 @@ export async function loadProfile(configDir) {
   const profilePath = path.join(configDir, 'candidate-profile.yml');
   if (!fs.existsSync(profilePath)) {
     throw new ProfileMissingError(
-      `config/candidate-profile.yml not found in ${configDir} — run /onboard`
+      `config/candidate-profile.yml not found in ${configDir} — run /apply-onboard`
     );
   }
   const yaml = await import('js-yaml');

--- a/src/score/index.mjs
+++ b/src/score/index.mjs
@@ -339,7 +339,7 @@ async function main() {
 
     const { cvMarkdown } = await loadProfile(CONFIG_DIR);
     if (!cvMarkdown) {
-      throw new ProfileMissingError(`config/cv.md not found in ${CONFIG_DIR} — run /onboard`);
+      throw new ProfileMissingError(`config/cv.md not found in ${CONFIG_DIR} — run /apply-onboard`);
     }
 
     const startId = parseInt(nextId(evalPath), 10);
@@ -508,7 +508,7 @@ async function main() {
 
   const { cvMarkdown } = await loadProfile(CONFIG_DIR);
   if (!cvMarkdown) {
-    throw new ProfileMissingError(`config/cv.md not found in ${CONFIG_DIR} — run /onboard`);
+    throw new ProfileMissingError(`config/cv.md not found in ${CONFIG_DIR} — run /apply-onboard`);
   }
 
   const { system, user } = buildPrompt({

--- a/tests/lib/load-profile.test.mjs
+++ b/tests/lib/load-profile.test.mjs
@@ -66,7 +66,7 @@ test('loadProfile — throws ProfileMissingError when yml missing', async () => 
       (err) => {
         assert.ok(err instanceof ProfileMissingError);
         assert.match(err.message, /candidate-profile\.yml/);
-        assert.match(err.message, /\/onboard/);
+        assert.match(err.message, /\/apply-onboard/);
         return true;
       }
     );

--- a/tests/scan/scan.test.mjs
+++ b/tests/scan/scan.test.mjs
@@ -438,7 +438,7 @@ test('scan CLI — missing candidate-profile.yml fails with ProfileMissingError'
       /candidate-profile\.yml/,
       `expected stderr to mention candidate-profile.yml, got: ${res.stderr}`
     );
-    assert.match(res.stderr, /\/onboard/, `expected stderr to mention /onboard`);
+    assert.match(res.stderr, /\/apply-onboard/, `expected stderr to mention /apply-onboard`);
   } finally {
     fs.rmSync(cfgDir, { recursive: true, force: true });
     fs.rmSync(dataDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- Closes #35. The `frontend-design` Claude Code plugin ships an `onboard` skill that shadows the project's `/onboard` slash command, so a first-time user following the README gets UX-design advice instead of CV extraction — the documented entry point is broken for anyone with that plugin installed.
- Renames the project command and its three sub-skills to break the collision: `/onboard`, `/onboard:profile`, `/onboard:companies`, `/onboard:setup` → `/apply-onboard`, `/apply-onboard:profile`, `/apply-onboard:companies`, `/apply-onboard:setup`. Files in `.claude/commands/onboard{,.md}` moved to `.claude/commands/apply-onboard{,.md}`.
- Updates first-run guard messages in `/scan`, `/score`, `/apply`, the `ProfileMissingError` strings in `src/lib/load-profile.mjs` and `src/score/index.mjs`, the `scripts/setup.sh` comment, the `CLAUDE.md` onboarding pointer, and the two affected tests. Adds a `BREAKING` entry to the Unreleased changelog.

## Verification

- Checked that after the rename the Claude Code skill list shows a single `onboard` entry (the frontend-design plugin) and three `apply-onboard:*` project entries with no collision.
- `npm test` → 359/359 passing
- `npm run lint` → clean (after `npm run format` on the adjusted test assertion)
- `npm run check:pii` → ✓ No PII detected

## Test plan

- [ ] In a fresh session with the `frontend-design` plugin installed, type `/apply-onboard` and confirm the project orchestrator loads (not the UX-design skill).
- [ ] Type `/apply-onboard:profile`, `/apply-onboard:companies`, `/apply-onboard:setup` and confirm each sub-command resolves to the project file under `.claude/commands/apply-onboard/`.
- [ ] Remove `config/candidate-profile.yml` and run `/scan` — expect the first-run guard to say "Run `/apply-onboard` first".
- [ ] Same for `/score <url>` and `/apply <url>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)