### PR TITLE
fix(score): avoid $0 substitution in cost doc (#37)

### DIFF
--- a/.claude/commands/score.md
+++ b/.claude/commands/score.md
@@ -69,7 +69,7 @@ Appends one JSON line to `data/evaluations.jsonl`:
 
 ## Cost
 
-~$0.03 per offer when using the stripped `claude -p` mode (~$0.14 otherwise). The script runs from a temp directory with `--disable-slash-commands --no-chrome --strict-mcp-config --setting-sources ""` to avoid Claude Code overhead.
+Around USD 0.03 per offer when using the stripped `claude -p` mode (around USD 0.14 otherwise). The script runs from a temp directory with `--disable-slash-commands --no-chrome --strict-mcp-config --setting-sources ""` to avoid Claude Code overhead.
 
 ## Batch mode
 


### PR DESCRIPTION
## Summary
- Rephrase the Cost section of `.claude/commands/score.md` so no literal `$0`/`$1` token remains — Claude Code was substituting `$0` with the first argument, splicing the URL into the middle of unrelated words.
- Audited all other slash commands (`scan.md`, `apply.md`, `apply-onboard*.md`): no other `$N` digit tokens found (only `$ARGUMENTS`, `${VAR}` and `$HOME`, which are safe).

## Test plan
- [x] `grep -nE '\$[0-9]' .claude/commands` returns no matches
- [ ] Run `/score <url>` and verify the Cost block renders with "USD 0.03" / "USD 0.14" instead of the spliced URL

Closes #37