### PR TITLE
feat(onboard): smart slug discovery for ATS verification (#38)

### DIFF
--- a/.claude/commands/apply-onboard/companies.md
+++ b/.claude/commands/apply-onboard/companies.md
@@ -90,6 +90,24 @@ Response shape:
 
 Add a 100 ms delay between verifications to be polite to the APIs.
 
+### 5b. Smart slug discovery when the careers URL is unknown
+
+If you only have a company **name** (no URL, or your guessed URL 404s), use `discoverCompany` from `src/scan/discover-company.mjs`. It walks platform-specific slug variations (`x`, `x-ai`, `xhq`, `xlabs`, `x-labs`, …) across Lever → Greenhouse → Ashby → Workday registry and returns the first hit. Successful resolutions are cached in `data/known-ats-slugs.json` so the next run is instant.
+
+```bash
+node -e "
+  import('./src/scan/discover-company.mjs').then(async m => {
+    const r = await m.discoverCompany('Doctolib', {
+      cachePath: 'data/known-ats-slugs.json',
+      workdayRegistryPath: 'data/known-workday-slugs.json',
+    });
+    console.log(JSON.stringify(r));
+  });
+"
+```
+
+Use this whenever your naive guess returns `ok: false` before dropping the candidate — many companies (Doctolib, Cohere, Modal, Scale AI, Writer, OpenAI, …) live on a different ATS or under a non-obvious slug.
+
 Drop any candidate that is a clear duplicate (same org, multiple slugs).
 
 ## 6. Trim to ~30 and get approval

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `discoverCompany(name, options)` in `src/scan/discover-company.mjs` — smart slug discovery that walks platform-specific variations (`x`, `x-ai`, `xhq`, `xlabs`, `x-labs`, …) across Lever → Greenhouse → Ashby → Workday registry and returns the first hit. Resolutions are cached in `data/known-ats-slugs.json`. Closes #38: `/apply-onboard:companies` no longer drops the 17/37 companies (Doctolib, Cohere, Modal, Scale AI, Writer, OpenAI, …) that live under non-obvious slugs.
 - `npm run explain -- "<title>" [--company "<co>"]` CLI traces why a title is accepted or filtered by the current `portals.yml` + `candidate-profile.yml`.
 - `verifySlug(slug)` primitive on each ATS fetcher (`lever`, `greenhouse`, `ashby`), returning `{ ok, count }` or `{ ok: false, status, reason }`.
 - `verifyCompany(careersUrl)` dispatcher and `getSupportedHosts()` helper in `src/scan/ats-detect.mjs`.

--- a/src/scan/discover-company.mjs
+++ b/src/scan/discover-company.mjs
@@ -1,0 +1,127 @@
+// Smart-discovery for an ATS slug given only a company name.
+// Tries platform-specific slug variations against the JSON APIs and
+// returns the first hit. Optionally caches successful resolutions in
+// data/known-ats-slugs.json so subsequent runs are instant.
+
+import fs from 'node:fs';
+import { verifySlug as verifyLever } from './ats/lever.mjs';
+import { verifySlug as verifyGreenhouse } from './ats/greenhouse.mjs';
+import { verifySlug as verifyAshby } from './ats/ashby.mjs';
+import { loadSlugRegistry, lookupWorkdaySlug } from './ats/workday-slugs.mjs';
+
+const VERIFIERS = {
+  lever: verifyLever,
+  greenhouse: verifyGreenhouse,
+  ashby: verifyAshby,
+};
+
+const CAREERS_URL = {
+  lever: (slug) => `https://jobs.lever.co/${slug}`,
+  greenhouse: (slug) => `https://boards.greenhouse.io/${slug}`,
+  ashby: (slug) => `https://jobs.ashbyhq.com/${slug}`,
+};
+
+export function slugCandidates(name, platform) {
+  const trimmed = String(name || '').trim();
+  if (!trimmed) return [];
+  const lower = trimmed.toLowerCase();
+  const noSpace = lower.replace(/\s+/g, '');
+  const hyphen = lower.replace(/\s+/g, '-');
+  const alnum = noSpace.replace(/[^a-z0-9]/g, '');
+  const base = new Set([lower, noSpace, hyphen, alnum].filter(Boolean));
+
+  const extras = new Set();
+  for (const b of base) {
+    if (platform === 'lever') {
+      extras.add(`${b}-ai`);
+      extras.add(`${b}ai`);
+    } else if (platform === 'greenhouse') {
+      extras.add(`${b}hq`);
+      extras.add(`${b}labs`);
+      extras.add(`${b}-labs`);
+    } else if (platform === 'ashby') {
+      extras.add(`${b}-ai`);
+      extras.add(`${b}ai`);
+      extras.add(`${b}-labs`);
+      extras.add(`${b}labs`);
+      extras.add(`${b}hq`);
+    }
+  }
+  return [...base, ...extras];
+}
+
+export function loadKnownSlugs(cachePath) {
+  if (!cachePath || !fs.existsSync(cachePath)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+export function saveKnownSlug(cachePath, key, entry) {
+  if (!cachePath) return;
+  const current = loadKnownSlugs(cachePath);
+  current[key] = entry;
+  fs.mkdirSync(cachePath.replace(/\/[^/]+$/, ''), { recursive: true });
+  fs.writeFileSync(cachePath, JSON.stringify(current, null, 2) + '\n');
+}
+
+function cacheKey(name) {
+  return String(name).trim().toLowerCase();
+}
+
+export async function discoverCompany(name, options = {}) {
+  const {
+    cachePath = null,
+    workdayRegistryPath = null,
+    delayMs = 100,
+    platforms = ['lever', 'greenhouse', 'ashby'],
+  } = options;
+
+  const key = cacheKey(name);
+  if (!key) return { ok: false, reason: 'empty name' };
+
+  const cache = loadKnownSlugs(cachePath);
+  if (cache[key]) {
+    return { ok: true, cached: true, ...cache[key] };
+  }
+
+  const tried = [];
+  for (const platform of platforms) {
+    const verify = VERIFIERS[platform];
+    if (!verify) continue;
+    for (const slug of slugCandidates(name, platform)) {
+      tried.push({ platform, slug });
+      const r = await verify(slug);
+      if (r.ok && (r.count ?? 0) > 0) {
+        const entry = {
+          platform,
+          slug,
+          careersUrl: CAREERS_URL[platform](slug),
+          count: r.count,
+        };
+        saveKnownSlug(cachePath, key, entry);
+        return { ok: true, cached: false, ...entry };
+      }
+      if (delayMs > 0) await new Promise((res) => setTimeout(res, delayMs));
+    }
+  }
+
+  if (workdayRegistryPath && fs.existsSync(workdayRegistryPath)) {
+    try {
+      const reg = loadSlugRegistry(workdayRegistryPath);
+      const w = lookupWorkdaySlug(reg, name);
+      if (w) {
+        const careersUrl = `https://${w.tenant}.${w.pod}.myworkdayjobs.com/${w.slug}`;
+        const entry = { platform: 'workday', slug: w.slug, careersUrl, count: null };
+        saveKnownSlug(cachePath, key, entry);
+        return { ok: true, cached: false, ...entry };
+      }
+    } catch {
+      // ignore registry errors
+    }
+  }
+
+  return { ok: false, reason: 'no slug matched', tried };
+}

--- a/tests/scan/discover-company.test.mjs
+++ b/tests/scan/discover-company.test.mjs
@@ -1,0 +1,171 @@
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { installMockFetch } from '../helpers.mjs';
+import {
+  discoverCompany,
+  slugCandidates,
+  loadKnownSlugs,
+} from '../../src/scan/discover-company.mjs';
+
+let restore;
+let tmpDir;
+afterEach(() => {
+  if (restore) restore();
+  restore = null;
+  if (tmpDir && fs.existsSync(tmpDir)) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+  tmpDir = null;
+});
+
+function mkTmp() {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'discover-'));
+  return tmpDir;
+}
+
+test('slugCandidates — variations Lever incluent -ai et ai', () => {
+  const cands = slugCandidates('Cohere', 'lever');
+  assert.ok(cands.includes('cohere'));
+  assert.ok(cands.includes('cohere-ai'));
+  assert.ok(cands.includes('cohereai'));
+});
+
+test('slugCandidates — variations Greenhouse incluent hq et labs', () => {
+  const cands = slugCandidates('scale', 'greenhouse');
+  assert.ok(cands.includes('scale'));
+  assert.ok(cands.includes('scalehq'));
+  assert.ok(cands.includes('scalelabs'));
+});
+
+test('slugCandidates — multi-mots produit noSpace, hyphen et alnum', () => {
+  const cands = slugCandidates('Scale AI', 'ashby');
+  assert.ok(cands.includes('scaleai'));
+  assert.ok(cands.includes('scale-ai'));
+});
+
+test('discoverCompany — bascule sur Greenhouse quand Lever échoue', async () => {
+  restore = installMockFetch({
+    'https://api.lever.co/v0/postings/doctolib?mode=json': { status: 404, body: {} },
+    'https://api.lever.co/v0/postings/doctolib-ai?mode=json': { status: 404, body: {} },
+    'https://api.lever.co/v0/postings/doctolibai?mode=json': { status: 404, body: {} },
+    'https://boards-api.greenhouse.io/v1/boards/doctolib/jobs?content=true': {
+      jobs: [{ id: 1 }, { id: 2 }],
+    },
+  });
+  const r = await discoverCompany('doctolib', { delayMs: 0 });
+  assert.equal(r.ok, true);
+  assert.equal(r.platform, 'greenhouse');
+  assert.equal(r.slug, 'doctolib');
+  assert.equal(r.careersUrl, 'https://boards.greenhouse.io/doctolib');
+  assert.equal(r.count, 2);
+});
+
+test('discoverCompany — bascule sur Ashby quand Lever et Greenhouse échouent', async () => {
+  restore = installMockFetch({
+    'https://api.lever.co/v0/postings/cohere?mode=json': { status: 404, body: {} },
+    'https://api.lever.co/v0/postings/cohere-ai?mode=json': { status: 404, body: {} },
+    'https://api.lever.co/v0/postings/cohereai?mode=json': { status: 404, body: {} },
+    'https://boards-api.greenhouse.io/v1/boards/cohere/jobs?content=true': {
+      status: 404,
+      body: {},
+    },
+    'https://boards-api.greenhouse.io/v1/boards/coherehq/jobs?content=true': {
+      status: 404,
+      body: {},
+    },
+    'https://boards-api.greenhouse.io/v1/boards/coherelabs/jobs?content=true': {
+      status: 404,
+      body: {},
+    },
+    'https://boards-api.greenhouse.io/v1/boards/cohere-labs/jobs?content=true': {
+      status: 404,
+      body: {},
+    },
+    'https://api.ashbyhq.com/posting-api/job-board/cohere?includeCompensation=false': {
+      jobs: [{ id: 'a' }],
+    },
+  });
+  const r = await discoverCompany('cohere', { delayMs: 0 });
+  assert.equal(r.ok, true);
+  assert.equal(r.platform, 'ashby');
+  assert.equal(r.careersUrl, 'https://jobs.ashbyhq.com/cohere');
+});
+
+test('discoverCompany — cache écrit puis relu sans fetch', async () => {
+  const dir = mkTmp();
+  const cachePath = path.join(dir, 'known-ats-slugs.json');
+  restore = installMockFetch({
+    'https://api.lever.co/v0/postings/mistral?mode=json': [{ id: '1' }],
+  });
+  const r1 = await discoverCompany('Mistral', { delayMs: 0, cachePath });
+  assert.equal(r1.ok, true);
+  assert.equal(r1.platform, 'lever');
+  assert.equal(r1.cached, false);
+
+  const cache = loadKnownSlugs(cachePath);
+  assert.ok(cache.mistral);
+  assert.equal(cache.mistral.platform, 'lever');
+
+  // Second call: no fetch needed (mock would throw on unexpected URL).
+  restore();
+  restore = installMockFetch({});
+  const r2 = await discoverCompany('Mistral', { delayMs: 0, cachePath });
+  assert.equal(r2.ok, true);
+  assert.equal(r2.cached, true);
+  assert.equal(r2.platform, 'lever');
+});
+
+test('discoverCompany — aucune correspondance renvoie ok:false', async () => {
+  restore = installMockFetch({
+    'https://api.lever.co/v0/postings/ghost?mode=json': { status: 404, body: {} },
+    'https://api.lever.co/v0/postings/ghost-ai?mode=json': { status: 404, body: {} },
+    'https://api.lever.co/v0/postings/ghostai?mode=json': { status: 404, body: {} },
+    'https://boards-api.greenhouse.io/v1/boards/ghost/jobs?content=true': {
+      status: 404,
+      body: {},
+    },
+    'https://boards-api.greenhouse.io/v1/boards/ghosthq/jobs?content=true': {
+      status: 404,
+      body: {},
+    },
+    'https://boards-api.greenhouse.io/v1/boards/ghostlabs/jobs?content=true': {
+      status: 404,
+      body: {},
+    },
+    'https://boards-api.greenhouse.io/v1/boards/ghost-labs/jobs?content=true': {
+      status: 404,
+      body: {},
+    },
+    'https://api.ashbyhq.com/posting-api/job-board/ghost?includeCompensation=false': {
+      status: 404,
+      body: {},
+    },
+    'https://api.ashbyhq.com/posting-api/job-board/ghost-ai?includeCompensation=false': {
+      status: 404,
+      body: {},
+    },
+    'https://api.ashbyhq.com/posting-api/job-board/ghostai?includeCompensation=false': {
+      status: 404,
+      body: {},
+    },
+    'https://api.ashbyhq.com/posting-api/job-board/ghost-labs?includeCompensation=false': {
+      status: 404,
+      body: {},
+    },
+    'https://api.ashbyhq.com/posting-api/job-board/ghostlabs?includeCompensation=false': {
+      status: 404,
+      body: {},
+    },
+    'https://api.ashbyhq.com/posting-api/job-board/ghosthq?includeCompensation=false': {
+      status: 404,
+      body: {},
+    },
+  });
+  const r = await discoverCompany('ghost', { delayMs: 0 });
+  assert.equal(r.ok, false);
+  assert.ok(Array.isArray(r.tried));
+  assert.ok(r.tried.length >= 9);
+});


### PR DESCRIPTION
## Summary

- New `discoverCompany(name, options)` in `src/scan/discover-company.mjs` walks platform-specific slug variations across Lever → Greenhouse → Ashby → Workday registry and returns the first live board.
- Successful resolutions are cached in `data/known-ats-slugs.json` (analogous to `known-workday-slugs.json`), so subsequent runs are instant.
- `/apply-onboard:companies` step 5b documents the new helper as the fallback whenever the naive guessed URL 404s.

## Why

Phase 2 of `/apply-onboard` was silently dropping ~17/37 candidate companies (Doctolib, Cohere, Modal, Scale AI, Writer, OpenAI, Hugging Face, Notion, Runway, …) because their public slug is non-obvious — they live on a different ATS or under a `-ai`/`hq`/`labs` variant. The user/agent was forced into a manual trial-and-error loop and typically gave up before reaching 30. Closes #38.

## Slug variations

| Platform   | Variations tried                                        |
| ---------- | ------------------------------------------------------- |
| Lever      | `x`, `x-ai`, `xai`                                      |
| Greenhouse | `x`, `xhq`, `xlabs`, `x-labs`                           |
| Ashby      | `x`, `x-ai`, `xai`, `x-labs`, `xlabs`, `xhq`            |
| Workday    | local `data/known-workday-slugs.json` registry lookup   |

Each base form is generated from the input name as `{lower, noSpace, hyphen, alnum}`.

## Test plan

- [x] `node --test tests/scan/discover-company.test.mjs` — 7 new tests pass (slug variations, Lever→Greenhouse fallback, Lever→Greenhouse→Ashby fallback, cache write+read, no-match path).
- [x] `npm test` — full suite 367/367 pass.
- [x] `npm run lint` — Prettier clean.
- [x] `npm run check:pii` — PII gate clean.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)