### PR TITLE
fix(scan): match required_any against title and description (#40)

### DIFF
--- a/docs/scan-workflow.md
+++ b/docs/scan-workflow.md
@@ -32,7 +32,7 @@ A URL that doesn't match these patterns is skipped silently. To add a new ATS, s
 
 ## Title filter
 
-`portals.yml.title_filter.required_any` is a list of keywords — a job title must contain at least one, matched as a word-boundary regex (so `International` does not match `Intern`).
+`portals.yml.title_filter.positive` / `negative` are whole-word regexes matched against the job **title**. `required_any` is a domain filter matched against the **title and the description**: the keyword can appear in either. This is deliberate — many ML internships are posted with generic titles like "Software Engineering Intern – Data Platform" where the domain keyword only appears in the description. Some ATS fetchers (Workday) do not populate the description field; for those portals, set `skip_required_any: true` per company or add the domain keyword to `positive` instead.
 
 Example:
 

--- a/src/lib/prefilter-rules.mjs
+++ b/src/lib/prefilter-rules.mjs
@@ -140,14 +140,20 @@ function findMatch(terms, title) {
 
 export function checkTitle(offer, whitelist) {
   const title = offer.title || '';
+  const body = offer.body || '';
   try {
     const neg = findMatch(whitelist.negative, title);
     if (neg) return { pass: false, reason: `title: negative match "${neg}"` };
     const pos = findMatch(whitelist.positive, title);
     if (!pos) return { pass: false, reason: 'title: no positive match' };
     if (Array.isArray(whitelist.required_any) && whitelist.required_any.length > 0) {
-      const req = findMatch(whitelist.required_any, title);
-      if (!req) return { pass: false, reason: 'title: missing required_any keyword' };
+      const haystack = `${title}\n${body}`;
+      const req = findMatch(whitelist.required_any, haystack);
+      if (!req)
+        return {
+          pass: false,
+          reason: 'title: missing required_any keyword (searched title + description)',
+        };
     }
     return { pass: true };
   } catch (err) {

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -43,7 +43,9 @@ title_filter:
   # Optional exclusion keywords — offers matching any of these are dropped.
   negative: []
 
-  # Optional secondary filter applied *on top of* positive/negative:
-  # if set, the title must also match at least one of these (same whole-word
-  # semantics and regex escape hatch as above). Leave empty or omit to skip.
+  # Optional domain filter applied *on top of* positive/negative:
+  # if set, the job title OR description must contain at least one of these
+  # keywords (same whole-word semantics and regex escape hatch as above).
+  # Leave empty or omit to skip. Use `skip_required_any: true` per company
+  # for ATS fetchers that do not populate the description (e.g. Workday).
   required_any: []

--- a/tests/lib/prefilter-title.test.mjs
+++ b/tests/lib/prefilter-title.test.mjs
@@ -79,6 +79,38 @@ test('checkTitle: required_any uses word-boundary (regression guard)', () => {
   assert.match(r.reason, /required_any/);
 });
 
+test('checkTitle: required_any matches keyword in body (issue #40 regression)', () => {
+  const wl = { positive: ['intern'], negative: [], required_any: ['machine learning'] };
+  const offer = {
+    title: 'Software Engineering Intern - Data Platform',
+    body: 'You will work on our machine learning infrastructure team.',
+  };
+  assert.deepEqual(checkTitle(offer, wl), { pass: true });
+});
+
+test('checkTitle: required_any fails when keyword absent from both title and body', () => {
+  const wl = { positive: ['intern'], negative: [], required_any: ['machine learning'] };
+  const offer = {
+    title: 'Marketing Intern',
+    body: 'Help us plan social media campaigns and write blog posts.',
+  };
+  const r = checkTitle(offer, wl);
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /missing required_any keyword/);
+});
+
+test('checkTitle: required_any still matches when keyword is only in title', () => {
+  const wl = { positive: ['intern'], negative: [], required_any: ['ml'] };
+  assert.deepEqual(checkTitle({ title: 'ML Intern', body: '' }, wl), { pass: true });
+});
+
+test('checkTitle: required_any fails cleanly on empty body (Workday case)', () => {
+  const wl = { positive: ['intern'], negative: [], required_any: ['ml'] };
+  const r = checkTitle({ title: 'Software Engineering Intern', body: '' }, wl);
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /missing required_any keyword/);
+});
+
 test('checkTitle: required_any accepts regex escape hatch', () => {
   const wl = { positive: ['engineer'], negative: [], required_any: ['/^ml\\b/i'] };
   assert.deepEqual(checkTitle({ title: 'ML Engineer' }, wl), { pass: true });


### PR DESCRIPTION
## Summary
- Fixes #40 — `required_any` was matched against job titles only, rejecting 99.5% of real offers (4017/4039 on a 28-company scan).
- `checkTitle` now matches `required_any` against `title + body`. `positive`/`negative` remain title-scoped — they discriminate the role type, not the domain.
- `skip_required_any: true` per portal remains the documented escape hatch for ATS fetchers that do not populate `body` (Workday).

## Why this shape
Recall at scan time matters more than precision — the `/score` LLM step does the domain-fit judgement. Title-only matching was a dead end for real-world postings like "Software Engineering Intern – Data Platform".

## Test plan
- [x] `npm test` — 381/381 pass (4 new regression tests in `tests/lib/prefilter-title.test.mjs`)
- [x] `npm run lint`
- [x] `npm run check:pii`
- [ ] Manual: re-run `/scan` on a known Greenhouse/Lever board with an ML intern whose title lacks "ML/AI" — confirm it now appears in `pipeline.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)