### PR TITLE
fix(scan): warn on empty boards (count=0) — #44

### DIFF
--- a/.claude/commands/apply-onboard/companies.md
+++ b/.claude/commands/apply-onboard/companies.md
@@ -112,7 +112,7 @@ Drop any candidate that is a clear duplicate (same org, multiple slugs).
 
 ### 5c. Confirm empty boards
 
-After step 5 + 5b, some candidates may have returned `{ok: true, count: 0, warning: ...}` — the board is live but currently exposes zero public jobs. This is ambiguous: the company may genuinely have a hiring freeze, OR the slug may be wrong (e.g. `vercel` vs `vercel-careers`).
+After step 5 + 5b, some candidates may have returned `{ ok: true, count: 0, warning: "…" }` (see the response shape in step 5) — the board is live but currently exposes zero public jobs. This is ambiguous: the company may genuinely have a hiring freeze, OR the slug may be wrong (e.g. `vercel` vs `vercel-careers`).
 
 If N ≥ 1 candidates carry a `warning`, present the list in a compact table:
 
@@ -126,7 +126,7 @@ Then call `AskUserQuestion` **once** with these exact options:
 
 - `"Drop all empty boards"` — remove every empty-board candidate from the list before step 6.
 - `"Keep all empty boards"` — proceed with them into the step-6 approval table as-is.
-- `"Let me decide per company"` — loop over each empty-board candidate and call `AskUserQuestion` with options `Keep`, `Drop`, `Edit URL`. On `Edit URL`, ask the user for the corrected URL and re-verify it via step 5 (`verifyCompany`). If the new URL also returns `count: 0`, ask again. If it returns `ok: false`, drop.
+- `"Let me decide per company"` — loop over each empty-board candidate and call `AskUserQuestion` with options `"Keep"`, `"Drop"`, `"Edit URL"`. On `"Edit URL"`, ask the user for the corrected URL and re-verify it via step 5 (`verifyCompany`). If the new URL returns `ok: true, count > 0`, keep the updated entry. If it returns `ok: false`, drop. If it still returns `count: 0`, call `AskUserQuestion` one more time with options `"Keep anyway"` and `"Drop"` — do not offer another `Edit URL` (at most one URL edit per company).
 
 If no candidate has a `warning`, skip this step silently.
 

--- a/.claude/commands/apply-onboard/companies.md
+++ b/.claude/commands/apply-onboard/companies.md
@@ -85,7 +85,7 @@ node -e "
 
 Response shape:
 
-- `{ ok: true, count: N }` → slug is live. Keep the company. If `count` is 0, flag it for sanity-check.
+- `{ ok: true, count: N, warning? }` → slug is live. Keep the company. If `count` is 0, `verifyCompany` adds `warning: 'board live but empty — possibly wrong slug'`; step 5c will ask the user to confirm these before writing.
 - `{ ok: false, status, reason }` → drop. On transient failures (5xx, network error), retry **once** after a 2 s backoff before dropping.
 
 Add a 100 ms delay between verifications to be polite to the APIs.
@@ -109,6 +109,26 @@ node -e "
 Use this whenever your naive guess returns `ok: false` before dropping the candidate — many companies (Doctolib, Cohere, Modal, Scale AI, Writer, OpenAI, …) live on a different ATS or under a non-obvious slug.
 
 Drop any candidate that is a clear duplicate (same org, multiple slugs).
+
+### 5c. Confirm empty boards
+
+After step 5 + 5b, some candidates may have returned `{ok: true, count: 0, warning: ...}` — the board is live but currently exposes zero public jobs. This is ambiguous: the company may genuinely have a hiring freeze, OR the slug may be wrong (e.g. `vercel` vs `vercel-careers`).
+
+If N ≥ 1 candidates carry a `warning`, present the list in a compact table:
+
+```
+Company         ATS     Careers URL
+────────────────────────────────────────────────
+Vercel          ashby   https://jobs.ashbyhq.com/vercel
+```
+
+Then call `AskUserQuestion` **once** with these exact options:
+
+- `"Drop all empty boards"` — remove every empty-board candidate from the list before step 6.
+- `"Keep all empty boards"` — proceed with them into the step-6 approval table as-is.
+- `"Let me decide per company"` — loop over each empty-board candidate and call `AskUserQuestion` with options `Keep`, `Drop`, `Edit URL`. On `Edit URL`, ask the user for the corrected URL and re-verify it via step 5 (`verifyCompany`). If the new URL also returns `count: 0`, ask again. If it returns `ok: false`, drop.
+
+If no candidate has a `warning`, skip this step silently.
 
 ## 6. Trim to ~30 and get approval (technical gate)
 

--- a/docs/superpowers/plans/2026-04-17-empty-board-warning.md
+++ b/docs/superpowers/plans/2026-04-17-empty-board-warning.md
@@ -1,0 +1,553 @@
+# Empty-board warning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface zero-job ATS boards as a distinct `⚠` state — in `verifyCompany`, in `/scan` summary, and via a user-confirmation step in `/apply-onboard:companies` — so the user can spot wrong slugs before they silently land in `portals.yml`.
+
+**Architecture:** Add a `warning` field to `verifyCompany` when `ok && count === 0`. Mirror that policy inside `runScan` so `perCompany[].warning` is populated. Update `formatSummary` to render `⚠`. Add a new step 5c to the `/apply-onboard:companies` agent instruction that batch-confirms empty boards before approval.
+
+**Tech Stack:** Node.js 20+, ESM (`.mjs`), `node:test`, Prettier.
+
+**Spec:** `docs/superpowers/specs/2026-04-17-empty-board-warning-design.md`
+
+**Issue:** [#44](https://github.com/LeoLaborie/claude-apply/issues/44)
+
+---
+
+## File Structure
+
+Files touched (3 code + tests, 1 doc):
+
+| Path | Responsibility |
+|---|---|
+| `src/scan/ats-detect.mjs` | Dispatcher — inject `warning` on empty boards |
+| `tests/scan/verify-company.test.mjs` | Cover the new warning contract |
+| `src/scan/index.mjs` | `runScan` populates `perCompany[].warning`; `formatSummary` renders `⚠` |
+| `tests/scan/scan.test.mjs` | Cover `runScan` + `formatSummary` warning behavior |
+| `.claude/commands/apply-onboard/companies.md` | New step 5c (agent instruction) |
+
+No new files, no new exports.
+
+---
+
+## Task 1: `verifyCompany` adds warning on count=0
+
+**Files:**
+- Modify: `src/scan/ats-detect.mjs:38-47` (`verifyCompany` function)
+- Test: `tests/scan/verify-company.test.mjs`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/scan/verify-company.test.mjs` (before the final closing line):
+
+```js
+test('verifyCompany — count=0 on Ashby adds warning', async () => {
+  restore = installMockFetch({
+    'https://api.ashbyhq.com/posting-api/job-board/vercel?includeCompensation=false': {
+      jobs: [],
+    },
+  });
+  const r = await verifyCompany('https://jobs.ashbyhq.com/vercel');
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 0);
+  assert.match(r.warning, /board live but empty/i);
+});
+
+test('verifyCompany — count=0 on Lever adds warning', async () => {
+  restore = installMockFetch({
+    'https://api.lever.co/v0/postings/ghosttown?mode=json': [],
+  });
+  const r = await verifyCompany('https://jobs.lever.co/ghosttown');
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 0);
+  assert.match(r.warning, /board live but empty/i);
+});
+
+test('verifyCompany — count>0 does not add warning', async () => {
+  restore = installMockFetch({
+    'https://api.lever.co/v0/postings/mistral?mode=json': [{ id: '1' }],
+  });
+  const r = await verifyCompany('https://jobs.lever.co/mistral');
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 1);
+  assert.equal(r.warning, undefined);
+});
+
+test('verifyCompany — ok:false does not add warning', async () => {
+  const r = await verifyCompany('https://careers.example.com/jobs');
+  assert.equal(r.ok, false);
+  assert.equal(r.warning, undefined);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test tests/scan/verify-company.test.mjs`
+Expected: 4 failures — either `r.warning` is `undefined` when it should match `/board live/`, or test that expects `undefined` passes (that one passes today).
+
+- [ ] **Step 3: Implement**
+
+Replace `src/scan/ats-detect.mjs:38-47` with:
+
+```js
+export async function verifyCompany(careersUrl) {
+  const det = detectPlatform(careersUrl);
+  if (!det) return { ok: false, reason: 'unknown platform' };
+  const { platform, slug } = det;
+  if (!VERIFIABLE_PLATFORMS.has(platform)) {
+    return { ok: false, reason: `platform ${platform} not supported by verifySlug` };
+  }
+  const mod = await import(`./ats/${platform}.mjs`);
+  const result = await mod.verifySlug(slug);
+  if (result.ok && result.count === 0) {
+    return { ...result, warning: 'board live but empty — possibly wrong slug' };
+  }
+  return result;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/scan/verify-company.test.mjs`
+Expected: all tests pass (8 total — 4 existing + 4 new).
+
+- [ ] **Step 5: Run full suite**
+
+Run: `npm test`
+Expected: 414 passing (410 baseline + 4 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/scan/ats-detect.mjs tests/scan/verify-company.test.mjs
+git commit -m "feat(scan): verifyCompany warns on empty boards (#44)
+
+Return {ok: true, count: 0, warning: '...'} when an ATS board is live
+but exposes zero public jobs. Per-ATS verifySlug contracts unchanged."
+```
+
+---
+
+## Task 2: `runScan` populates `perCompany[].warning`
+
+**Files:**
+- Modify: `src/scan/index.mjs:150-155` (error-path push — add `warning: null`)
+- Modify: `src/scan/index.mjs:171-175` (success-path push — compute warning)
+- Test: `tests/scan/scan.test.mjs`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/scan/scan.test.mjs`:
+
+```js
+test('runScan — perCompany.warning set when raw=0 without error', async () => {
+  const portalsConfig = {
+    title_filter: { positive: [], negative: [] },
+    tracked_companies: [
+      { name: 'Ghost Town', careers_url: 'https://jobs.ashbyhq.com/ghost', enabled: true },
+    ],
+  };
+  const profile = { blacklist_companies: [], target_locations: ['France'] };
+
+  const restore = installMockFetch({
+    'https://api.ashbyhq.com/posting-api/job-board/ghost?includeCompensation=false': {
+      jobs: [],
+    },
+  });
+
+  const pipelinePath = path.join(tmp, 'pipeline.md');
+  const historyPath = path.join(tmp, 'scan-history.tsv');
+  const filteredPath = path.join(tmp, 'filtered-out.tsv');
+  const applicationsPath = path.join(tmp, 'applications.md');
+  fs.writeFileSync(applicationsPath, '# Apps\n');
+
+  try {
+    const result = await runScan({
+      portalsConfig,
+      profile,
+      pipelinePath,
+      historyPath,
+      filteredPath,
+      applicationsPath,
+      dryRun: true,
+    });
+    assert.equal(result.perCompany.length, 1);
+    const [entry] = result.perCompany;
+    assert.equal(entry.count, 0);
+    assert.equal(entry.error, null);
+    assert.match(entry.warning, /board live but empty/i);
+  } finally {
+    restore();
+  }
+});
+
+test('runScan — perCompany.warning is null when raw>0', async () => {
+  const portalsConfig = {
+    title_filter: { positive: [], negative: [] },
+    tracked_companies: [
+      { name: 'Mistral AI', careers_url: 'https://jobs.lever.co/mistral', enabled: true },
+    ],
+  };
+  const profile = { blacklist_companies: [], target_locations: ['France'] };
+
+  const restore = installMockFetch({
+    'https://api.lever.co/v0/postings/mistral?mode=json': [
+      {
+        hostedUrl: 'https://jobs.lever.co/mistral/a',
+        text: 'Engineer',
+        categories: { location: 'Paris' },
+        descriptionPlain: 'Paris France',
+      },
+    ],
+  });
+
+  const pipelinePath = path.join(tmp, 'pipeline.md');
+  const historyPath = path.join(tmp, 'scan-history.tsv');
+  const filteredPath = path.join(tmp, 'filtered-out.tsv');
+  const applicationsPath = path.join(tmp, 'applications.md');
+  fs.writeFileSync(applicationsPath, '# Apps\n');
+
+  try {
+    const result = await runScan({
+      portalsConfig,
+      profile,
+      pipelinePath,
+      historyPath,
+      filteredPath,
+      applicationsPath,
+      dryRun: true,
+    });
+    assert.equal(result.perCompany.length, 1);
+    assert.equal(result.perCompany[0].warning, null);
+  } finally {
+    restore();
+  }
+});
+
+test('runScan — perCompany.warning is null when there is an error', async () => {
+  const portalsConfig = {
+    title_filter: { positive: [], negative: [] },
+    tracked_companies: [
+      { name: 'Broken', careers_url: 'https://jobs.lever.co/broken', enabled: true },
+    ],
+  };
+  const profile = { blacklist_companies: [], target_locations: ['France'] };
+
+  const restore = installMockFetch({
+    'https://api.lever.co/v0/postings/broken?mode=json': { __status: 404 },
+  });
+
+  const pipelinePath = path.join(tmp, 'pipeline.md');
+  const historyPath = path.join(tmp, 'scan-history.tsv');
+  const filteredPath = path.join(tmp, 'filtered-out.tsv');
+  const applicationsPath = path.join(tmp, 'applications.md');
+  fs.writeFileSync(applicationsPath, '# Apps\n');
+
+  try {
+    const result = await runScan({
+      portalsConfig,
+      profile,
+      pipelinePath,
+      historyPath,
+      filteredPath,
+      applicationsPath,
+      dryRun: true,
+    });
+    assert.equal(result.perCompany.length, 1);
+    const [entry] = result.perCompany;
+    assert.ok(entry.error);
+    assert.equal(entry.warning, null);
+  } finally {
+    restore();
+  }
+});
+```
+
+Note: the third test assumes `installMockFetch` supports a `{__status: 404}` shape for non-200 responses. If it does not, inspect `tests/helpers.mjs` and adapt — pass `null` or use the helper's documented way to simulate a 4xx. Do NOT skip this test; instead adjust the mock to actually trigger the error path.
+
+- [ ] **Step 2: Verify mock helper capability**
+
+Run: `grep -n "installMockFetch\|__status\|status" tests/helpers.mjs | head -20`
+
+If `__status` is not supported, read the helper and pick the actually-supported shape (e.g. passing a function or a Response-like object). Update the third test accordingly. The goal is only to populate `result.error` on the `perCompany` entry so we can assert `warning: null`.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `node --test tests/scan/scan.test.mjs`
+Expected: the new tests fail — `entry.warning` is `undefined` (property missing entirely).
+
+- [ ] **Step 4: Implement — error path**
+
+Edit `src/scan/index.mjs:150-155`. Replace:
+
+```js
+perCompany.push({
+  company: result.company,
+  platform: result.platform,
+  count: 0,
+  error: result.error,
+});
+```
+
+with:
+
+```js
+perCompany.push({
+  company: result.company,
+  platform: result.platform,
+  count: 0,
+  error: result.error,
+  warning: null,
+});
+```
+
+- [ ] **Step 5: Implement — success path**
+
+Edit `src/scan/index.mjs:171-175`. Replace:
+
+```js
+perCompany.push({
+  company: result.company,
+  platform: result.platform,
+  count: result.offers.length,
+});
+```
+
+with:
+
+```js
+const warning =
+  result.offers.length === 0 ? 'board live but empty — possibly wrong slug' : null;
+perCompany.push({
+  company: result.company,
+  platform: result.platform,
+  count: result.offers.length,
+  error: null,
+  warning,
+});
+```
+
+Adding `error: null` keeps the two push sites shape-symmetric (every entry has both `error` and `warning`).
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `node --test tests/scan/scan.test.mjs`
+Expected: all scan tests pass (existing + 3 new).
+
+- [ ] **Step 7: Run full suite**
+
+Run: `npm test`
+Expected: 417 passing (414 after Task 1 + 3 new).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/scan/index.mjs tests/scan/scan.test.mjs
+git commit -m "feat(scan): runScan flags empty boards on perCompany (#44)
+
+perCompany entries now always carry {error, warning}. warning is set
+to a constant string when raw count is zero without error, null otherwise."
+```
+
+---
+
+## Task 3: `formatSummary` renders `⚠` for warnings
+
+**Files:**
+- Modify: `src/scan/index.mjs:281-283` (`formatSummary` per-company block)
+- Test: `tests/scan/scan.test.mjs` (add one formatSummary test — we need to export it or test it indirectly via stdout)
+
+- [ ] **Step 1: Check whether formatSummary is exported**
+
+Run: `grep -n "export\|formatSummary" src/scan/index.mjs`
+
+If `formatSummary` is not exported, add it to the exports for testability. At the bottom of `src/scan/index.mjs` (or next to `runScan`'s export), add:
+
+```js
+export { formatSummary };
+```
+
+Only add this if it is not already exported.
+
+- [ ] **Step 2: Write failing test**
+
+Append to `tests/scan/scan.test.mjs`:
+
+```js
+import { formatSummary } from '../../src/scan/index.mjs';
+
+test('formatSummary — renders ⚠ for a company with a warning', () => {
+  const result = {
+    scanned: 2,
+    raw: 5,
+    perCompany: [
+      { company: 'Anthropic', platform: 'lever', count: 5, error: null, warning: null },
+      {
+        company: 'Vercel',
+        platform: 'ashby',
+        count: 0,
+        error: null,
+        warning: 'board live but empty — possibly wrong slug',
+      },
+    ],
+    filtered: {
+      skipped_dup: 0,
+      skipped_title: 0,
+      skipped_blacklist: 0,
+      skipped_location: 0,
+      skipped_date: 0,
+    },
+    added: [],
+    errors: [],
+    historyWrites: 0,
+  };
+  const out = formatSummary(result, true);
+  assert.match(out, /⚠ Vercel/);
+  assert.match(out, /board live but empty/);
+  assert.match(out, /✓ Anthropic/);
+});
+```
+
+Merge the `import` line with the existing top-level import block if present (keep a single `import` from `src/scan/index.mjs`).
+
+- [ ] **Step 3: Run tests to verify it fails**
+
+Run: `node --test tests/scan/scan.test.mjs`
+Expected: the formatSummary test fails — `⚠` is not emitted; only `✓` or `✗` are.
+
+- [ ] **Step 4: Implement**
+
+Edit `src/scan/index.mjs:281-283`. Replace:
+
+```js
+const mark = c.error ? '✗' : '✓';
+const note = c.error ? `(${c.error})` : `(${c.platform})`;
+lines.push(`  ${mark} ${c.company.padEnd(18)} ${String(c.count).padStart(3)} offres ${note}`);
+```
+
+with:
+
+```js
+const mark = c.error ? '✗' : c.warning ? '⚠' : '✓';
+const note = c.error
+  ? `(${c.error})`
+  : c.warning
+    ? `(${c.platform} — ${c.warning})`
+    : `(${c.platform})`;
+lines.push(`  ${mark} ${c.company.padEnd(18)} ${String(c.count).padStart(3)} offres ${note}`);
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `node --test tests/scan/scan.test.mjs`
+Expected: all scan tests pass.
+
+- [ ] **Step 6: Run full suite + lint**
+
+Run: `npm test && npm run lint`
+Expected: 418 passing, lint clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/scan/index.mjs tests/scan/scan.test.mjs
+git commit -m "feat(scan): formatSummary renders ⚠ for empty boards (#44)
+
+Companies with warning=... now render with ⚠ mark and inline reason
+in the /scan summary block, keeping live progress lines unchanged."
+```
+
+---
+
+## Task 4: Add step 5c to `/apply-onboard:companies`
+
+**Files:**
+- Modify: `.claude/commands/apply-onboard/companies.md` (insert after line 111, before the `## 6.` header)
+
+- [ ] **Step 1: Locate the insertion point**
+
+Run: `grep -n "^## 6\\.\\|^### 5b\\|Drop any candidate that is a clear duplicate" .claude/commands/apply-onboard/companies.md`
+
+The new subsection goes between the end of 5b (duplicate-drop sentence) and the `## 6. Trim to ~30 and get approval` header.
+
+- [ ] **Step 2: Insert the new subsection**
+
+Insert the following block immediately before the `## 6. Trim to ~30 and get approval (technical gate)` heading:
+
+```markdown
+### 5c. Confirm empty boards
+
+After step 5 + 5b, some candidates may have returned `{ok: true, count: 0, warning: ...}` — the board is live but currently exposes zero public jobs. This is ambiguous: the company may genuinely have a hiring freeze, OR the slug may be wrong (e.g. `vercel` vs `vercel-careers`).
+
+If N ≥ 1 candidates carry a `warning`, present the list in a compact table:
+
+```
+Company         ATS     Careers URL
+────────────────────────────────────────────────
+Vercel          ashby   https://jobs.ashbyhq.com/vercel
+```
+
+Then call `AskUserQuestion` **once** with these exact options:
+
+- `"Drop all empty boards"` — remove every empty-board candidate from the list before step 6.
+- `"Keep all empty boards"` — proceed with them into the step-6 approval table as-is.
+- `"Let me decide per company"` — loop over each empty-board candidate and call `AskUserQuestion` with options `Keep`, `Drop`, `Edit URL`. On `Edit URL`, ask the user for the corrected URL and re-verify it via step 5 (`verifyCompany`). If the new URL also returns `count: 0`, ask again. If it returns `ok: false`, drop.
+
+If no candidate has a `warning`, skip this step silently.
+```
+
+- [ ] **Step 3: Verify no other docs need updating**
+
+Run: `grep -rn "count: 0\\|count===0\\|count === 0" docs/ .claude/ --include='*.md'`
+
+If step 5 of `companies.md` still says "If count is 0, flag it for sanity-check" (companies.md:88), update that bullet to point to 5c instead:
+
+Replace the bullet `- `{ ok: true, count: N }` → slug is live. Keep the company. If `count` is 0, flag it for sanity-check.` with:
+
+```
+- `{ ok: true, count: N, warning? }` → slug is live. Keep the company. If `count` is 0, verifyCompany adds `warning: 'board live but empty — possibly wrong slug'`; step 5c will ask the user to confirm these before writing.
+```
+
+- [ ] **Step 4: Lint & PII check**
+
+Run: `npm run format && npm run check:pii`
+Expected: clean (no changes after `format` ideally, PII check passes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude/commands/apply-onboard/companies.md
+git commit -m "docs(onboard): confirm empty boards before approval (#44)
+
+Add step 5c: batch-confirm candidates whose verifyCompany returned
+count=0 warning. Three options: drop-all, keep-all, per-company loop
+with Edit-URL re-verify."
+```
+
+---
+
+## Task 5: Push and update draft PR
+
+- [ ] **Step 1: Push**
+
+Run: `git push`
+
+- [ ] **Step 2: Mark the draft PR ready for review**
+
+Run: `gh pr ready 60`
+
+- [ ] **Step 3: Verify CI**
+
+Run: `gh pr checks 60 --watch`
+Expected: lint, tests, PII all pass.
+
+If anything fails, diagnose the root cause and add a fix-up commit; do not force-push.
+
+---
+
+## Self-review checklist (done)
+
+- **Spec coverage:** verifyCompany (Task 1), runScan warning (Task 2), formatSummary ⚠ (Task 3), step 5c (Task 4). All four spec sections map to tasks.
+- **No placeholders:** every step has exact file paths, exact commands, concrete code.
+- **Type consistency:** `warning` field is a string or `null` across all sites. Both `perCompany` push sites end up with the same shape (`{company, platform, count, error, warning}`). Warning string is one constant: `'board live but empty — possibly wrong slug'`.
+- **Test-first:** each code task has a failing-test step before implementation.

--- a/docs/superpowers/specs/2026-04-17-empty-board-warning-design.md
+++ b/docs/superpowers/specs/2026-04-17-empty-board-warning-design.md
@@ -1,0 +1,208 @@
+# Empty-board warning — design
+
+**Issue:** [#44](https://github.com/LeoLaborie/claude-apply/issues/44) — `verifyCompany` returns `ok:true` for empty boards (count=0) with no warning.
+
+**Date:** 2026-04-17
+
+## Problem
+
+`verifyCompany('https://jobs.ashbyhq.com/vercel')` returns `{ok: true, count: 0}`. The endpoint is live, but the board exposes zero public jobs. Two indistinguishable cases collapse into the same success response:
+
+1. The company has a hiring freeze or paused listings — the slug is correct.
+2. The slug is wrong (`vercel` instead of `vercel-careers`) or the company has moved off Ashby — the slug is stale.
+
+Today, `/scan` prints `✓ Vercel — 0 raw, 0 new` next to companies with hundreds of offers, and `/apply-onboard:companies` writes `portals.yml` without asking the user to confirm. Silent failure at onboarding is the worst shape: the user assumes the pipeline is healthy.
+
+## Goals
+
+- Surface `count === 0` as a distinct state from `count > 0`, without breaking the existing `{ok: true, count: N}` contract.
+- Emit a visible `⚠` in the `/scan` summary so the user can immediately spot suspicious entries.
+- Force the user to confirm empty boards during `/apply-onboard:companies` before they land in `portals.yml`.
+
+## Non-goals
+
+- Auto-correcting wrong slugs. That's `discoverCompany`'s job (step 5b of onboarding).
+- Distinguishing "slug moved" from "hiring freeze" heuristically. The user decides.
+- Changing the per-ATS `verifySlug` contracts. They keep returning `{ok: true, count: N}` unchanged.
+
+## Architecture
+
+Three isolated changes, each testable independently:
+
+| Module | Change | Tests |
+|---|---|---|
+| `src/scan/ats-detect.mjs` | `verifyCompany` adds `warning` when `ok && count === 0` | `tests/scan/verify-company.test.mjs` |
+| `src/scan/index.mjs` | `runScan` populates `warning` on `perCompany` when `raw === 0 && !error`; `formatSummary` renders `⚠` | `tests/scan/scan.test.mjs` |
+| `.claude/commands/apply-onboard/companies.md` | New step 5c — batch-confirm empty boards | Agent instruction, no unit test |
+
+No new modules. All existing callers of `verifyCompany` continue to work — the new `warning` field is additive.
+
+## Component 1 — `verifyCompany` warning
+
+**File:** `src/scan/ats-detect.mjs`
+
+The dispatcher inspects the `verifySlug` result and injects a `warning` when `count === 0`. Per-ATS `verifySlug` implementations are unchanged.
+
+```js
+export async function verifyCompany(careersUrl) {
+  const det = detectPlatform(careersUrl);
+  if (!det) return { ok: false, reason: 'unknown platform' };
+  const { platform, slug } = det;
+  if (!VERIFIABLE_PLATFORMS.has(platform)) {
+    return { ok: false, reason: `platform ${platform} not supported by verifySlug` };
+  }
+  const mod = await import(`./ats/${platform}.mjs`);
+  const result = await mod.verifySlug(slug);
+  if (result.ok && result.count === 0) {
+    return { ...result, warning: 'board live but empty — possibly wrong slug' };
+  }
+  return result;
+}
+```
+
+### Contract after change
+
+- `{ok: true, count: N}` where `N > 0` — healthy board (unchanged).
+- `{ok: true, count: 0, warning: 'board live but empty — possibly wrong slug'}` — **new**.
+- `{ok: false, status, reason}` — unreachable board (unchanged).
+
+### Tests
+
+Add to `tests/scan/verify-company.test.mjs`:
+
+1. `verifyCompany — count=0 on Ashby adds warning` — mock Ashby returning `{jobs: []}`, assert `{ok: true, count: 0, warning: /empty/}`.
+2. `verifyCompany — count=0 on Lever adds warning` — symmetric for Lever.
+3. `verifyCompany — count>0 does not add warning` — regression guard; assert no `warning` key.
+4. `verifyCompany — ok:false does not add warning` — warning only rides on successful responses.
+
+## Component 2 — `/scan` summary
+
+**Files:** `src/scan/index.mjs`, `tests/scan/scan.test.mjs`
+
+### `runScan` change
+
+`runScan` does not call `verifyCompany` — it calls `fetchX` directly and already knows the raw count per company. So it applies the same policy locally: when `companyRaw === 0 && !companyErr`, it attaches a `warning` to the `perCompany` entry. The `warning` field is `null` otherwise (symmetric with `error`).
+
+Locate the `perCompany.push({...})` block (around src/scan/index.mjs:255) and extend it:
+
+```js
+const warning =
+  !companyErr && companyRaw === 0 ? 'board live but empty — possibly wrong slug' : null;
+perCompany.push({
+  company: companyName,
+  platform,
+  count: companyRaw,
+  newCount: companyNew,
+  error: companyErr,
+  warning,
+});
+```
+
+`warning` and `error` are mutually exclusive: when `error` is set, `warning` is always `null`.
+
+### `formatSummary` change
+
+Replace the `mark`/`note` computation:
+
+```js
+const mark = c.error ? '✗' : c.warning ? '⚠' : '✓';
+const note = c.error
+  ? `(${c.error})`
+  : c.warning
+    ? `(${c.platform} — ${c.warning})`
+    : `(${c.platform})`;
+lines.push(`  ${mark} ${c.company.padEnd(18)} ${String(c.count).padStart(3)} offres ${note}`);
+```
+
+Rendered summary sample:
+
+```
+  ✓ Anthropic          42 offres (lever)
+  ⚠ Vercel              0 offres (ashby — board live but empty — possibly wrong slug)
+  ✗ Broken Corp         0 offres (HTTP 404)
+```
+
+The live progress line (`onProgress` callback) is not changed — warnings are a summary-time concern, not per-tick.
+
+### Tests
+
+Add to `tests/scan/scan.test.mjs`:
+
+1. `runScan — perCompany.warning is set when raw=0 without error`
+2. `runScan — perCompany.warning is null when raw>0`
+3. `runScan — perCompany.warning is null when there is an error` (warning/error exclusivity)
+4. `formatSummary — renders ⚠ for a company with a warning` — assert the output contains `⚠ Vercel` and `board live but empty`.
+
+## Component 3 — `/apply-onboard:companies` confirmation
+
+**File:** `.claude/commands/apply-onboard/companies.md`
+
+Insert a new step 5c between 5b (smart slug discovery) and 6 (trim + approval). Agent-only instruction; no code change.
+
+```markdown
+### 5c. Confirm empty boards
+
+After step 5 + 5b, some candidates may have returned
+`{ok: true, count: 0, warning: ...}` — the board is live but currently
+exposes zero public jobs. This is ambiguous: the company may genuinely
+have a hiring freeze, OR the slug may be wrong (e.g. `vercel` vs
+`vercel-careers`).
+
+If N ≥ 1 candidates carry a `warning`, present the list in a compact
+table:
+
+    Company         ATS     Careers URL
+    ────────────────────────────────────────────────
+    Vercel          ashby   https://jobs.ashbyhq.com/vercel
+
+Then call `AskUserQuestion` once with these exact options:
+
+- `"Drop all empty boards"` — remove every empty-board candidate from
+  the list before step 6.
+- `"Keep all empty boards"` — proceed with them into the step-6
+  approval table as-is.
+- `"Let me decide per company"` — loop over each empty-board candidate
+  and call `AskUserQuestion` with options `Keep`, `Drop`, `Edit URL`.
+  On `Edit URL`, ask the user for the corrected URL and re-verify it
+  via step 5 (`verifyCompany`). If the new URL also returns
+  `count: 0`, ask again. If it returns `ok: false`, drop.
+
+If no candidate has a `warning`, skip this step silently.
+```
+
+The approval gate added in PR #55 (hash-based `assertPortalsApproved`) continues to work — the list submitted to `markPortalsApproved` is whatever survives 5c.
+
+## Data flow
+
+```
+/scan:
+  runScan → fetchX → perCompany[].warning → formatSummary → ⚠ in stdout
+
+/apply-onboard:companies:
+  candidates → verifyCompany → {warning?} → step 5c (AskUserQuestion batch)
+             → step 6 (approval table + AskUserQuestion) → markPortalsApproved
+             → assertPortalsApproved → Write portals.yml
+```
+
+## Error handling
+
+- `verifyCompany` on a non-200 board still returns `{ok: false, ...}` — no warning.
+- `runScan` on a fetch error still sets `error` on `perCompany` — no warning (mutually exclusive).
+- The warning string is a constant, not a user-facing localized message. Agent instruction in 5c renders it verbatim.
+
+## Testing
+
+- **Unit:** 4 new tests in `verify-company.test.mjs`, 4 new in `scan.test.mjs`. Baseline 410 tests must still pass.
+- **Manual:** Re-run `/scan` against a portal configured with a dead slug (e.g. a stale Ashby slug) and confirm the `⚠` line in the summary.
+- **Manual:** Run `/apply-onboard:companies` with one known-empty board in the candidate set; confirm step 5c triggers and accepts all three response paths.
+
+## Risk and rollback
+
+- **Backward compatibility:** The `warning` field is additive. Existing callers that only read `ok` and `count` are unaffected. `/apply-onboard:companies` already references `count: 0` in its docs — this change makes the flag programmatic.
+- **Rollback:** Single-PR revert restores the previous behavior. No migration, no state file changes.
+
+## Out of scope
+
+- Rewriting per-ATS `verifySlug` to classify dead vs alive boards more finely.
+- Adding a `suspect_slugs` cache or history file.
+- Changing `fetchX` fetchers — they already return zero jobs on empty boards, and that path is handled end-to-end by the `warning` propagation above.

--- a/src/scan/ats-detect.mjs
+++ b/src/scan/ats-detect.mjs
@@ -43,5 +43,9 @@ export async function verifyCompany(careersUrl) {
     return { ok: false, reason: `platform ${platform} not supported by verifySlug` };
   }
   const mod = await import(`./ats/${platform}.mjs`);
-  return mod.verifySlug(slug);
+  const result = await mod.verifySlug(slug);
+  if (result.ok && result.count === 0) {
+    return { ...result, warning: 'board live but empty — possibly wrong slug' };
+  }
+  return result;
 }

--- a/src/scan/index.mjs
+++ b/src/scan/index.mjs
@@ -152,6 +152,7 @@ export async function runScan(opts) {
         platform: result.platform,
         count: 0,
         error: result.error,
+        warning: null,
       });
       progressIndex++;
       if (onProgress) {
@@ -168,10 +169,14 @@ export async function runScan(opts) {
       continue;
     }
 
+    const warning =
+      result.offers.length === 0 ? 'board live but empty — possibly wrong slug' : null;
     perCompany.push({
       company: result.company,
       platform: result.platform,
       count: result.offers.length,
+      error: null,
+      warning,
     });
     raw += result.offers.length;
 

--- a/src/scan/index.mjs
+++ b/src/scan/index.mjs
@@ -275,7 +275,7 @@ export async function runScan(opts) {
   return { scanned: companies.length, raw, perCompany, filtered, added, errors, historyWrites };
 }
 
-function formatSummary(result, dryRun) {
+export function formatSummary(result, dryRun) {
   const lines = [];
   const now = new Date().toISOString().slice(0, 16).replace('T', ' ');
   lines.push(`Portal Scan — ${now}`);
@@ -283,8 +283,12 @@ function formatSummary(result, dryRun) {
   lines.push(`Entreprises scannées : ${result.scanned}/${result.scanned}`);
   lines.push(`Offres brutes         : ${result.raw}`);
   for (const c of result.perCompany) {
-    const mark = c.error ? '✗' : '✓';
-    const note = c.error ? `(${c.error})` : `(${c.platform})`;
+    const mark = c.error ? '✗' : c.warning ? '⚠' : '✓';
+    const note = c.error
+      ? `(${c.error})`
+      : c.warning
+        ? `(${c.platform} — ${c.warning})`
+        : `(${c.platform})`;
     lines.push(`  ${mark} ${c.company.padEnd(18)} ${String(c.count).padStart(3)} offres ${note}`);
   }
   lines.push('');

--- a/tests/scan/scan.test.mjs
+++ b/tests/scan/scan.test.mjs
@@ -6,7 +6,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { installMockFetch } from '../helpers.mjs';
-import { runScan } from '../../src/scan/index.mjs';
+import { runScan, formatSummary } from '../../src/scan/index.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.join(__dirname, '..', '..');
@@ -532,6 +532,37 @@ test('runScan — perCompany.warning is null when there is an error', async () =
   } finally {
     restore();
   }
+});
+
+test('formatSummary — renders ⚠ for a company with a warning', () => {
+  const result = {
+    scanned: 2,
+    raw: 5,
+    perCompany: [
+      { company: 'Anthropic', platform: 'lever', count: 5, error: null, warning: null },
+      {
+        company: 'Vercel',
+        platform: 'ashby',
+        count: 0,
+        error: null,
+        warning: 'board live but empty — possibly wrong slug',
+      },
+    ],
+    filtered: {
+      skipped_dup: 0,
+      skipped_title: 0,
+      skipped_blacklist: 0,
+      skipped_location: 0,
+      skipped_date: 0,
+    },
+    added: [],
+    errors: [],
+    historyWrites: 0,
+  };
+  const out = formatSummary(result, true);
+  assert.match(out, /⚠ Vercel/);
+  assert.match(out, /board live but empty/);
+  assert.match(out, /✓ Anthropic/);
 });
 
 test('scan CLI — missing candidate-profile.yml fails with ProfileMissingError', () => {

--- a/tests/scan/scan.test.mjs
+++ b/tests/scan/scan.test.mjs
@@ -412,6 +412,128 @@ test('runScan — sends empty searchText when all positive entries are regex', a
   }
 });
 
+test('runScan — perCompany.warning set when raw=0 without error', async () => {
+  const portalsConfig = {
+    title_filter: { positive: [], negative: [] },
+    tracked_companies: [
+      { name: 'Ghost Town', careers_url: 'https://jobs.ashbyhq.com/ghost', enabled: true },
+    ],
+  };
+  const profile = { blacklist_companies: [], target_locations: ['France'] };
+
+  const restore = installMockFetch({
+    'https://api.ashbyhq.com/posting-api/job-board/ghost?includeCompensation=false': {
+      jobs: [],
+    },
+  });
+
+  const pipelinePath = path.join(tmp, 'pipeline.md');
+  const historyPath = path.join(tmp, 'scan-history.tsv');
+  const filteredPath = path.join(tmp, 'filtered-out.tsv');
+  const applicationsPath = path.join(tmp, 'applications.md');
+  fs.writeFileSync(applicationsPath, '# Apps\n');
+
+  try {
+    const result = await runScan({
+      portalsConfig,
+      profile,
+      pipelinePath,
+      historyPath,
+      filteredPath,
+      applicationsPath,
+      dryRun: true,
+    });
+    assert.equal(result.perCompany.length, 1);
+    const [entry] = result.perCompany;
+    assert.equal(entry.count, 0);
+    assert.equal(entry.error, null);
+    assert.match(entry.warning, /board live but empty/i);
+  } finally {
+    restore();
+  }
+});
+
+test('runScan — perCompany.warning is null when raw>0', async () => {
+  const portalsConfig = {
+    title_filter: { positive: [], negative: [] },
+    tracked_companies: [
+      { name: 'Mistral AI', careers_url: 'https://jobs.lever.co/mistral', enabled: true },
+    ],
+  };
+  const profile = { blacklist_companies: [], target_locations: ['France'] };
+
+  const restore = installMockFetch({
+    'https://api.lever.co/v0/postings/mistral?mode=json': [
+      {
+        hostedUrl: 'https://jobs.lever.co/mistral/a',
+        text: 'Engineer',
+        categories: { location: 'Paris' },
+        descriptionPlain: 'Paris France',
+      },
+    ],
+  });
+
+  const pipelinePath = path.join(tmp, 'pipeline.md');
+  const historyPath = path.join(tmp, 'scan-history.tsv');
+  const filteredPath = path.join(tmp, 'filtered-out.tsv');
+  const applicationsPath = path.join(tmp, 'applications.md');
+  fs.writeFileSync(applicationsPath, '# Apps\n');
+
+  try {
+    const result = await runScan({
+      portalsConfig,
+      profile,
+      pipelinePath,
+      historyPath,
+      filteredPath,
+      applicationsPath,
+      dryRun: true,
+    });
+    assert.equal(result.perCompany.length, 1);
+    assert.equal(result.perCompany[0].warning, null);
+  } finally {
+    restore();
+  }
+});
+
+test('runScan — perCompany.warning is null when there is an error', async () => {
+  const portalsConfig = {
+    title_filter: { positive: [], negative: [] },
+    tracked_companies: [
+      { name: 'Broken', careers_url: 'https://jobs.lever.co/broken', enabled: true },
+    ],
+  };
+  const profile = { blacklist_companies: [], target_locations: ['France'] };
+
+  const restore = installMockFetch({
+    'https://api.lever.co/v0/postings/broken?mode=json': { status: 404, body: null },
+  });
+
+  const pipelinePath = path.join(tmp, 'pipeline.md');
+  const historyPath = path.join(tmp, 'scan-history.tsv');
+  const filteredPath = path.join(tmp, 'filtered-out.tsv');
+  const applicationsPath = path.join(tmp, 'applications.md');
+  fs.writeFileSync(applicationsPath, '# Apps\n');
+
+  try {
+    const result = await runScan({
+      portalsConfig,
+      profile,
+      pipelinePath,
+      historyPath,
+      filteredPath,
+      applicationsPath,
+      dryRun: true,
+    });
+    assert.equal(result.perCompany.length, 1);
+    const [entry] = result.perCompany;
+    assert.ok(entry.error);
+    assert.equal(entry.warning, null);
+  } finally {
+    restore();
+  }
+});
+
 test('scan CLI — missing candidate-profile.yml fails with ProfileMissingError', () => {
   const cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-cfg-'));
   const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-data-'));

--- a/tests/scan/verify-company.test.mjs
+++ b/tests/scan/verify-company.test.mjs
@@ -102,15 +102,15 @@ test('verifyCompany — count=0 on Lever adds warning', async () => {
 
 test('verifyCompany — count>0 does not add warning', async () => {
   restore = installMockFetch({
-    'https://api.lever.co/v0/postings/mistral?mode=json': [{ id: '1' }],
+    'https://api.lever.co/v0/postings/acmecorp?mode=json': [{ id: '1' }, { id: '2' }],
   });
-  const r = await verifyCompany('https://jobs.lever.co/mistral');
+  const r = await verifyCompany('https://jobs.lever.co/acmecorp');
   assert.equal(r.ok, true);
-  assert.equal(r.count, 1);
+  assert.equal(r.count, 2);
   assert.equal(r.warning, undefined);
 });
 
-test('verifyCompany — ok:false does not add warning', async () => {
+test('verifyCompany — ok:false (unknown platform) does not add warning', async () => {
   const r = await verifyCompany('https://careers.example.com/jobs');
   assert.equal(r.ok, false);
   assert.equal(r.warning, undefined);

--- a/tests/scan/verify-company.test.mjs
+++ b/tests/scan/verify-company.test.mjs
@@ -77,3 +77,41 @@ test('verifyCompany — dispatches Workday URL to workday.verifySlug', async () 
     restore();
   }
 });
+
+test('verifyCompany — count=0 on Ashby adds warning', async () => {
+  restore = installMockFetch({
+    'https://api.ashbyhq.com/posting-api/job-board/vercel?includeCompensation=false': {
+      jobs: [],
+    },
+  });
+  const r = await verifyCompany('https://jobs.ashbyhq.com/vercel');
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 0);
+  assert.match(r.warning, /board live but empty/i);
+});
+
+test('verifyCompany — count=0 on Lever adds warning', async () => {
+  restore = installMockFetch({
+    'https://api.lever.co/v0/postings/ghosttown?mode=json': [],
+  });
+  const r = await verifyCompany('https://jobs.lever.co/ghosttown');
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 0);
+  assert.match(r.warning, /board live but empty/i);
+});
+
+test('verifyCompany — count>0 does not add warning', async () => {
+  restore = installMockFetch({
+    'https://api.lever.co/v0/postings/mistral?mode=json': [{ id: '1' }],
+  });
+  const r = await verifyCompany('https://jobs.lever.co/mistral');
+  assert.equal(r.ok, true);
+  assert.equal(r.count, 1);
+  assert.equal(r.warning, undefined);
+});
+
+test('verifyCompany — ok:false does not add warning', async () => {
+  const r = await verifyCompany('https://careers.example.com/jobs');
+  assert.equal(r.ok, false);
+  assert.equal(r.warning, undefined);
+});


### PR DESCRIPTION
## Summary

Draft PR for issue #44. Design spec is committed — implementation follows after user reviews the spec.

- `verifyCompany` returns `{ok: true, count: 0, warning: "board live but empty — possibly wrong slug"}` when a board is live but empty.
- `/scan` summary renders `⚠` next to zero-job companies with the warning inline.
- `/apply-onboard:companies` adds a new step 5c that batch-confirms empty boards via a single `AskUserQuestion` before trimming to ~30.

## Test plan

- [ ] Unit: 4 new tests in \`tests/scan/verify-company.test.mjs\`, 4 new in \`tests/scan/scan.test.mjs\`.
- [ ] Full baseline: \`npm test\` — 410 existing + 8 new = 418 passing.
- [ ] Manual: run \`/scan\` with a stale Ashby slug, confirm \`⚠\` rendering in summary.
- [ ] Manual: run \`/apply-onboard:companies\` with a known-empty candidate, verify step 5c triggers and all three options work.

## Spec

docs/superpowers/specs/2026-04-17-empty-board-warning-design.md

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)