### PR TITLE
fix(config): technical first-run guard for /scan and /score (#46)

### DIFF
--- a/src/lib/config-loader.mjs
+++ b/src/lib/config-loader.mjs
@@ -1,0 +1,18 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export class MissingConfigError extends Error {
+  constructor(filePath) {
+    const rel = path.relative(process.cwd(), filePath) || filePath;
+    super(
+      `${rel} introuvable. Lance d'abord /apply-onboard pour construire tes fichiers de config.`
+    );
+    this.name = 'MissingConfigError';
+    this.code = 'MISSING_CONFIG';
+    this.path = filePath;
+  }
+}
+
+export function requireConfig(filePath) {
+  if (!fs.existsSync(filePath)) throw new MissingConfigError(filePath);
+}

--- a/src/lib/load-profile.mjs
+++ b/src/lib/load-profile.mjs
@@ -1,15 +1,9 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { requireConfig } from './config-loader.mjs';
 import { validateProfile } from './candidate-profile.schema.mjs';
 import { findRepoRoot } from './repo-root.mjs';
-
-export class ProfileMissingError extends Error {
-  constructor(message) {
-    super(message);
-    this.name = 'ProfileMissingError';
-  }
-}
 
 export class ProfileInvalidError extends Error {
   constructor(message, errors) {
@@ -45,11 +39,7 @@ function resolveProfilePaths(profile, repoRoot) {
 
 export async function loadProfile(configDir, { repoRoot } = {}) {
   const profilePath = path.join(configDir, 'candidate-profile.yml');
-  if (!fs.existsSync(profilePath)) {
-    throw new ProfileMissingError(
-      `config/candidate-profile.yml not found in ${configDir} — run /apply-onboard`
-    );
-  }
+  requireConfig(profilePath);
   const yaml = await import('js-yaml');
   const profile = yaml.load(fs.readFileSync(profilePath, 'utf8'));
   const { ok, errors } = validateProfile(profile);

--- a/src/scan/index.mjs
+++ b/src/scan/index.mjs
@@ -27,6 +27,7 @@ import { appendFilteredOut } from '../lib/jsonl-writer.mjs';
 import { readPipelineMd, appendOffer, writePipelineMd } from '../lib/pipeline-md.mjs';
 import { loadSeenUrls, appendHistoryRow } from '../lib/scan-history.mjs';
 import { loadProfile } from '../lib/load-profile.mjs';
+import { MissingConfigError, requireConfig } from '../lib/config-loader.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -340,8 +341,11 @@ async function main() {
     process.env.CLAUDE_APPLY_CONFIG_DIR || path.join(__dirname, '..', '..', 'config');
   const DATA_DIR = process.env.CLAUDE_APPLY_DATA_DIR || path.join(__dirname, '..', '..', 'data');
 
+  const portalsPath = path.join(CONFIG_DIR, 'portals.yml');
+  requireConfig(portalsPath);
+
   const yaml = await import('js-yaml');
-  const portalsConfig = yaml.load(fs.readFileSync(path.join(CONFIG_DIR, 'portals.yml'), 'utf8'));
+  const portalsConfig = yaml.load(fs.readFileSync(portalsPath, 'utf8'));
   const { profile } = await loadProfile(CONFIG_DIR);
 
   const result = await runScan({
@@ -374,6 +378,10 @@ async function main() {
 const isMain = import.meta.url === `file://${process.argv[1]}`;
 if (isMain) {
   main().catch((err) => {
+    if (err instanceof MissingConfigError) {
+      console.error(err.message);
+      process.exit(2);
+    }
     console.error(err);
     process.exit(1);
   });

--- a/src/score/index.mjs
+++ b/src/score/index.mjs
@@ -347,8 +347,8 @@ async function main() {
       return;
     }
 
-    const { profile, cvMarkdown } = await loadProfile(CONFIG_DIR);
     requireConfig(path.join(CONFIG_DIR, 'cv.md'));
+    const { profile, cvMarkdown } = await loadProfile(CONFIG_DIR);
 
     const startId = parseInt(nextId(evalPath), 10);
     const limit = pLimit(flags.parallel);
@@ -523,8 +523,8 @@ async function main() {
     return;
   }
 
-  const { profile, cvMarkdown } = await loadProfile(CONFIG_DIR);
   requireConfig(path.join(CONFIG_DIR, 'cv.md'));
+  const { profile, cvMarkdown } = await loadProfile(CONFIG_DIR);
 
   const { system, user } = buildPrompt({
     cvMarkdown,

--- a/src/score/index.mjs
+++ b/src/score/index.mjs
@@ -18,7 +18,8 @@ import { appendJsonl, appendFilteredOut } from '../lib/jsonl-writer.mjs';
 import { writeTrackerTsv } from '../lib/tsv-writer.mjs';
 import { detectClosedPage } from '../lib/page-liveness.mjs';
 import { runPrefilter } from '../lib/prefilter-rules.mjs';
-import { loadProfile, ProfileMissingError } from '../lib/load-profile.mjs';
+import { loadProfile } from '../lib/load-profile.mjs';
+import { MissingConfigError, requireConfig } from '../lib/config-loader.mjs';
 import { readPipelineMd, findOfferByUrl, parseOfferLine } from '../lib/pipeline-md.mjs';
 import { pLimit } from '../lib/p-limit.mjs';
 
@@ -347,9 +348,7 @@ async function main() {
     }
 
     const { profile, cvMarkdown } = await loadProfile(CONFIG_DIR);
-    if (!cvMarkdown) {
-      throw new ProfileMissingError(`config/cv.md not found in ${CONFIG_DIR} — run /apply-onboard`);
-    }
+    requireConfig(path.join(CONFIG_DIR, 'cv.md'));
 
     const startId = parseInt(nextId(evalPath), 10);
     const limit = pLimit(flags.parallel);
@@ -525,9 +524,7 @@ async function main() {
   }
 
   const { profile, cvMarkdown } = await loadProfile(CONFIG_DIR);
-  if (!cvMarkdown) {
-    throw new ProfileMissingError(`config/cv.md not found in ${CONFIG_DIR} — run /apply-onboard`);
-  }
+  requireConfig(path.join(CONFIG_DIR, 'cv.md'));
 
   const { system, user } = buildPrompt({
     cvMarkdown,
@@ -575,6 +572,10 @@ async function main() {
 
 if (import.meta.url === `file://${process.argv[1]}`) {
   main().catch((err) => {
+    if (err instanceof MissingConfigError) {
+      console.error(err.message);
+      process.exit(2);
+    }
     console.error(err);
     process.exit(3);
   });

--- a/tests/lib/config-loader.test.mjs
+++ b/tests/lib/config-loader.test.mjs
@@ -1,0 +1,62 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { MissingConfigError, requireConfig } from '../../src/lib/config-loader.mjs';
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cfg-loader-'));
+}
+
+test('requireConfig — throws MissingConfigError when file absent', () => {
+  const dir = makeTmpDir();
+  try {
+    const absent = path.join(dir, 'nope.yml');
+    assert.throws(
+      () => requireConfig(absent),
+      (err) => {
+        assert.ok(err instanceof MissingConfigError);
+        assert.equal(err.name, 'MissingConfigError');
+        assert.equal(err.code, 'MISSING_CONFIG');
+        assert.equal(err.path, absent);
+        assert.match(err.message, /introuvable/);
+        assert.match(err.message, /\/apply-onboard/);
+        return true;
+      }
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('requireConfig — does not throw when file exists', () => {
+  const dir = makeTmpDir();
+  try {
+    const file = path.join(dir, 'ok.yml');
+    fs.writeFileSync(file, 'a: 1\n', 'utf8');
+    assert.doesNotThrow(() => requireConfig(file));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('MissingConfigError — message uses path relative to cwd when possible', () => {
+  const dir = makeTmpDir();
+  try {
+    const absent = path.join(dir, 'deep', 'nope.yml');
+    try {
+      requireConfig(absent);
+      assert.fail('expected throw');
+    } catch (err) {
+      assert.ok(err instanceof MissingConfigError);
+      const rel = path.relative(process.cwd(), absent);
+      assert.ok(
+        err.message.startsWith(rel) || err.message.startsWith(absent),
+        `message should start with a path reference, got: ${err.message}`
+      );
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/lib/load-profile.test.mjs
+++ b/tests/lib/load-profile.test.mjs
@@ -5,9 +5,9 @@ import os from 'node:os';
 import path from 'node:path';
 import {
   loadProfile,
-  ProfileMissingError,
   ProfileInvalidError,
 } from '../../src/lib/load-profile.mjs';
+import { MissingConfigError } from '../../src/lib/config-loader.mjs';
 
 function makeTmpDir(prefix = 'load-profile-') {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -58,13 +58,14 @@ test('loadProfile — returns null cvMarkdown when cv.md missing', async () => {
   }
 });
 
-test('loadProfile — throws ProfileMissingError when yml missing', async () => {
+test('loadProfile — throws MissingConfigError when yml missing', async () => {
   const dir = makeTmpDir();
   try {
     await assert.rejects(
       () => loadProfile(dir),
       (err) => {
-        assert.ok(err instanceof ProfileMissingError);
+        assert.ok(err instanceof MissingConfigError);
+        assert.equal(err.code, 'MISSING_CONFIG');
         assert.match(err.message, /candidate-profile\.yml/);
         assert.match(err.message, /\/apply-onboard/);
         return true;

--- a/tests/lib/load-profile.test.mjs
+++ b/tests/lib/load-profile.test.mjs
@@ -3,10 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import {
-  loadProfile,
-  ProfileInvalidError,
-} from '../../src/lib/load-profile.mjs';
+import { loadProfile, ProfileInvalidError } from '../../src/lib/load-profile.mjs';
 import { MissingConfigError } from '../../src/lib/config-loader.mjs';
 
 function makeTmpDir(prefix = 'load-profile-') {

--- a/tests/scan/scan.test.mjs
+++ b/tests/scan/scan.test.mjs
@@ -565,7 +565,7 @@ test('formatSummary — renders ⚠ for a company with a warning', () => {
   assert.match(out, /✓ Anthropic/);
 });
 
-test('scan CLI — missing candidate-profile.yml fails with ProfileMissingError', () => {
+test('scan CLI — missing candidate-profile.yml exits 2 with clean message', () => {
   const cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-cfg-'));
   const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-data-'));
   try {
@@ -588,13 +588,37 @@ test('scan CLI — missing candidate-profile.yml fails with ProfileMissingError'
       }
     );
 
-    assert.notEqual(res.status, 0, 'expected non-zero exit when profile missing');
-    assert.match(
-      res.stderr,
-      /candidate-profile\.yml/,
-      `expected stderr to mention candidate-profile.yml, got: ${res.stderr}`
+    assert.equal(res.status, 2, `expected exit 2, got ${res.status}`);
+    assert.match(res.stderr, /candidate-profile\.yml/);
+    assert.match(res.stderr, /\/apply-onboard/);
+    assert.doesNotMatch(res.stderr, /\bat async\b|\bat Object\./);
+  } finally {
+    fs.rmSync(cfgDir, { recursive: true, force: true });
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
+test('scan CLI — missing portals.yml exits 2 with clean message', () => {
+  const cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-cfg-'));
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-data-'));
+  try {
+    const res = spawnSync(
+      process.execPath,
+      [path.join(REPO_ROOT, 'src', 'scan', 'index.mjs'), '--dry-run', '--json'],
+      {
+        env: {
+          ...process.env,
+          CLAUDE_APPLY_CONFIG_DIR: cfgDir,
+          CLAUDE_APPLY_DATA_DIR: dataDir,
+        },
+        encoding: 'utf8',
+      }
     );
-    assert.match(res.stderr, /\/apply-onboard/, `expected stderr to mention /apply-onboard`);
+
+    assert.equal(res.status, 2, `expected exit 2, got ${res.status}`);
+    assert.match(res.stderr, /portals\.yml/);
+    assert.match(res.stderr, /\/apply-onboard/);
+    assert.doesNotMatch(res.stderr, /\bat async\b|\bat Object\./);
   } finally {
     fs.rmSync(cfgDir, { recursive: true, force: true });
     fs.rmSync(dataDir, { recursive: true, force: true });

--- a/tests/score/main-config-guard.test.mjs
+++ b/tests/score/main-config-guard.test.mjs
@@ -1,0 +1,65 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+test('score CLI — missing candidate-profile.yml exits 2 with clean message', () => {
+  const cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'score-cfg-'));
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'score-data-'));
+  const offerFile = path.join(os.tmpdir(), 'score-offer-test.json');
+
+  // Minimal offer JSON that passes detectClosedPage (no status, no error title)
+  fs.writeFileSync(
+    offerFile,
+    JSON.stringify({
+      url: 'https://example.com/job/senior-engineer',
+      finalUrl: 'https://example.com/job/senior-engineer',
+      title: 'Senior Engineer',
+      body: 'We are looking for a senior engineer to join our growing team. You will work on exciting projects and collaborate with talented colleagues across the globe. Requirements include 5 or more years of experience, proficiency in JavaScript and Node.js, strong communication skills, experience with distributed systems, and a passion for building reliable software systems at scale. We offer competitive salary, fully remote work options, and a comprehensive benefits package including health insurance.',
+      company: 'Example Corp',
+      location: 'Remote',
+      metadata_source: 'json-input',
+    }),
+  );
+
+  // Provide cv.md so the cv guard passes; omit candidate-profile.yml to trigger the profile guard
+  fs.writeFileSync(path.join(cfgDir, 'cv.md'), '# CV\n\nAlice Martin — software engineer.\n');
+
+  try {
+    const res = spawnSync(
+      process.execPath,
+      [
+        path.join(REPO_ROOT, 'src', 'score', 'index.mjs'),
+        '--json-input',
+        offerFile,
+      ],
+      {
+        env: {
+          ...process.env,
+          CLAUDE_APPLY_CONFIG_DIR: cfgDir,
+          CLAUDE_APPLY_DATA_DIR: dataDir,
+        },
+        encoding: 'utf8',
+      },
+    );
+
+    assert.equal(res.status, 2, `expected exit 2 when profile missing, got ${res.status}\nstderr: ${res.stderr}`);
+    assert.match(res.stderr, /candidate-profile\.yml/, 'stderr mentions candidate-profile.yml');
+    assert.match(res.stderr, /\/apply-onboard/, 'stderr mentions /apply-onboard');
+    assert.doesNotMatch(
+      res.stderr,
+      /\bat async\b|\bat Object\./,
+      'stderr must not contain a stack trace',
+    );
+  } finally {
+    fs.rmSync(cfgDir, { recursive: true, force: true });
+    fs.rmSync(dataDir, { recursive: true, force: true });
+    fs.rmSync(offerFile, { force: true });
+  }
+});

--- a/tests/score/main-config-guard.test.mjs
+++ b/tests/score/main-config-guard.test.mjs
@@ -25,7 +25,7 @@ test('score CLI — missing candidate-profile.yml exits 2 with clean message', (
       company: 'Example Corp',
       location: 'Remote',
       metadata_source: 'json-input',
-    }),
+    })
   );
 
   // Provide cv.md so the cv guard passes; omit candidate-profile.yml to trigger the profile guard
@@ -34,11 +34,7 @@ test('score CLI — missing candidate-profile.yml exits 2 with clean message', (
   try {
     const res = spawnSync(
       process.execPath,
-      [
-        path.join(REPO_ROOT, 'src', 'score', 'index.mjs'),
-        '--json-input',
-        offerFile,
-      ],
+      [path.join(REPO_ROOT, 'src', 'score', 'index.mjs'), '--json-input', offerFile],
       {
         env: {
           ...process.env,
@@ -46,16 +42,20 @@ test('score CLI — missing candidate-profile.yml exits 2 with clean message', (
           CLAUDE_APPLY_DATA_DIR: dataDir,
         },
         encoding: 'utf8',
-      },
+      }
     );
 
-    assert.equal(res.status, 2, `expected exit 2 when profile missing, got ${res.status}\nstderr: ${res.stderr}`);
+    assert.equal(
+      res.status,
+      2,
+      `expected exit 2 when profile missing, got ${res.status}\nstderr: ${res.stderr}`
+    );
     assert.match(res.stderr, /candidate-profile\.yml/, 'stderr mentions candidate-profile.yml');
     assert.match(res.stderr, /\/apply-onboard/, 'stderr mentions /apply-onboard');
     assert.doesNotMatch(
       res.stderr,
       /\bat async\b|\bat Object\./,
-      'stderr must not contain a stack trace',
+      'stderr must not contain a stack trace'
     );
   } finally {
     fs.rmSync(cfgDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Closes #46. Adds a physical first-run config guard to `/scan` and `/score` entry points, so they fail with a clear user-facing message instead of a YAML stack trace when config is missing.

- New `src/lib/config-loader.mjs` — `MissingConfigError` + `requireConfig(filePath)`
- `src/lib/load-profile.mjs` — drops local `ProfileMissingError`, uses `requireConfig`
- `src/scan/index.mjs` — guards `portals.yml` before read; catches `MissingConfigError` → exit 2 with message only
- `src/score/index.mjs` — migrates `ProfileMissingError` → `MissingConfigError`; same catch pattern

Scope limited to `/scan` and `/score` (scope A agreed with user). `/apply` stays covered by the textual guard (agentic), `/dashboard` is out of scope.

## Status

**Draft — spec under review.** Spec lives locally at `docs/superpowers/specs/2026-04-17-issue-46-config-guard-design.md` (gitignored per project convention). Implementation follows after spec approval.

## Test plan

- [ ] `node --test tests/lib/config-loader.test.mjs` — unit tests for `requireConfig`
- [ ] `node --test tests/scan/main-config-guard.test.mjs` — `/scan` exit 2 + message, no stack trace
- [ ] `node --test tests/score/main-config-guard.test.mjs` — `/score` exit 2 + message
- [ ] `npm test` — full suite still green (410 baseline)
- [ ] Manual: `rm config/portals.yml && node src/scan/index.mjs` → clean message

🤖 Generated with [Claude Code](https://claude.com/claude-code)