### PR TITLE
fix(scan): filter space-containing slug candidates in discoverCompany

### DIFF
--- a/src/scan/discover-company.mjs
+++ b/src/scan/discover-company.mjs
@@ -47,7 +47,7 @@ export function slugCandidates(name, platform) {
       extras.add(`${b}hq`);
     }
   }
-  return [...base, ...extras];
+  return [...base, ...extras].filter((s) => !s.includes(' '));
 }
 
 export function loadKnownSlugs(cachePath) {

--- a/tests/scan/discover-company.test.mjs
+++ b/tests/scan/discover-company.test.mjs
@@ -46,6 +46,17 @@ test('slugCandidates — multi-mots produit noSpace, hyphen et alnum', () => {
   assert.ok(cands.includes('scale-ai'));
 });
 
+test('slugCandidates — aucun candidat ne contient un espace', () => {
+  for (const platform of ['lever', 'greenhouse', 'ashby']) {
+    const cands = slugCandidates('Hugging Face', platform);
+    for (const slug of cands) {
+      assert.ok(!slug.includes(' '), `slug contient un espace : "${slug}" (platform: ${platform})`);
+    }
+    assert.ok(cands.includes('huggingface'));
+    assert.ok(cands.includes('hugging-face'));
+  }
+});
+
 test('discoverCompany — bascule sur Greenhouse quand Lever échoue', async () => {
   restore = installMockFetch({
     'https://api.lever.co/v0/postings/doctolib?mode=json': { status: 404, body: {} },


### PR DESCRIPTION
## Summary

- `slugCandidates()` incluait `lower` (e.g. `"hugging face"`) dans le Set `base`, produisant des slugs avec espaces qui retournent toujours 404 sur toutes les plateformes ATS
- Ajout d'un `.filter(s => !s.includes(' '))` sur le tableau de retour — une ligne, zéro régression
- Test ajouté : vérifie que pour "Hugging Face" sur lever/greenhouse/ashby, aucun candidat ne contient d'espace, et que `huggingface` et `hugging-face` sont bien présents

## Test plan

- [ ] `node --test tests/scan/discover-company.test.mjs` → 8 pass
- [ ] `npm test` → 435 pass, 0 fail

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)