### PR TITLE
fix(score): extract company name from ATS URL slug (#63)

### DIFF
--- a/src/lib/extract-company.mjs
+++ b/src/lib/extract-company.mjs
@@ -1,0 +1,23 @@
+const PATTERNS = [
+  { re: /^https?:\/\/(?:job-boards|boards)\.greenhouse\.io\/([^/?#]+)/i },
+  { re: /^https?:\/\/jobs\.lever\.co\/([^/?#]+)/i },
+  { re: /^https?:\/\/jobs\.ashbyhq\.com\/([^/?#]+)/i },
+  { re: /^https?:\/\/([^.]+)\.wd\d+\.myworkdayjobs\.com\//i },
+];
+
+function formatSlug(slug) {
+  return slug
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+export function extractCompanyFromUrl(url) {
+  if (!url || typeof url !== 'string') return null;
+  for (const { re } of PATTERNS) {
+    const m = url.match(re);
+    if (m && m[1]) return formatSlug(m[1]);
+  }
+  return null;
+}

--- a/src/score/index.mjs
+++ b/src/score/index.mjs
@@ -22,6 +22,7 @@ import { loadProfile } from '../lib/load-profile.mjs';
 import { MissingConfigError, requireConfig } from '../lib/config-loader.mjs';
 import { readPipelineMd, findOfferByUrl, parseOfferLine } from '../lib/pipeline-md.mjs';
 import { pLimit } from '../lib/p-limit.mjs';
+import { extractCompanyFromUrl } from '../lib/extract-company.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -87,7 +88,7 @@ async function buildOffer(url, overrides = {}) {
       status: fetched.status,
       body: fetched.body,
       title: fetched.scrapedTitle || '',
-      company: fetched.scrapedCompany || '',
+      company: extractCompanyFromUrl(url) || fetched.scrapedCompany || '',
       location: fetched.scrapedLocation || '',
       metadata_source: 'scrape',
     };

--- a/tests/score/extract-company.test.mjs
+++ b/tests/score/extract-company.test.mjs
@@ -1,0 +1,63 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractCompanyFromUrl } from '../../src/lib/extract-company.mjs';
+
+test('Greenhouse job-boards → Doctolib', () => {
+  assert.equal(
+    extractCompanyFromUrl('https://job-boards.greenhouse.io/doctolib/jobs/7642865003'),
+    'Doctolib'
+  );
+});
+
+test('Greenhouse boards (alt) → Alan', () => {
+  assert.equal(extractCompanyFromUrl('https://boards.greenhouse.io/alan/jobs/123'), 'Alan');
+});
+
+test('Lever → Stripe', () => {
+  assert.equal(extractCompanyFromUrl('https://jobs.lever.co/stripe/abc-def-123'), 'Stripe');
+});
+
+test('Ashby avec tiret → Alan Health', () => {
+  assert.equal(
+    extractCompanyFromUrl('https://jobs.ashbyhq.com/alan-health/some-uuid'),
+    'Alan Health'
+  );
+});
+
+test('Workday avec locale → Stripe', () => {
+  assert.equal(
+    extractCompanyFromUrl('https://stripe.wd5.myworkdayjobs.com/en-US/External/job/123'),
+    'Stripe'
+  );
+});
+
+test('Workday sans locale → Stripe', () => {
+  assert.equal(
+    extractCompanyFromUrl('https://stripe.wd5.myworkdayjobs.com/External/job/123'),
+    'Stripe'
+  );
+});
+
+test('URL inconnue → null', () => {
+  assert.equal(extractCompanyFromUrl('https://careers.company.com/jobs/123'), null);
+});
+
+test('URL malformée → null', () => {
+  assert.equal(extractCompanyFromUrl('not-a-url'), null);
+});
+
+test('null → null', () => {
+  assert.equal(extractCompanyFromUrl(null), null);
+});
+
+test('undefined → null', () => {
+  assert.equal(extractCompanyFromUrl(undefined), null);
+});
+
+test('slug vide (double slash) → null', () => {
+  assert.equal(extractCompanyFromUrl('https://jobs.lever.co//abc'), null);
+});
+
+test('slug avec underscore → Acme Corp', () => {
+  assert.equal(extractCompanyFromUrl('https://jobs.lever.co/acme_corp/abc'), 'Acme Corp');
+});


### PR DESCRIPTION
## Summary

- Closes #63 — `company` champ toujours `"unknown"` dans `evaluations.jsonl`
- Nouveau module pur `src/lib/extract-company.mjs` : extrait le slug employeur depuis l'URL pour Greenhouse, Lever, Ashby et Workday
- Intégration dans `buildOffer()` (chemin `scrape` uniquement) — priorité URL slug → scraping DOM → `''`
- 12 tests unitaires, sans réseau ni Playwright

## Test plan

- [x] `node --test tests/score/extract-company.test.mjs` — 12/12 verts
- [x] Suite complète `npm test` — 446/446, 0 régression
- [x] Lint propre (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)