### PR TITLE
fix(scan): required_any now checks title only (#62)

### DIFF
--- a/docs/scan-workflow.md
+++ b/docs/scan-workflow.md
@@ -32,7 +32,7 @@ A URL that doesn't match these patterns is skipped silently. To add a new ATS, s
 
 ## Title filter
 
-`portals.yml.title_filter.positive` / `negative` are whole-word regexes matched against the job **title**. `required_any` is a domain filter matched against the **title and the description**: the keyword can appear in either. This is deliberate — many ML internships are posted with generic titles like "Software Engineering Intern – Data Platform" where the domain keyword only appears in the description. Some ATS fetchers (Workday) do not populate the description field; for those portals, set `skip_required_any: true` per company or add the domain keyword to `positive` instead.
+`portals.yml.title_filter.positive` / `negative` are whole-word regexes matched against the job **title**. `required_any` is a domain filter matched against the **job title only**: at least one keyword must appear in the title. This ensures non-tech roles at tech companies (e.g. "General Secretary Associate intern") are filtered out even when their descriptions mention tech terms casually. Use `skip_required_any: true` per company to bypass this filter for ATS portals whose job titles do not include the domain keyword (e.g. Mistral AI, where the company name alone implies the domain).
 
 Example:
 

--- a/src/lib/prefilter-rules.mjs
+++ b/src/lib/prefilter-rules.mjs
@@ -140,19 +140,17 @@ function findMatch(terms, title) {
 
 export function checkTitle(offer, whitelist) {
   const title = offer.title || '';
-  const body = offer.body || '';
   try {
     const neg = findMatch(whitelist.negative, title);
     if (neg) return { pass: false, reason: `title: negative match "${neg}"` };
     const pos = findMatch(whitelist.positive, title);
     if (!pos) return { pass: false, reason: 'title: no positive match' };
     if (Array.isArray(whitelist.required_any) && whitelist.required_any.length > 0) {
-      const haystack = `${title}\n${body}`;
-      const req = findMatch(whitelist.required_any, haystack);
+      const req = findMatch(whitelist.required_any, title);
       if (!req)
         return {
           pass: false,
-          reason: 'title: missing required_any keyword (searched title + description)',
+          reason: 'title: missing required_any keyword',
         };
     }
     return { pass: true };

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -44,8 +44,8 @@ title_filter:
   negative: []
 
   # Optional domain filter applied *on top of* positive/negative:
-  # if set, the job title OR description must contain at least one of these
-  # keywords (same whole-word semantics and regex escape hatch as above).
+  # if set, the job title must contain at least one of these keywords
+  # (same whole-word semantics and regex escape hatch as above).
   # Leave empty or omit to skip. Use `skip_required_any: true` per company
-  # for ATS fetchers that do not populate the description (e.g. Workday).
+  # to bypass for portals whose titles do not include the domain keyword.
   required_any: []

--- a/tests/lib/prefilter-title.test.mjs
+++ b/tests/lib/prefilter-title.test.mjs
@@ -79,21 +79,9 @@ test('checkTitle: required_any uses word-boundary (regression guard)', () => {
   assert.match(r.reason, /required_any/);
 });
 
-test('checkTitle: required_any matches keyword in body (issue #40 regression)', () => {
+test('checkTitle: required_any fails when keyword absent from title', () => {
   const wl = { positive: ['intern'], negative: [], required_any: ['machine learning'] };
-  const offer = {
-    title: 'Software Engineering Intern - Data Platform',
-    body: 'You will work on our machine learning infrastructure team.',
-  };
-  assert.deepEqual(checkTitle(offer, wl), { pass: true });
-});
-
-test('checkTitle: required_any fails when keyword absent from both title and body', () => {
-  const wl = { positive: ['intern'], negative: [], required_any: ['machine learning'] };
-  const offer = {
-    title: 'Marketing Intern',
-    body: 'Help us plan social media campaigns and write blog posts.',
-  };
+  const offer = { title: 'Marketing Intern' };
   const r = checkTitle(offer, wl);
   assert.equal(r.pass, false);
   assert.match(r.reason, /missing required_any keyword/);
@@ -104,9 +92,20 @@ test('checkTitle: required_any still matches when keyword is only in title', () 
   assert.deepEqual(checkTitle({ title: 'ML Intern', body: '' }, wl), { pass: true });
 });
 
-test('checkTitle: required_any fails cleanly on empty body (Workday case)', () => {
+test('checkTitle: required_any checks title only', () => {
   const wl = { positive: ['intern'], negative: [], required_any: ['ml'] };
   const r = checkTitle({ title: 'Software Engineering Intern', body: '' }, wl);
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /missing required_any keyword/);
+});
+
+test('checkTitle: required_any rejects non-tech title even when body mentions tech keyword (issue #62 regression)', () => {
+  const wl = { positive: ['intern'], negative: [], required_any: ['software', 'engineer', 'AI'] };
+  const offer = {
+    title: 'General Secretary Associate intern',
+    body: 'You will use our software platform to manage documents.',
+  };
+  const r = checkTitle(offer, wl);
   assert.equal(r.pass, false);
   assert.match(r.reason, /missing required_any keyword/);
 });


### PR DESCRIPTION
## Summary

- `checkTitle()` now matches `required_any` keywords against the **job title only** (was: title + description)
- Removes false positives: non-tech roles at tech companies (e.g. "General Secretary Associate intern") were passing the filter because their descriptions casually mentioned "software" or "research"
- Updates docs and template comment to reflect the new title-only semantics

## Test Plan

- [x] New regression test: "General Secretary Associate intern" + body mentioning "software" → correctly rejected
- [x] Removed `issue #40` body-search test (behavior intentionally abandoned)
- [x] 434 tests passing, 0 failures

Closes #62