### PR TITLE
fix(schema): replace cv_fr_path/cv_en_path with single cv_path

### DIFF
--- a/.claude/commands/apply-onboard/profile.md
+++ b/.claude/commands/apply-onboard/profile.md
@@ -42,7 +42,7 @@ Anything genuinely missing becomes a question in step 3.
 
 Create `config/cv.md` as a clean markdown version of the CV. This file is read by `/score` and the cover-letter generator — faithful to the PDF, flowing markdown (no tables, `##` for sections). Do not paraphrase or embellish.
 
-Detect the language from the CV content (usually `fr` or `en`) and copy the source PDF to `config/cv.<lang>.pdf`. Record this as a **repo-relative path** (e.g. `cv_fr_path: config/cv.fr.pdf`) so the profile stays portable between machines. Absolute and `~/`-prefixed paths are also accepted if the user already stores their CV elsewhere.
+Copy the source PDF to `config/cv.pdf`. Record this as a **repo-relative path** (`cv_path: config/cv.pdf`) so the profile stays portable between machines. Absolute and `~/`-prefixed paths are also accepted if the user already stores their CV elsewhere.
 
 ## 2.5. Confirm extracted job-search fields
 
@@ -117,7 +117,7 @@ Sources:
 
 - Extracted from the CV: `first_name`, `last_name`, `email`, `phone`, `linkedin_url`, `github_url`, `city`, `country`, `school`, `degree`, `graduation_year`, `education[]`, `experiences[]`, `languages[]`.
 - From the question block: `availability_start`, `internship_duration_months`, `work_authorization`, `requires_sponsorship`, `auto_apply_min_score`, optionally `blacklist_companies` and `min_start_date`.
-- From step 2: `cv_fr_path` and `cv_en_path`.
+- From step 2: `cv_path`.
 - EEO fields default to `null` unless explicitly provided: `gender`, `ethnicity`, `veteran_status`, `disability_status`.
 
 Do NOT write `config/profile.yml` or `config/profile-condensed.md` — those files are no longer read by any command (`/score` reads `config/cv.md` directly).

--- a/.claude/commands/apply.md
+++ b/.claude/commands/apply.md
@@ -189,7 +189,7 @@ For each field, in DOM order:
 
 - **Known structured class** (`email`, `first_name`, `phone`, …): resolve via `mapProfileValue(classKey, profile)` and fill using the appropriate method. Verify the final value matches.
 
-- **`cv_upload`**: resolve the CV path from the profile (`profile.cv_fr_path` or `profile.cv_en_path` depending on the detected language).
+- **`cv_upload`**: resolve the CV path from the profile (`profile.cv_path`).
 
   **Never use `form_input` or `javascript_tool` for file inputs** — HTTPS pages block `input.value` writes for `type=file`. Some ATSes even appear to accept a JS-injected `DataTransfer` ("Success! <filename>" in the UI) but the backend silently rejects the file at submit. **CDP is mandatory**. Call the helper:
 

--- a/docs/playbooks/apply-workday.md
+++ b/docs/playbooks/apply-workday.md
@@ -111,7 +111,7 @@ Expected fields: first name, last name, email, phone, country, city, postal code
 ### Filling: my-experience
 
 1. **CV upload**: detect `input[type="file"]` in the page. If found:
-   - Resolve CV path: read `profile.cv_fr_path` or `profile.cv_en_path` based on `detectLanguage({ title: role, description: jdText })` from `src/apply/language-detect.mjs`. `loadProfile` already returns absolute paths, so pass the value straight to `--file`.
+   - Resolve CV path: read `profile.cv_path`. `loadProfile` already returns an absolute path, so pass the value straight to `--file`.
    - Upload via CDP:
      ```bash
      node src/apply/upload-file.mjs \

--- a/docs/superpowers/specs/2026-04-17-cv-path-single-field-design.md
+++ b/docs/superpowers/specs/2026-04-17-cv-path-single-field-design.md
@@ -1,0 +1,76 @@
+# Design — Issue #64 : champ unique `cv_path`
+
+**Date :** 2026-04-17  
+**Issue :** [#64](https://github.com/leo-laborie/claude-apply-dev/issues/64) — `cv_en_path` et `cv_fr_path` requis même quand un seul CV existe  
+**Branch :** `fix/issue-64-cv-path-optional`
+
+## Problème
+
+`candidate-profile.schema.mjs` liste `cv_fr_path` et `cv_en_path` dans `REQUIRED_FIELDS`. Le validateur rejette `null` pour l'un ou l'autre, ce qui oblige les candidats avec un seul CV à dupliquer le chemin — comportement trompeur et inutile. Les deux champs contiennent la même information dans la grande majorité des cas.
+
+## Décision
+
+Remplacer `cv_fr_path` et `cv_en_path` par un champ unique obligatoire `cv_path`.
+
+- Breaking change assumé : les profils existants devront renommer leur champ.
+- Approche plus simple que la règle "at-least-one" : un seul champ, une seule validation.
+
+## Fichiers à modifier
+
+### 1. `src/lib/candidate-profile.schema.mjs`
+
+- Retirer `cv_fr_path` et `cv_en_path` de `REQUIRED_FIELDS`
+- Ajouter `cv_path` à `REQUIRED_FIELDS`
+- Retirer les deux anciens champs de `OPTIONAL_FIELDS` s'ils y figurent
+
+### 2. `src/apply/field-classifier.mjs`
+
+Lignes 199-201 utilisent `profile.cv_en_path` comme fallback pour les uploads secondaires. Remplacer par `profile.cv_path` :
+
+```js
+const anyCV = profile.cv_path;
+transcript_upload: profile.transcript_path ?? anyCV,
+portfolio_upload:  profile.portfolio_path  ?? anyCV,
+other_upload:      profile.other_document_path ?? anyCV,
+```
+
+La sélection de langue (`cv_fr_path` ou `cv_en_path` selon la langue détectée) dans `.claude/commands/apply.md` devient simplement `profile.cv_path`.
+
+### 3. `src/lib/load-profile.mjs`
+
+`PATH_FIELDS` contient les deux anciens champs pour la résolution de chemin. Remplacer par `cv_path`.
+
+### 4. `templates/candidate-profile.example.yml`
+
+```yaml
+# Chemin vers votre CV (repo-relative, absolu, ou ~/... acceptés)
+cv_path: config/cv.pdf
+```
+
+Supprimer les deux lignes `cv_fr_path` / `cv_en_path`.
+
+### 5. `.claude/commands/apply.md`
+
+Mettre à jour la référence :
+> `cv_upload` : résoudre le chemin depuis `profile.cv_path`
+
+### 6. Tests (`tests/apply/candidate-profile.test.mjs`)
+
+- Remplacer `cv_fr_path` / `cv_en_path` par `cv_path` dans toutes les fixtures
+- Le test "flags missing required fields" vérifie `cv_path` (pas les deux anciens champs)
+- Ajouter un test : profil avec `cv_path` valide → `ok: true`
+- Ajouter un test : profil sans `cv_path` → erreur `missing required field: cv_path`
+
+## Critères de succès
+
+- `validateProfile` accepte un profil avec seulement `cv_path`
+- `validateProfile` rejette un profil sans `cv_path`
+- `validateProfile` rejette un profil avec `cv_fr_path` ou `cv_en_path` (champs inconnus)
+- Tous les tests existants passent après migration des fixtures
+- Le template d'exemple utilise `cv_path`
+- `npm run check:pii` passe
+
+## Non-objectifs
+
+- Pas de migration automatique des profils utilisateurs existants (breaking change documenté)
+- Pas de support d'alias `cv_fr_path` → `cv_path` pour la rétrocompatibilité

--- a/src/apply/field-classifier.mjs
+++ b/src/apply/field-classifier.mjs
@@ -196,9 +196,9 @@ export function mapProfileValue(classKey, profile, opts = {}) {
     eeo_ethnicity: profile.ethnicity ?? 'Prefer not to say',
     eeo_veteran: profile.veteran_status ?? 'Prefer not to say',
     eeo_disability: profile.disability_status ?? 'Prefer not to say',
-    transcript_upload: profile.transcript_path ?? profile.cv_en_path,
-    portfolio_upload: profile.portfolio_path ?? profile.cv_en_path,
-    other_upload: profile.other_document_path ?? profile.cv_en_path,
+    transcript_upload: profile.transcript_path ?? profile.cv_path,
+    portfolio_upload: profile.portfolio_path ?? profile.cv_path,
+    other_upload: profile.other_document_path ?? profile.cv_path,
   };
   return map[classKey];
 }

--- a/src/lib/candidate-profile.schema.mjs
+++ b/src/lib/candidate-profile.schema.mjs
@@ -14,8 +14,7 @@ export const REQUIRED_FIELDS = [
   'requires_sponsorship',
   'availability_start',
   'internship_duration_months',
-  'cv_fr_path',
-  'cv_en_path',
+  'cv_path',
   'auto_apply_min_score',
 ];
 

--- a/src/lib/load-profile.mjs
+++ b/src/lib/load-profile.mjs
@@ -13,13 +13,7 @@ export class ProfileInvalidError extends Error {
   }
 }
 
-const PATH_FIELDS = [
-  'cv_fr_path',
-  'cv_en_path',
-  'transcript_path',
-  'portfolio_path',
-  'other_document_path',
-];
+const PATH_FIELDS = ['cv_path', 'transcript_path', 'portfolio_path', 'other_document_path'];
 
 function resolveOnePath(p, repoRoot) {
   if (p == null) return p;

--- a/templates/candidate-profile.example.yml
+++ b/templates/candidate-profile.example.yml
@@ -57,9 +57,8 @@ languages:
   - { code: en, level: C1 }
   - { code: es, level: A2 }
 
-# --- CV paths (repo-relative recommended; absolute or ~/... also accepted) ---
-cv_fr_path: config/cv.fr.pdf
-cv_en_path: config/cv.en.pdf
+# --- CV path (repo-relative recommended; absolute or ~/... also accepted) ---
+cv_path: config/cv.pdf
 
 # --- Optional document paths (repo-relative, absolute, or ~/... all accepted) ---
 transcript_path: null # releve de notes / academic transcript

--- a/tests/apply/candidate-profile.test.mjs
+++ b/tests/apply/candidate-profile.test.mjs
@@ -43,8 +43,7 @@ test('validateProfile accepts optional EEO fields as null', () => {
     requires_sponsorship: false,
     availability_start: '2026-09-01',
     internship_duration_months: 6,
-    cv_fr_path: 'candidate-cv-fr.pdf',
-    cv_en_path: 'candidate-cv-en.pdf',
+    cv_path: 'candidate-cv.pdf',
     auto_apply_min_score: 8,
     gender: null,
     ethnicity: null,
@@ -72,8 +71,7 @@ test('validateProfile accepts blacklist_companies and min_start_date as optional
     requires_sponsorship: false,
     availability_start: '2026-09-01',
     internship_duration_months: 6,
-    cv_fr_path: 'candidate-cv-fr.pdf',
-    cv_en_path: 'candidate-cv-en.pdf',
+    cv_path: 'candidate-cv.pdf',
     auto_apply_min_score: 8,
     blacklist_companies: ['Evil Corp', 'Other Co'],
     min_start_date: '2026-08-24',
@@ -99,8 +97,7 @@ test('validateProfile rejects non-array blacklist_companies', () => {
     requires_sponsorship: false,
     availability_start: '2026-09-01',
     internship_duration_months: 6,
-    cv_fr_path: 'a.pdf',
-    cv_en_path: 'b.pdf',
+    cv_path: 'a.pdf',
     auto_apply_min_score: 8,
     blacklist_companies: 'not an array',
   });
@@ -125,11 +122,56 @@ test('validateProfile rejects badly-formatted min_start_date', () => {
     requires_sponsorship: false,
     availability_start: '2026-09-01',
     internship_duration_months: 6,
-    cv_fr_path: 'a.pdf',
-    cv_en_path: 'b.pdf',
+    cv_path: 'a.pdf',
     auto_apply_min_score: 8,
     min_start_date: '24 August 2026',
   });
   assert.equal(ok, false);
   assert.ok(errors.some((e) => e.includes('min_start_date')));
+});
+
+test('validateProfile accepts profile with cv_path only', () => {
+  const { ok, errors } = validateProfile({
+    first_name: 'Alice',
+    last_name: 'Martin',
+    email: 'alice@example.com',
+    phone: '+33600000000',
+    linkedin_url: 'https://linkedin.com/in/a',
+    github_url: 'https://github.com/a',
+    city: 'Paris',
+    country: 'France',
+    school: 'S',
+    degree: 'D',
+    graduation_year: 2026,
+    work_authorization: 'EU',
+    requires_sponsorship: false,
+    availability_start: '2026-09-01',
+    internship_duration_months: 6,
+    cv_path: 'cv.pdf',
+    auto_apply_min_score: 8,
+  });
+  assert.equal(ok, true, `errors: ${JSON.stringify(errors)}`);
+});
+
+test('validateProfile rejects profile without cv_path', () => {
+  const { ok, errors } = validateProfile({
+    first_name: 'Alice',
+    last_name: 'Martin',
+    email: 'alice@example.com',
+    phone: '+33600000000',
+    linkedin_url: 'https://linkedin.com/in/a',
+    github_url: 'https://github.com/a',
+    city: 'Paris',
+    country: 'France',
+    school: 'S',
+    degree: 'D',
+    graduation_year: 2026,
+    work_authorization: 'EU',
+    requires_sponsorship: false,
+    availability_start: '2026-09-01',
+    internship_duration_months: 6,
+    auto_apply_min_score: 8,
+  });
+  assert.equal(ok, false);
+  assert.ok(errors.some((e) => e.includes('cv_path')));
 });

--- a/tests/apply/field-classifier.test.mjs
+++ b/tests/apply/field-classifier.test.mjs
@@ -159,7 +159,7 @@ test('mapProfileValue: transcript/portfolio/other with dedicated paths', () => {
   const profile = {
     first_name: 'Alice',
     last_name: 'Martin',
-    cv_en_path: '/path/to/cv.pdf',
+    cv_path: '/path/to/cv.pdf',
     transcript_path: '/path/to/transcript.pdf',
     portfolio_path: '/path/to/portfolio.pdf',
     other_document_path: '/path/to/other.pdf',
@@ -173,7 +173,7 @@ test('mapProfileValue: transcript/portfolio/other fallback to CV', () => {
   const profile = {
     first_name: 'Alice',
     last_name: 'Martin',
-    cv_en_path: '/path/to/cv.pdf',
+    cv_path: '/path/to/cv.pdf',
   };
   assert.equal(mapProfileValue('transcript_upload', profile), '/path/to/cv.pdf');
   assert.equal(mapProfileValue('portfolio_upload', profile), '/path/to/cv.pdf');

--- a/tests/fixtures/candidate-profile.example.yml
+++ b/tests/fixtures/candidate-profile.example.yml
@@ -62,8 +62,7 @@ ethnicity: null
 veteran_status: null
 disability_status: null
 
-cv_fr_path: candidate-cv-fr.pdf
-cv_en_path: candidate-cv-en.pdf
+cv_path: candidate-cv.pdf
 
 auto_apply_min_score: 8
 

--- a/tests/lib/load-profile.test.mjs
+++ b/tests/lib/load-profile.test.mjs
@@ -25,8 +25,7 @@ work_authorization: EU citizen
 requires_sponsorship: false
 availability_start: '2026-09-01'
 internship_duration_months: 6
-cv_fr_path: a.pdf
-cv_en_path: b.pdf
+cv_path: a.pdf
 auto_apply_min_score: 8
 `;
 
@@ -106,20 +105,18 @@ work_authorization: EU citizen
 requires_sponsorship: false
 availability_start: '2026-09-01'
 internship_duration_months: 6
-cv_fr_path: config/cv.fr.pdf
-cv_en_path: config/cv.en.pdf
+cv_path: config/cv.pdf
 transcript_path: ~/docs/transcript.pdf
 portfolio_path: /abs/portfolio.pdf
 auto_apply_min_score: 8
 `;
 
-test('loadProfile — resolves relative CV paths against explicit repoRoot', async () => {
+test('loadProfile — resolves relative CV path against explicit repoRoot', async () => {
   const dir = makeTmpDir();
   try {
     fs.writeFileSync(path.join(dir, 'candidate-profile.yml'), VALID_YAML_ALL_PATHS);
     const { profile } = await loadProfile(dir, { repoRoot: dir });
-    assert.equal(profile.cv_fr_path, path.join(dir, 'config/cv.fr.pdf'));
-    assert.equal(profile.cv_en_path, path.join(dir, 'config/cv.en.pdf'));
+    assert.equal(profile.cv_path, path.join(dir, 'config/cv.pdf'));
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -167,7 +164,7 @@ test('loadProfile — auto-detects repoRoot via findRepoRoot when not passed', a
     fs.mkdirSync(configDir);
     fs.writeFileSync(path.join(configDir, 'candidate-profile.yml'), VALID_YAML_ALL_PATHS);
     const { profile } = await loadProfile(configDir);
-    assert.equal(profile.cv_fr_path, path.join(fs.realpathSync(repoDir), 'config/cv.fr.pdf'));
+    assert.equal(profile.cv_path, path.join(fs.realpathSync(repoDir), 'config/cv.pdf'));
   } finally {
     fs.rmSync(repoDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Replaces the two required fields `cv_fr_path` and `cv_en_path` with a single required `cv_path` field
- Candidates with one CV no longer need to duplicate the path in both fields
- Updates schema, path resolution, field classifier, template, fixtures, tests, and docs

## Breaking change

Existing `config/candidate-profile.yml` files must rename `cv_fr_path` (or `cv_en_path`) to `cv_path`.

## Test plan

- [x] 436 tests pass (`npm test`)
- [x] `npm run check:pii` — no PII detected
- [x] `npm run lint` — Prettier OK
- [x] New tests: profile with `cv_path` only → valid; profile without `cv_path` → error `missing required field: cv_path`

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)