### PR TITLE
fix(scan): per-company after-filter count in progress output

### DIFF
--- a/docs/superpowers/plans/2026-04-17-scan-filter-count.md
+++ b/docs/superpowers/plans/2026-04-17-scan-filter-count.md
@@ -1,0 +1,636 @@
+# Scan Per-Company Filter Count Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Afficher les compteurs intermédiaires par entreprise dans `/scan` : `431 raw → 2 after filter → 0 new (2 already seen)`.
+
+**Architecture:** Inverser l'ordre des guards (prefilter avant dédup) dans la boucle interne de `runScan()`, ajouter un compteur `afterFilterCount` par entreprise, enrichir `perCompany` + `onProgress`, mettre à jour `formatSummary()` et le stderr de `main()`. Un seul fichier source modifié.
+
+**Tech Stack:** Node 20, ESM, `node:test` (tests), pas de dépendances nouvelles.
+
+---
+
+## Fichiers
+
+- **Modify:** `src/scan/index.mjs` — boucle interne, perCompany, onProgress, formatSummary, stderr
+- **Modify:** `tests/scan/scan.test.mjs` — 3 nouveaux tests + mise à jour des refs `count` → `rawCount`
+
+---
+
+### Task 1 : Tests rouges — nouveaux champs sur perCompany
+
+**Files:**
+- Modify: `tests/scan/scan.test.mjs`
+
+- [ ] **Step 1 : Écrire le test `perCompany expose rawCount, afterFilterCount, newCount`**
+
+Ajouter ce test à la fin de `tests/scan/scan.test.mjs` (après la ligne 627) :
+
+```js
+test('runScan — perCompany expose rawCount, afterFilterCount, newCount', async () => {
+  const portalsConfig = {
+    title_filter: {
+      positive: ['Intern', 'Stage'],
+      negative: ['Senior'],
+    },
+    tracked_companies: [
+      { name: 'Mistral AI', careers_url: 'https://jobs.lever.co/mistral', enabled: true },
+    ],
+  };
+  const profile = {
+    min_start_date: '2026-08-24',
+    blacklist_companies: [],
+    target_locations: ['France', 'Paris', 'Remote'],
+  };
+
+  const leverJson = [
+    {
+      hostedUrl: 'https://jobs.lever.co/mistral/job1',
+      text: 'Research Intern',
+      categories: { location: 'Paris' },
+      descriptionPlain: 'Stage 6 mois Paris France September 2026.',
+    },
+    {
+      hostedUrl: 'https://jobs.lever.co/mistral/job2',
+      text: 'Senior Engineer',
+      categories: { location: 'Paris' },
+      descriptionPlain: 'Senior Paris France.',
+    },
+    {
+      hostedUrl: 'https://jobs.lever.co/mistral/job3',
+      text: 'Data Intern',
+      categories: { location: 'Paris' },
+      descriptionPlain: 'Stage Paris France September 2026.',
+    },
+  ];
+
+  const restore = installMockFetch({
+    'https://api.lever.co/v0/postings/mistral?mode=json': leverJson,
+  });
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-counts-'));
+  const pipelinePath = path.join(tmpDir, 'pipeline.md');
+  const historyPath = path.join(tmpDir, 'scan-history.tsv');
+  const filteredPath = path.join(tmpDir, 'filtered-out.tsv');
+  const applicationsPath = path.join(tmpDir, 'applications.md');
+  fs.writeFileSync(applicationsPath, '# Apps\n');
+
+  try {
+    const result = await runScan({
+      portalsConfig,
+      profile,
+      pipelinePath,
+      historyPath,
+      filteredPath,
+      applicationsPath,
+      dryRun: false,
+    });
+
+    restore();
+
+    assert.equal(result.perCompany.length, 1);
+    const [entry] = result.perCompany;
+    assert.equal(entry.rawCount, 3, 'rawCount should be total ATS offers');
+    assert.equal(entry.afterFilterCount, 2, 'afterFilterCount: 2 pass prefilter (Senior rejected)');
+    assert.equal(entry.newCount, 2, 'newCount: both passed, none are dups');
+  } finally {
+    restore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+```
+
+- [ ] **Step 2 : Vérifier que le test échoue**
+
+```bash
+cd .worktrees/issue-67-scan-filter-count && node --test --test-name-pattern="perCompany expose rawCount" tests/scan/scan.test.mjs
+```
+
+Attendu : FAIL avec `entry.rawCount is not 3` ou `rawCount` undefined.
+
+---
+
+### Task 2 : Tests rouges — formatSummary avec compteurs intermédiaires
+
+**Files:**
+- Modify: `tests/scan/scan.test.mjs`
+
+- [ ] **Step 1 : Écrire le test `formatSummary — cas filtre actif`**
+
+Ajouter après le test de Task 1 :
+
+```js
+test('formatSummary — cas filtre actif affiche raw → after filter → new', () => {
+  const result = {
+    scanned: 1,
+    raw: 10,
+    perCompany: [
+      {
+        company: 'Anthropic',
+        platform: 'lever',
+        rawCount: 10,
+        afterFilterCount: 3,
+        newCount: 1,
+        error: null,
+        warning: null,
+      },
+    ],
+    filtered: {
+      skipped_dup: 2,
+      skipped_title: 7,
+      skipped_blacklist: 0,
+      skipped_location: 0,
+      skipped_date: 0,
+    },
+    added: [{ company: 'Anthropic', title: 'ML Intern', url: 'https://jobs.lever.co/a/1' }],
+    errors: [],
+    historyWrites: 3,
+  };
+  const out = formatSummary(result, false);
+  assert.match(out, /10 raw → 3 after filter → 1 new/);
+});
+```
+
+- [ ] **Step 2 : Écrire le test `formatSummary — cas simplifié`**
+
+Ajouter juste après :
+
+```js
+test('formatSummary — cas simplifié quand afterFilterCount === rawCount', () => {
+  const result = {
+    scanned: 1,
+    raw: 5,
+    perCompany: [
+      {
+        company: 'Mistral AI',
+        platform: 'lever',
+        rawCount: 5,
+        afterFilterCount: 5,
+        newCount: 0,
+        error: null,
+        warning: null,
+      },
+    ],
+    filtered: {
+      skipped_dup: 5,
+      skipped_title: 0,
+      skipped_blacklist: 0,
+      skipped_location: 0,
+      skipped_date: 0,
+    },
+    added: [],
+    errors: [],
+    historyWrites: 0,
+  };
+  const out = formatSummary(result, false);
+  assert.match(out, /5 raw, 0 new/);
+  assert.doesNotMatch(out, /after filter/);
+});
+```
+
+- [ ] **Step 3 : Vérifier que les 2 nouveaux tests échouent**
+
+```bash
+cd .worktrees/issue-67-scan-filter-count && node --test --test-name-pattern="formatSummary — cas" tests/scan/scan.test.mjs
+```
+
+Attendu : 2 FAIL (rawCount/afterFilterCount/newCount undefined dans le mock perCompany).
+
+---
+
+### Task 3 : Mise à jour des tests existants qui référencent `count`
+
+**Files:**
+- Modify: `tests/scan/scan.test.mjs`
+
+- [ ] **Step 1 : Remplacer `entry.count` → `entry.rawCount` (ligne 448)**
+
+Dans le test `runScan — perCompany.warning set when raw=0 without error` (ligne ~446-453) :
+
+```js
+// Avant
+assert.equal(entry.count, 0);
+// Après
+assert.equal(entry.rawCount, 0);
+```
+
+- [ ] **Step 2 : Mettre à jour les objets `perCompany` dans `formatSummary — renders ⚠` (ligne ~537-566)**
+
+Remplacer les deux entrées du mock `perCompany` :
+
+```js
+// Avant
+perCompany: [
+  { company: 'Anthropic', platform: 'lever', count: 5, error: null, warning: null },
+  {
+    company: 'Vercel',
+    platform: 'ashby',
+    count: 0,
+    error: null,
+    warning: 'board live but empty — possibly wrong slug',
+  },
+],
+// Après
+perCompany: [
+  { company: 'Anthropic', platform: 'lever', rawCount: 5, afterFilterCount: 5, newCount: 5, error: null, warning: null },
+  {
+    company: 'Vercel',
+    platform: 'ashby',
+    rawCount: 0,
+    afterFilterCount: 0,
+    newCount: 0,
+    error: null,
+    warning: 'board live but empty — possibly wrong slug',
+  },
+],
+```
+
+- [ ] **Step 3 : Vérifier que les tests modifiés passent encore (suite complète actuelle)**
+
+```bash
+cd .worktrees/issue-67-scan-filter-count && node --test tests/scan/scan.test.mjs 2>&1 | tail -15
+```
+
+Attendu : les 3 nouveaux tests FAIL, les tests existants restent verts.
+
+---
+
+### Task 4 : Implémentation — boucle interne + compteurs
+
+**Files:**
+- Modify: `src/scan/index.mjs:188-270`
+
+- [ ] **Step 1 : Initialiser `companyAfterFilter` avant la boucle d'offres**
+
+Dans `runScan()`, juste avant `let companyNew = 0;` (ligne ~189), ajouter :
+
+```js
+let companyAfterFilter = 0;
+let companyNew = 0;
+```
+
+- [ ] **Step 2 : Inverser l'ordre des guards dans la boucle interne**
+
+Remplacer entièrement la boucle `for (const offer of result.offers)` (lignes 190-256) par :
+
+```js
+for (const offer of result.offers) {
+  let check;
+  try {
+    check = runPrefilter(offer, effectiveConfig);
+  } catch (err) {
+    filtered.skipped_other = (filtered.skipped_other || 0) + 1;
+    errors.push({ company: offer.company, error: `prefilter: ${err.message}` });
+    if (!dryRun && !seen.has(offer.url)) {
+      seen.add(offer.url);
+      appendHistoryRow(historyPath, {
+        url: offer.url,
+        first_seen: today,
+        portal: result.platform,
+        title: offer.title,
+        company: offer.company,
+        status: 'skipped_other',
+      });
+      historyWrites++;
+    }
+    continue;
+  }
+
+  if (!check.pass) {
+    const status = reasonToStatus(check.reason);
+    filtered[status] = (filtered[status] || 0) + 1;
+    if (!dryRun && !seen.has(offer.url)) {
+      seen.add(offer.url);
+      appendHistoryRow(historyPath, {
+        url: offer.url,
+        first_seen: today,
+        portal: result.platform,
+        title: offer.title,
+        company: offer.company,
+        status,
+      });
+      historyWrites++;
+      appendFilteredOut(filteredPath, {
+        date: today,
+        url: offer.url,
+        company: offer.company,
+        title: offer.title,
+        reason: check.reason,
+      });
+    }
+    continue;
+  }
+
+  // Offer passed prefilter — count it before dedup check
+  companyAfterFilter++;
+
+  if (seen.has(offer.url)) {
+    filtered.skipped_dup++;
+    continue;
+  }
+  seen.add(offer.url);
+
+  added.push(offer);
+  companyNew++;
+  appendOffer(doc, offer);
+  if (!dryRun) {
+    appendHistoryRow(historyPath, {
+      url: offer.url,
+      first_seen: today,
+      portal: result.platform,
+      title: offer.title,
+      company: offer.company,
+      status: 'added',
+    });
+    historyWrites++;
+  }
+}
+```
+
+- [ ] **Step 3 : Réinitialiser `companyAfterFilter` et `companyNew` au début de chaque itération**
+
+Les deux variables sont déclarées dans la boucle `for (const result of fetchResults)`. S'assurer qu'elles sont bien initialisées à `0` à chaque itération d'entreprise (juste avant la boucle `for (const offer of result.offers)`).
+
+Vérifier que le code ressemble bien à :
+
+```js
+let companyAfterFilter = 0;
+let companyNew = 0;
+for (const offer of result.offers) {
+  // ...
+}
+```
+
+- [ ] **Step 4 : Vérifier que le premier test rouge passe**
+
+```bash
+cd .worktrees/issue-67-scan-filter-count && node --test --test-name-pattern="perCompany expose rawCount" tests/scan/scan.test.mjs
+```
+
+Attendu : toujours FAIL (perCompany ne retourne pas encore rawCount — Task 5 le fait).
+
+---
+
+### Task 5 : Implémentation — enrichir perCompany et onProgress
+
+**Files:**
+- Modify: `src/scan/index.mjs`
+
+- [ ] **Step 1 : Renommer `count` → `rawCount` et ajouter les nouveaux champs dans `perCompany` (cas normal)**
+
+Trouver le bloc `perCompany.push` pour le cas sans erreur (lignes ~175-181) et le remplacer par :
+
+```js
+const warning =
+  result.offers.length === 0 ? 'board live but empty — possibly wrong slug' : null;
+perCompany.push({
+  company: result.company,
+  platform: result.platform,
+  rawCount: result.offers.length,
+  afterFilterCount: companyAfterFilter,
+  newCount: companyNew,
+  error: null,
+  warning,
+});
+```
+
+Note : ce push a lieu **après** la boucle d'offres, donc `companyAfterFilter` et `companyNew` sont déjà calculés.
+
+Attention : le push `perCompany.push` pour le cas sans erreur se trouve actuellement avant la boucle d'offres (lignes 173-181). Il faut le déplacer **après** la boucle `for (const offer of result.offers)` puisque `companyAfterFilter` et `companyNew` n'existent qu'après.
+
+Le bloc final pour une entreprise sans erreur doit ressembler à :
+
+```js
+let companyAfterFilter = 0;
+let companyNew = 0;
+for (const offer of result.offers) {
+  // ... (boucle Task 4)
+}
+
+const warning =
+  result.offers.length === 0 ? 'board live but empty — possibly wrong slug' : null;
+perCompany.push({
+  company: result.company,
+  platform: result.platform,
+  rawCount: result.offers.length,
+  afterFilterCount: companyAfterFilter,
+  newCount: companyNew,
+  error: null,
+  warning,
+});
+
+progressIndex++;
+if (onProgress) {
+  onProgress({
+    index: progressIndex,
+    total: fetchResults.length,
+    company: result.company,
+    platform: result.platform,
+    rawCount: result.offers.length,
+    afterFilterCount: companyAfterFilter,
+    newCount: companyNew,
+    error: null,
+  });
+}
+```
+
+- [ ] **Step 2 : Mettre à jour le `perCompany.push` du cas d'erreur pour ajouter rawCount/afterFilterCount/newCount**
+
+Trouver le bloc `perCompany.push` dans le `if (result.error)` (lignes ~151-157) et le remplacer par :
+
+```js
+perCompany.push({
+  company: result.company,
+  platform: result.platform,
+  rawCount: 0,
+  afterFilterCount: 0,
+  newCount: 0,
+  error: result.error,
+  warning: null,
+});
+```
+
+- [ ] **Step 3 : Mettre à jour le `onProgress` du cas d'erreur (lignes ~160-168)**
+
+```js
+if (onProgress) {
+  onProgress({
+    index: progressIndex,
+    total: fetchResults.length,
+    company: result.company,
+    platform: result.platform,
+    rawCount: 0,
+    afterFilterCount: 0,
+    newCount: 0,
+    error: result.error,
+  });
+}
+```
+
+- [ ] **Step 4 : Vérifier que les 3 tests rouges de Task 1-2 passent maintenant**
+
+```bash
+cd .worktrees/issue-67-scan-filter-count && node --test --test-name-pattern="perCompany expose rawCount|formatSummary — cas" tests/scan/scan.test.mjs
+```
+
+Attendu : 3 FAIL restants (formatSummary n'est pas encore mis à jour).
+
+---
+
+### Task 6 : Implémentation — formatSummary et stderr
+
+**Files:**
+- Modify: `src/scan/index.mjs:279-323`
+
+- [ ] **Step 1 : Mettre à jour la boucle `perCompany` dans `formatSummary()`**
+
+Remplacer les lignes ~286-294 :
+
+```js
+// Avant
+for (const c of result.perCompany) {
+  const mark = c.error ? '✗' : c.warning ? '⚠' : '✓';
+  const note = c.error
+    ? `(${c.error})`
+    : c.warning
+      ? `(${c.platform} — ${c.warning})`
+      : `(${c.platform})`;
+  lines.push(`  ${mark} ${c.company.padEnd(18)} ${String(c.count).padStart(3)} offres ${note}`);
+}
+```
+
+Par :
+
+```js
+for (const c of result.perCompany) {
+  const mark = c.error ? '✗' : c.warning ? '⚠' : '✓';
+  const note = c.error
+    ? `(${c.error})`
+    : c.warning
+      ? `(${c.platform} — ${c.warning})`
+      : `(${c.platform})`;
+  const counts =
+    c.error || c.rawCount === c.afterFilterCount
+      ? `${c.rawCount} raw, ${c.newCount} new`
+      : `${c.rawCount} raw → ${c.afterFilterCount} after filter → ${c.newCount} new`;
+  lines.push(`  ${mark} ${c.company.padEnd(18)} ${counts} ${note}`);
+}
+```
+
+- [ ] **Step 2 : Mettre à jour la ligne de progress dans `main()` (lignes ~360-368)**
+
+Remplacer le callback `onProgress` :
+
+```js
+// Avant
+onProgress: ({ index, total, company, count, newCount, error }) => {
+  if (error) {
+    process.stderr.write(`[${index}/${total}] \u2717 ${company} \u2014 ${error}\n`);
+  } else {
+    process.stderr.write(
+      `[${index}/${total}] \u2713 ${company} \u2014 ${count} raw, ${newCount} new\n`
+    );
+  }
+},
+```
+
+Par :
+
+```js
+onProgress: ({ index, total, company, rawCount, afterFilterCount, newCount, error }) => {
+  if (error) {
+    process.stderr.write(`[${index}/${total}] \u2717 ${company} \u2014 ${error}\n`);
+  } else {
+    const alreadySeen = afterFilterCount - newCount;
+    const line =
+      afterFilterCount === rawCount
+        ? `${rawCount} raw, ${newCount} new`
+        : `${rawCount} raw \u2192 ${afterFilterCount} after filter \u2192 ${newCount} new (${alreadySeen} already seen)`;
+    process.stderr.write(`[${index}/${total}] \u2713 ${company} \u2014 ${line}\n`);
+  }
+},
+```
+
+- [ ] **Step 3 : Vérifier que tous les tests rouges passent maintenant**
+
+```bash
+cd .worktrees/issue-67-scan-filter-count && node --test --test-name-pattern="perCompany expose rawCount|formatSummary — cas" tests/scan/scan.test.mjs
+```
+
+Attendu : 3 PASS.
+
+---
+
+### Task 7 : Suite complète, lint, commit, PR
+
+**Files:**
+- `src/scan/index.mjs`
+- `tests/scan/scan.test.mjs`
+- `docs/superpowers/specs/2026-04-17-scan-filter-count-design.md`
+
+- [ ] **Step 1 : Exécuter la suite complète**
+
+```bash
+cd .worktrees/issue-67-scan-filter-count && npm test 2>&1 | tail -20
+```
+
+Attendu :
+```
+# tests 437
+# pass 437
+# fail 0
+```
+
+Si des tests échouent à cause de `entry.count` : vérifier que Task 3 a bien été appliquée.
+
+- [ ] **Step 2 : Lint et format**
+
+```bash
+cd .worktrees/issue-67-scan-filter-count && npm run lint && npm run format
+```
+
+Attendu : aucune erreur, fichiers reformatés si besoin.
+
+- [ ] **Step 3 : Re-run des tests après format**
+
+```bash
+cd .worktrees/issue-67-scan-filter-count && npm test 2>&1 | tail -10
+```
+
+Attendu : toujours 437 pass.
+
+- [ ] **Step 4 : Committer la spec (force-add car gitignored)**
+
+```bash
+cd .worktrees/issue-67-scan-filter-count && git add -f docs/superpowers/specs/2026-04-17-scan-filter-count-design.md && git add -f docs/superpowers/plans/2026-04-17-scan-filter-count.md && git commit -m "docs(scan): design spec and implementation plan for per-company filter count (#67)"
+```
+
+- [ ] **Step 5 : Committer l'implémentation**
+
+```bash
+cd .worktrees/issue-67-scan-filter-count && git add src/scan/index.mjs tests/scan/scan.test.mjs && git commit -m "fix(scan): per-company after-filter count in progress output (#67)"
+```
+
+- [ ] **Step 6 : Pousser et créer le PR**
+
+```bash
+cd .worktrees/issue-67-scan-filter-count && git push && gh pr create --draft --title "fix(scan): per-company after-filter count in progress output" --body "$(cat <<'EOF'
+Fixes #67
+
+## Summary
+- Adds intermediate `afterFilterCount` per company in `runScan()` output
+- Inverts guard order (prefilter before dedup) so filtered count is accurate
+- Progress line now shows: `431 raw → 2 after filter → 0 new (2 already seen)`
+- Short form used when no filtering occurs: `5 raw, 0 new`
+
+## Test plan
+- [ ] 3 new tests: perCompany fields, formatSummary active filter, formatSummary short form
+- [ ] Existing warning/error tests updated to use `rawCount` instead of `count`
+- [ ] Full test suite passes (437 tests)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Attendu : URL du PR affiché dans le terminal.

--- a/docs/superpowers/specs/2026-04-17-scan-filter-count-design.md
+++ b/docs/superpowers/specs/2026-04-17-scan-filter-count-design.md
@@ -1,0 +1,106 @@
+# Design : compteurs intermédiaires par entreprise dans /scan
+
+**Issue** : #67  
+**Date** : 2026-04-17  
+**Branche** : fix/issue-67-scan-filter-count
+
+## Problème
+
+La ligne de progression par entreprise n'affiche que le compte brut et les nouvelles offres :
+
+```
+[7/29] ✓ Anthropic — 431 raw, 0 new
+```
+
+Quand `new = 0`, il est impossible de distinguer :
+- toutes les offres déjà vues (dédup), ou
+- toutes les offres rejetées par `title_filter`, ou
+- toutes les offres filtrées par localisation/date.
+
+## Solution retenue : two-pass dans la boucle interne
+
+### Changement dans la boucle interne de `runScan()`
+
+Inverser l'ordre des deux guards (prefilter avant dédup) :
+
+**Avant :**
+```
+1. Check dup → continue (sans passer par prefilter)
+2. runPrefilter() → skip si titre/lieu/date/blacklist
+3. Ajout pipeline
+```
+
+**Après :**
+```
+1. runPrefilter() → si fail : écrire history/filteredOut une seule fois, continue
+2. Check dup → filtered.skipped_dup++, continue
+3. companyAfterFilter++
+4. Ajout pipeline
+```
+
+Cette inversion est sémantiquement plus propre (filtrer d'abord, dédupliquer ensuite) et préserve exactement les mêmes writes disque. La seule différence comportementale : un dup qui aurait aussi échoué au prefilter est maintenant comptabilisé dans `skipped_title` (etc.) plutôt que `skipped_dup`. En pratique cette collision est rare et le total reste cohérent.
+
+### Nouveaux champs dans `perCompany`
+
+```js
+{
+  company,
+  platform,
+  rawCount,         // anciennement count — offres retournées par l'ATS
+  afterFilterCount, // offres passant runPrefilter(), avant dédup
+  newCount,         // offres ajoutées au pipeline
+  error,
+  warning,
+}
+```
+
+`count` est renommé `rawCount` pour la cohérence avec le nouveau nommage.
+
+### Nouveaux champs dans `onProgress`
+
+```js
+onProgress({ index, total, company, platform,
+  rawCount, afterFilterCount, newCount, error });
+```
+
+### Format de sortie
+
+**Cas général (filtre actif) :**
+```
+[7/29] ✓ Anthropic — 431 raw → 2 after filter → 0 new (2 already seen)
+```
+
+**Cas simplifié (afterFilterCount === rawCount, aucune offre filtrée) :**
+```
+[7/29] ✓ Anthropic — 431 raw, 0 new
+```
+
+La forme courte évite le bruit quand le filtre titre est absent ou permissif.
+
+**Dans `formatSummary()` par entreprise :**
+```
+  ✓ Anthropic           431 raw → 2 after filter → 0 new
+  ✓ Mistral              12 raw, 0 new
+```
+
+## Fichiers impactés
+
+| Fichier | Changement |
+|---------|------------|
+| `src/scan/index.mjs` | Inversion guard, nouveaux compteurs, formatSummary, onProgress |
+| `tests/scan/scan.test.mjs` | Assertions sur les nouveaux champs |
+
+## Ce qui ne change pas
+
+- Logique de `runPrefilter()` — aucun changement
+- Format de `pipeline.md`, `scan-history.tsv`, `filtered-out.tsv`
+- API de `runScan()` (paramètres d'entrée)
+- Comportement `--json` (expose déjà `perCompany`)
+
+## Tests
+
+- Scénario "tout filtré par titre" → `afterFilterCount = 0`, `newCount = 0`
+- Scénario "tout vu" → `afterFilterCount = raw`, `newCount = 0`
+- Scénario "mix" → comptes corrects sur chaque étape
+- Format stderr `onProgress` validé par snapshots de chaîne
+- Format `formatSummary` validé sur cas général et cas simplifié

--- a/src/scan/index.mjs
+++ b/src/scan/index.mjs
@@ -151,7 +151,9 @@ export async function runScan(opts) {
       perCompany.push({
         company: result.company,
         platform: result.platform,
-        count: 0,
+        rawCount: 0,
+        afterFilterCount: 0,
+        newCount: 0,
         error: result.error,
         warning: null,
       });
@@ -162,7 +164,8 @@ export async function runScan(opts) {
           total: fetchResults.length,
           company: result.company,
           platform: result.platform,
-          count: 0,
+          rawCount: 0,
+          afterFilterCount: 0,
           newCount: 0,
           error: result.error,
         });
@@ -170,15 +173,6 @@ export async function runScan(opts) {
       continue;
     }
 
-    const warning =
-      result.offers.length === 0 ? 'board live but empty — possibly wrong slug' : null;
-    perCompany.push({
-      company: result.company,
-      platform: result.platform,
-      count: result.offers.length,
-      error: null,
-      warning,
-    });
     raw += result.offers.length;
 
     const companyConfig = companyByName.get(result.company);
@@ -186,23 +180,17 @@ export async function runScan(opts) {
       ? { ...prefilterConfig, whitelist: { ...whitelist, required_any: [] } }
       : prefilterConfig;
 
+    let companyAfterFilter = 0;
     let companyNew = 0;
     for (const offer of result.offers) {
-      if (seen.has(offer.url)) {
-        // URL already in scan-history or applications.md — no need to re-log
-        // (it already has a row with its original status). Just count it.
-        filtered.skipped_dup++;
-        continue;
-      }
-      seen.add(offer.url); // prevent intra-run duplicates
-
       let check;
       try {
         check = runPrefilter(offer, effectiveConfig);
       } catch (err) {
         filtered.skipped_other = (filtered.skipped_other || 0) + 1;
         errors.push({ company: offer.company, error: `prefilter: ${err.message}` });
-        if (!dryRun) {
+        if (!dryRun && !seen.has(offer.url)) {
+          seen.add(offer.url);
           appendHistoryRow(historyPath, {
             url: offer.url,
             first_seen: today,
@@ -215,10 +203,12 @@ export async function runScan(opts) {
         }
         continue;
       }
+
       if (!check.pass) {
         const status = reasonToStatus(check.reason);
         filtered[status] = (filtered[status] || 0) + 1;
-        if (!dryRun) {
+        if (!dryRun && !seen.has(offer.url)) {
+          seen.add(offer.url);
           appendHistoryRow(historyPath, {
             url: offer.url,
             first_seen: today,
@@ -239,6 +229,15 @@ export async function runScan(opts) {
         continue;
       }
 
+      // Offer passed prefilter — count it before dedup check
+      companyAfterFilter++;
+
+      if (seen.has(offer.url)) {
+        filtered.skipped_dup++;
+        continue;
+      }
+      seen.add(offer.url);
+
       added.push(offer);
       companyNew++;
       appendOffer(doc, offer);
@@ -255,6 +254,18 @@ export async function runScan(opts) {
       }
     }
 
+    const warning =
+      result.offers.length === 0 ? 'board live but empty — possibly wrong slug' : null;
+    perCompany.push({
+      company: result.company,
+      platform: result.platform,
+      rawCount: result.offers.length,
+      afterFilterCount: companyAfterFilter,
+      newCount: companyNew,
+      error: null,
+      warning,
+    });
+
     progressIndex++;
     if (onProgress) {
       onProgress({
@@ -262,7 +273,8 @@ export async function runScan(opts) {
         total: fetchResults.length,
         company: result.company,
         platform: result.platform,
-        count: result.offers.length,
+        rawCount: result.offers.length,
+        afterFilterCount: companyAfterFilter,
         newCount: companyNew,
         error: null,
       });
@@ -290,7 +302,11 @@ export function formatSummary(result, dryRun) {
       : c.warning
         ? `(${c.platform} — ${c.warning})`
         : `(${c.platform})`;
-    lines.push(`  ${mark} ${c.company.padEnd(18)} ${String(c.count).padStart(3)} offres ${note}`);
+    const counts =
+      c.error || c.rawCount === c.afterFilterCount
+        ? `${c.rawCount} raw, ${c.newCount} new`
+        : `${c.rawCount} raw → ${c.afterFilterCount} after filter → ${c.newCount} new`;
+    lines.push(`  ${mark} ${c.company.padEnd(18)} ${counts} ${note}`);
   }
   lines.push('');
   lines.push('Filtrage :');
@@ -357,13 +373,16 @@ async function main() {
     applicationsPath: path.join(DATA_DIR, 'applications.md'),
     dryRun,
     onlySlug,
-    onProgress: ({ index, total, company, count, newCount, error }) => {
+    onProgress: ({ index, total, company, rawCount, afterFilterCount, newCount, error }) => {
       if (error) {
         process.stderr.write(`[${index}/${total}] \u2717 ${company} \u2014 ${error}\n`);
       } else {
-        process.stderr.write(
-          `[${index}/${total}] \u2713 ${company} \u2014 ${count} raw, ${newCount} new\n`
-        );
+        const alreadySeen = afterFilterCount - newCount;
+        const line =
+          afterFilterCount === rawCount
+            ? `${rawCount} raw, ${newCount} new`
+            : `${rawCount} raw \u2192 ${afterFilterCount} after filter \u2192 ${newCount} new (${alreadySeen} already seen)`;
+        process.stderr.write(`[${index}/${total}] \u2713 ${company} \u2014 ${line}\n`);
       }
     },
   });

--- a/tests/scan/progress.test.mjs
+++ b/tests/scan/progress.test.mjs
@@ -86,7 +86,7 @@ test('onProgress is called once per company with correct shape', async () => {
   assert.equal(calls[0].total, 2);
   assert.equal(calls[0].company, 'Acme Corp');
   assert.equal(calls[0].platform, 'lever');
-  assert.equal(calls[0].count, 2);
+  assert.equal(calls[0].rawCount, 2);
   assert.equal(calls[0].newCount, 1);
   assert.equal(calls[0].error, null);
 
@@ -95,7 +95,7 @@ test('onProgress is called once per company with correct shape', async () => {
   assert.equal(calls[1].total, 2);
   assert.equal(calls[1].company, 'Beta Inc');
   assert.equal(calls[1].platform, 'ashby');
-  assert.equal(calls[1].count, 1);
+  assert.equal(calls[1].rawCount, 1);
   assert.equal(calls[1].newCount, 1);
   assert.equal(calls[1].error, null);
 });
@@ -138,7 +138,7 @@ test('onProgress reports errors for failing companies', async () => {
   assert.equal(calls[0].index, 1);
   assert.equal(calls[0].total, 1);
   assert.equal(calls[0].company, 'Broken Co');
-  assert.equal(calls[0].count, 0);
+  assert.equal(calls[0].rawCount, 0);
   assert.ok(calls[0].error, 'expected a non-null error');
 });
 

--- a/tests/scan/scan.test.mjs
+++ b/tests/scan/scan.test.mjs
@@ -445,7 +445,7 @@ test('runScan — perCompany.warning set when raw=0 without error', async () => 
     });
     assert.equal(result.perCompany.length, 1);
     const [entry] = result.perCompany;
-    assert.equal(entry.count, 0);
+    assert.equal(entry.rawCount, 0);
     assert.equal(entry.error, null);
     assert.match(entry.warning, /board live but empty/i);
   } finally {
@@ -539,11 +539,21 @@ test('formatSummary — renders ⚠ for a company with a warning', () => {
     scanned: 2,
     raw: 5,
     perCompany: [
-      { company: 'Anthropic', platform: 'lever', count: 5, error: null, warning: null },
+      {
+        company: 'Anthropic',
+        platform: 'lever',
+        rawCount: 5,
+        afterFilterCount: 5,
+        newCount: 5,
+        error: null,
+        warning: null,
+      },
       {
         company: 'Vercel',
         platform: 'ashby',
-        count: 0,
+        rawCount: 0,
+        afterFilterCount: 0,
+        newCount: 0,
         error: null,
         warning: 'board live but empty — possibly wrong slug',
       },
@@ -623,4 +633,135 @@ test('scan CLI — missing portals.yml exits 2 with clean message', () => {
     fs.rmSync(cfgDir, { recursive: true, force: true });
     fs.rmSync(dataDir, { recursive: true, force: true });
   }
+});
+
+test('runScan — perCompany expose rawCount, afterFilterCount, newCount', async () => {
+  const portalsConfig = {
+    title_filter: {
+      positive: ['Intern', 'Stage'],
+      negative: ['Senior'],
+    },
+    tracked_companies: [
+      { name: 'Mistral AI', careers_url: 'https://jobs.lever.co/mistral', enabled: true },
+    ],
+  };
+  const profile = {
+    min_start_date: '2026-08-24',
+    blacklist_companies: [],
+    target_locations: ['France', 'Paris', 'Remote'],
+  };
+
+  const leverJson = [
+    {
+      hostedUrl: 'https://jobs.lever.co/mistral/job1',
+      text: 'Research Intern',
+      categories: { location: 'Paris' },
+      descriptionPlain: 'Stage 6 mois Paris France September 2026.',
+    },
+    {
+      hostedUrl: 'https://jobs.lever.co/mistral/job2',
+      text: 'Senior Engineer',
+      categories: { location: 'Paris' },
+      descriptionPlain: 'Senior Paris France.',
+    },
+    {
+      hostedUrl: 'https://jobs.lever.co/mistral/job3',
+      text: 'Data Intern',
+      categories: { location: 'Paris' },
+      descriptionPlain: 'Stage Paris France September 2026.',
+    },
+  ];
+
+  const restore = installMockFetch({
+    'https://api.lever.co/v0/postings/mistral?mode=json': leverJson,
+  });
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-counts-'));
+  const pipelinePath = path.join(tmpDir, 'pipeline.md');
+  const historyPath = path.join(tmpDir, 'scan-history.tsv');
+  const filteredPath = path.join(tmpDir, 'filtered-out.tsv');
+  const applicationsPath = path.join(tmpDir, 'applications.md');
+  fs.writeFileSync(applicationsPath, '# Apps\n');
+
+  try {
+    const result = await runScan({
+      portalsConfig,
+      profile,
+      pipelinePath,
+      historyPath,
+      filteredPath,
+      applicationsPath,
+      dryRun: false,
+    });
+
+    assert.equal(result.perCompany.length, 1);
+    const [entry] = result.perCompany;
+    assert.equal(entry.rawCount, 3, 'rawCount should be total ATS offers');
+    assert.equal(entry.afterFilterCount, 2, 'afterFilterCount: 2 pass prefilter (Senior rejected)');
+    assert.equal(entry.newCount, 2, 'newCount: both passed, none are dups');
+  } finally {
+    restore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('formatSummary — cas filtre actif affiche raw → after filter → new', () => {
+  const result = {
+    scanned: 1,
+    raw: 10,
+    perCompany: [
+      {
+        company: 'Anthropic',
+        platform: 'lever',
+        rawCount: 10,
+        afterFilterCount: 3,
+        newCount: 1,
+        error: null,
+        warning: null,
+      },
+    ],
+    filtered: {
+      skipped_dup: 2,
+      skipped_title: 7,
+      skipped_blacklist: 0,
+      skipped_location: 0,
+      skipped_date: 0,
+    },
+    added: [{ company: 'Anthropic', title: 'ML Intern', url: 'https://jobs.lever.co/a/1' }],
+    errors: [],
+    historyWrites: 3,
+  };
+  const out = formatSummary(result, false);
+  assert.match(out, /10 raw → 3 after filter → 1 new/);
+});
+
+test('formatSummary — cas simplifié quand afterFilterCount === rawCount', () => {
+  const result = {
+    scanned: 1,
+    raw: 5,
+    perCompany: [
+      {
+        company: 'Mistral AI',
+        platform: 'lever',
+        rawCount: 5,
+        afterFilterCount: 5,
+        newCount: 0,
+        error: null,
+        warning: null,
+      },
+    ],
+    filtered: {
+      skipped_dup: 5,
+      skipped_title: 0,
+      skipped_blacklist: 0,
+      skipped_location: 0,
+      skipped_date: 0,
+    },
+    added: [],
+    errors: [],
+    historyWrites: 0,
+  };
+  const out = formatSummary(result, false);
+  assert.match(out, /5 raw, 0 new/);
+  assert.doesNotMatch(out, /after filter/);
 });


### PR DESCRIPTION
Fixes #67

## Summary
- Adds intermediate `afterFilterCount` per company in `runScan()` output
- Inverts guard order (prefilter before dedup) so filtered count is accurate
- Progress line now shows: `431 raw → 2 after filter → 0 new (2 already seen)`
- Short form used when no filtering occurs: `5 raw, 0 new`

## Test plan
- [x] 3 new tests: perCompany fields, formatSummary active filter, formatSummary short form
- [x] Existing `count` refs updated to `rawCount` (scan.test.mjs + progress.test.mjs)
- [x] Full test suite passes (437 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)