### PR TITLE
feat(score): add --re-score flag to update existing evaluations (#76)

### DIFF
--- a/.claude/commands/score.md
+++ b/.claude/commands/score.md
@@ -44,6 +44,7 @@ The three metadata flags are **all-or-nothing**: pass all three or none. Mixing 
 - `--company "..."` `--role "..."` `--location "..."` — authoritative metadata overrides. Must be passed together.
 - `--id NNN` — force the evaluation id (default: auto-increment from the last line of `evaluations.jsonl`).
 - `--json-input <path>` — bypass URL fetch; read a pre-built offer JSON blob (used by tests and agent pipelines).
+- `--re-score` — re-evaluate an offer already present in `data/evaluations.jsonl`. Preserves the existing `id`; refreshes `score`, `reason`, `date`, `verdict`, `company`, `role`, `location`. Compatible with single URL, `--from-pipeline`, and `--batch`. `--id` is ignored when `--re-score` is used.
 
 ## Output
 
@@ -86,6 +87,29 @@ node src/score/index.mjs --batch [--parallel N]
 Progress is logged to stderr. Each scored record is printed to stdout as a JSON line.
 
 Idempotent: re-running `--batch` only scores offers not yet in `evaluations.jsonl`.
+
+## Re-scoring existing evaluations
+
+Use `--re-score` after updating `config/cv.md`, changing the scoring prompt, or noticing a stale score. It re-fetches the page and rewrites the matching entry in `data/evaluations.jsonl` in place.
+
+```bash
+# Single URL (must already be in evaluations.jsonl)
+node src/score/index.mjs <url> --re-score
+
+# Preferred: pull metadata from pipeline.md
+node src/score/index.mjs <url> --from-pipeline --re-score
+
+# Batch: re-score every offer in pipeline.md.
+# Already-scored offers are overwritten; offers not yet scored are scored for the first time.
+node src/score/index.mjs --batch --re-score
+```
+
+Behaviour:
+
+- The `id` of the existing entry is preserved so report links do not break.
+- The old `data/tracker-additions/<id>-*.tsv` files are deleted before a new TSV is written (useful when company/role — hence the slug — change).
+- If the page is now closed/broken during a re-score, the existing entry is **kept** (not overwritten, not moved to `filtered-out.tsv`). A warning is logged.
+- Single-URL re-score exits 2 if the URL is absent from `evaluations.jsonl`.
 
 ## Next step
 

--- a/docs/superpowers/plans/2026-04-18-rescore-flag.md
+++ b/docs/superpowers/plans/2026-04-18-rescore-flag.md
@@ -1,0 +1,1236 @@
+# `--re-score` Flag Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `--re-score` flag to `src/score/index.mjs` so users can re-evaluate previously scored URLs in-place, in both single-URL and batch modes, without manual file editing.
+
+**Architecture:** Two small library helpers (`updateJsonlEntry`, `removeTrackerTsvById`) handle atomic in-place replacement; `src/score/index.mjs` branches on `flags.reScore` in both the single and batch code paths. In batch mode, writes to `evaluations.jsonl` are serialized via a `pLimit(1)` mutex because update-by-URL is not safe under concurrent read-modify-write; fetching and `claude -p` calls keep their existing parallelism.
+
+**Tech Stack:** Node 20 ESM, `node:test`, `node:fs`, existing `src/lib/p-limit.mjs`.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-rescore-flag-design.md`
+
+---
+
+## Task 1: `updateJsonlEntry` helper (atomic in-place update)
+
+**Files:**
+- Modify: `src/lib/jsonl-writer.mjs`
+- Test: `tests/lib/jsonl-writer.test.mjs`
+
+- [ ] **Step 1: Write failing test — match found, replace line**
+
+Append to `tests/lib/jsonl-writer.test.mjs` (keep the existing `tmp`, `afterEach`, and imports; add `updateJsonlEntry` to the import statement at the top):
+
+```javascript
+import { appendJsonl, appendFilteredOut, updateJsonlEntry } from '../../src/lib/jsonl-writer.mjs';
+```
+
+```javascript
+test('updateJsonlEntry — remplace la première ligne correspondante', () => {
+  const p = path.join(tmp, 'evals.jsonl');
+  appendJsonl(p, { id: '001', url: 'https://a/1', score: 3.0 });
+  appendJsonl(p, { id: '002', url: 'https://a/2', score: 4.0 });
+  appendJsonl(p, { id: '003', url: 'https://a/3', score: 5.0 });
+
+  const prev = updateJsonlEntry(
+    p,
+    (e) => e.url === 'https://a/2',
+    { id: '002', url: 'https://a/2', score: 4.5 }
+  );
+
+  assert.deepEqual(prev, { id: '002', url: 'https://a/2', score: 4.0 });
+  const lines = fs.readFileSync(p, 'utf8').trim().split('\n').map((l) => JSON.parse(l));
+  assert.equal(lines.length, 3);
+  assert.deepEqual(lines[0], { id: '001', url: 'https://a/1', score: 3.0 });
+  assert.deepEqual(lines[1], { id: '002', url: 'https://a/2', score: 4.5 });
+  assert.deepEqual(lines[2], { id: '003', url: 'https://a/3', score: 5.0 });
+});
+
+test('updateJsonlEntry — retourne null et ne modifie rien quand rien ne match', () => {
+  const p = path.join(tmp, 'evals.jsonl');
+  appendJsonl(p, { id: '001', url: 'https://a/1', score: 3.0 });
+  const before = fs.readFileSync(p, 'utf8');
+
+  const prev = updateJsonlEntry(p, (e) => e.url === 'https://missing', { id: '999' });
+
+  assert.equal(prev, null);
+  const after = fs.readFileSync(p, 'utf8');
+  assert.equal(before, after);
+});
+
+test('updateJsonlEntry — préserve les lignes JSON invalides sans crasher', () => {
+  const p = path.join(tmp, 'evals.jsonl');
+  fs.writeFileSync(
+    p,
+    [
+      JSON.stringify({ id: '001', url: 'https://a/1' }),
+      'this is not json',
+      JSON.stringify({ id: '002', url: 'https://a/2' }),
+    ].join('\n') + '\n'
+  );
+
+  updateJsonlEntry(p, (e) => e.url === 'https://a/2', { id: '002', url: 'https://a/2', score: 9 });
+
+  const lines = fs.readFileSync(p, 'utf8').trim().split('\n');
+  assert.equal(lines.length, 3);
+  assert.equal(lines[1], 'this is not json');
+  assert.deepEqual(JSON.parse(lines[2]), { id: '002', url: 'https://a/2', score: 9 });
+});
+
+test('updateJsonlEntry — file manquant retourne null', () => {
+  const p = path.join(tmp, 'missing.jsonl');
+  const prev = updateJsonlEntry(p, () => true, {});
+  assert.equal(prev, null);
+  assert.equal(fs.existsSync(p), false);
+});
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `node --test tests/lib/jsonl-writer.test.mjs`
+Expected: 4 new tests FAIL (`updateJsonlEntry is not a function` or similar).
+
+- [ ] **Step 3: Implement `updateJsonlEntry`**
+
+Edit `src/lib/jsonl-writer.mjs`, add at the bottom of the file:
+
+```javascript
+export function updateJsonlEntry(filePath, matchFn, newObj) {
+  if (!fs.existsSync(filePath)) return null;
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const lines = raw.split('\n');
+  let previous = null;
+  let matchedIdx = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line) continue;
+    let obj;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (matchFn(obj)) {
+      previous = obj;
+      matchedIdx = i;
+      break;
+    }
+  }
+
+  if (matchedIdx === -1) return null;
+
+  lines[matchedIdx] = JSON.stringify(newObj);
+  const output = lines.join('\n');
+  const tmpPath = filePath + '.tmp';
+  fs.writeFileSync(tmpPath, output, 'utf8');
+  fs.renameSync(tmpPath, filePath);
+  return previous;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `node --test tests/lib/jsonl-writer.test.mjs`
+Expected: all tests in the file PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/jsonl-writer.mjs tests/lib/jsonl-writer.test.mjs
+git commit -m "feat(lib): add updateJsonlEntry helper for atomic in-place JSONL updates (#76)"
+```
+
+---
+
+## Task 2: `removeTrackerTsvById` helper
+
+**Files:**
+- Modify: `src/lib/tsv-writer.mjs`
+- Test: `tests/lib/tsv-writer.test.mjs` (new file)
+
+- [ ] **Step 1: Create the test file with failing tests**
+
+Create `tests/lib/tsv-writer.test.mjs`:
+
+```javascript
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { writeTrackerTsv, removeTrackerTsvById } from '../../src/lib/tsv-writer.mjs';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tsv-writer-'));
+
+afterEach(() => {
+  for (const f of fs.readdirSync(tmp)) fs.unlinkSync(path.join(tmp, f));
+});
+
+test('removeTrackerTsvById — supprime les fichiers préfixés par <id>-', () => {
+  fs.writeFileSync(path.join(tmp, '042-acme.tsv'), 'x\n');
+  fs.writeFileSync(path.join(tmp, '042-other-slug.tsv'), 'x\n');
+  fs.writeFileSync(path.join(tmp, '043-kept.tsv'), 'x\n');
+  fs.writeFileSync(path.join(tmp, '042.tsv'), 'x\n'); // no dash → not matched
+
+  const removed = removeTrackerTsvById(tmp, '042');
+  assert.equal(removed.length, 2);
+  assert.ok(removed.includes('042-acme.tsv'));
+  assert.ok(removed.includes('042-other-slug.tsv'));
+  const remaining = fs.readdirSync(tmp).sort();
+  assert.deepEqual(remaining, ['042.tsv', '043-kept.tsv']);
+});
+
+test('removeTrackerTsvById — dir manquant renvoie tableau vide', () => {
+  const removed = removeTrackerTsvById(path.join(tmp, 'missing-dir'), '001');
+  assert.deepEqual(removed, []);
+});
+
+test('removeTrackerTsvById — aucun fichier matchant renvoie tableau vide', () => {
+  fs.writeFileSync(path.join(tmp, '010-keep.tsv'), 'x\n');
+  const removed = removeTrackerTsvById(tmp, '042');
+  assert.deepEqual(removed, []);
+  assert.equal(fs.existsSync(path.join(tmp, '010-keep.tsv')), true);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test tests/lib/tsv-writer.test.mjs`
+Expected: FAIL on `removeTrackerTsvById is not a function`.
+
+- [ ] **Step 3: Implement `removeTrackerTsvById`**
+
+Edit `src/lib/tsv-writer.mjs`, append at the end of the file:
+
+```javascript
+export function removeTrackerTsvById(dir, id) {
+  if (!fs.existsSync(dir)) return [];
+  const prefix = `${id}-`;
+  const removed = [];
+  for (const name of fs.readdirSync(dir)) {
+    if (name.startsWith(prefix) && name.endsWith('.tsv')) {
+      fs.unlinkSync(path.join(dir, name));
+      removed.push(name);
+    }
+  }
+  return removed;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/lib/tsv-writer.test.mjs`
+Expected: all 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/tsv-writer.mjs tests/lib/tsv-writer.test.mjs
+git commit -m "feat(lib): add removeTrackerTsvById helper (#76)"
+```
+
+---
+
+## Task 3: Parse `--re-score` in `parseScoreArgs`
+
+**Files:**
+- Modify: `src/score/index.mjs` (function `parseScoreArgs`)
+- Test: `tests/score/metadata-source.test.mjs` (append cases)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/score/metadata-source.test.mjs`:
+
+```javascript
+test('parseScoreArgs — --re-score flag (single URL)', () => {
+  const f = parseScoreArgs(['https://jobs.example.com/a', '--re-score']);
+  assert.equal(f.reScore, true);
+  assert.equal(f.url, 'https://jobs.example.com/a');
+  assert.equal(f.batch, false);
+});
+
+test('parseScoreArgs — --re-score + --batch', () => {
+  const f = parseScoreArgs(['--batch', '--re-score']);
+  assert.equal(f.reScore, true);
+  assert.equal(f.batch, true);
+});
+
+test('parseScoreArgs — --re-score + --from-pipeline', () => {
+  const f = parseScoreArgs(['https://jobs.example.com/a', '--from-pipeline', '--re-score']);
+  assert.equal(f.reScore, true);
+  assert.equal(f.fromPipeline, true);
+});
+
+test('parseScoreArgs — --re-score absent → false par défaut', () => {
+  const f = parseScoreArgs(['https://jobs.example.com/a']);
+  assert.equal(f.reScore, false);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test tests/score/metadata-source.test.mjs`
+Expected: 4 new tests FAIL (`f.reScore` is `undefined`, not `true`/`false`).
+
+- [ ] **Step 3: Add `reScore` to `parseScoreArgs`**
+
+In `src/score/index.mjs`, find the `flags` object in `parseScoreArgs` (around line 269–280) and add `reScore: false` to the defaults:
+
+```javascript
+const flags = {
+  url: null,
+  jsonInput: null,
+  id: null,
+  company: null,
+  role: null,
+  location: null,
+  fromPipeline: false,
+  batch: false,
+  parallel: 5,
+  reScore: false,
+};
+```
+
+Then, after the `--batch` handling block (around line 300–304), add a block to detect `--re-score`:
+
+```javascript
+const rsIdx = args.indexOf('--re-score');
+if (rsIdx !== -1) {
+  flags.reScore = true;
+  args.splice(rsIdx, 1);
+}
+```
+
+Place this block **before** `flags.url = args.find(...)` so the positional URL extraction works correctly.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/score/metadata-source.test.mjs`
+Expected: all tests PASS (old + new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/score/index.mjs tests/score/metadata-source.test.mjs
+git commit -m "feat(score): parse --re-score flag (#76)"
+```
+
+---
+
+## Task 4: `findEvaluationByUrl` helper + export
+
+**Files:**
+- Modify: `src/score/index.mjs`
+- Test: `tests/score/score-batch.test.mjs` (append)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/score/score-batch.test.mjs`:
+
+```javascript
+import { findEvaluationByUrl } from '../../src/score/index.mjs';
+
+test('findEvaluationByUrl — retourne l\'entrée quand l\'URL existe', () => {
+  const tmp = mkTmp();
+  const evalPath = path.join(tmp, 'data', 'evaluations.jsonl');
+  fs.writeFileSync(
+    evalPath,
+    [
+      JSON.stringify({ id: '001', url: 'https://a/1', score: 3 }),
+      JSON.stringify({ id: '002', url: 'https://a/2', score: 4 }),
+    ].join('\n') + '\n'
+  );
+  const hit = findEvaluationByUrl(evalPath, 'https://a/2');
+  assert.equal(hit.id, '002');
+  assert.equal(hit.score, 4);
+});
+
+test('findEvaluationByUrl — null quand l\'URL est absente', () => {
+  const tmp = mkTmp();
+  const evalPath = path.join(tmp, 'data', 'evaluations.jsonl');
+  fs.writeFileSync(evalPath, JSON.stringify({ id: '001', url: 'https://a/1' }) + '\n');
+  assert.equal(findEvaluationByUrl(evalPath, 'https://missing'), null);
+});
+
+test('findEvaluationByUrl — null quand le fichier n\'existe pas', () => {
+  assert.equal(findEvaluationByUrl('/tmp/nonexistent-evals.jsonl', 'https://x'), null);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test tests/score/score-batch.test.mjs`
+Expected: FAIL on `findEvaluationByUrl is not a function` / import error.
+
+- [ ] **Step 3: Implement and export `findEvaluationByUrl`**
+
+In `src/score/index.mjs`, add after `getScoredUrls`:
+
+```javascript
+export function findEvaluationByUrl(evaluationsPath, url) {
+  if (!fs.existsSync(evaluationsPath)) return null;
+  const lines = fs.readFileSync(evaluationsPath, 'utf8').trim().split('\n').filter(Boolean);
+  for (const line of lines) {
+    try {
+      const obj = JSON.parse(line);
+      if (obj.url === url) return obj;
+    } catch {}
+  }
+  return null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/score/score-batch.test.mjs`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/score/index.mjs tests/score/score-batch.test.mjs
+git commit -m "feat(score): add findEvaluationByUrl helper (#76)"
+```
+
+---
+
+## Task 5: Single-URL `--re-score` flow
+
+**Files:**
+- Modify: `src/score/index.mjs` (imports + `main`)
+- Test: `tests/score/score-rescore.test.mjs` (new file)
+
+- [ ] **Step 1: Create the failing integration test**
+
+Create `tests/score/score-rescore.test.mjs`:
+
+```javascript
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const scoreBin = path.join(repoRoot, 'src/score/index.mjs');
+
+function mkTmp() {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'score-rescore-'));
+  fs.mkdirSync(path.join(d, 'config'), { recursive: true });
+  fs.mkdirSync(path.join(d, 'data', 'tracker-additions'), { recursive: true });
+  fs.writeFileSync(path.join(d, 'config', 'cv.md'), '# CV\nDummy.\n');
+  return d;
+}
+
+function writeOfferJson(dir, offer) {
+  const p = path.join(dir, 'offer.json');
+  fs.writeFileSync(p, JSON.stringify(offer));
+  return p;
+}
+
+function runScore(args, tmp, extraEnv = {}) {
+  return spawnSync('node', [scoreBin, ...args], {
+    env: {
+      ...process.env,
+      CLAUDE_APPLY_CONFIG_DIR: path.join(tmp, 'config'),
+      CLAUDE_APPLY_DATA_DIR: path.join(tmp, 'data'),
+      ...extraEnv,
+    },
+    encoding: 'utf8',
+  });
+}
+
+test('--re-score: URL absente de evaluations.jsonl → exit 2', () => {
+  const tmp = mkTmp();
+  const evalPath = path.join(tmp, 'data', 'evaluations.jsonl');
+  fs.writeFileSync(
+    evalPath,
+    JSON.stringify({ id: '001', url: 'https://other/1', score: 3.0 }) + '\n'
+  );
+  const offerPath = writeOfferJson(tmp, { url: 'https://missing/1', body: 'x' });
+
+  const proc = runScore(['--json-input', offerPath, '--re-score'], tmp);
+
+  assert.equal(proc.status, 2);
+  assert.match(proc.stderr, /not found in .*evaluations\.jsonl/);
+});
+
+test('--re-score: URL présente → remplace la ligne, préserve l\'id, supprime l\'ancien TSV', () => {
+  const tmp = mkTmp();
+  const evalPath = path.join(tmp, 'data', 'evaluations.jsonl');
+  const tsvDir = path.join(tmp, 'data', 'tracker-additions');
+
+  fs.writeFileSync(
+    evalPath,
+    [
+      JSON.stringify({
+        id: '007',
+        date: '2026-01-01',
+        company: 'OldCo',
+        role: 'Old Role',
+        url: 'https://x/7',
+        score: 2.0,
+        verdict: 'skip',
+        reason: 'old reason',
+        status: 'Evaluated',
+      }),
+      JSON.stringify({ id: '008', url: 'https://x/8', score: 4.0 }),
+    ].join('\n') + '\n'
+  );
+  fs.writeFileSync(path.join(tsvDir, '007-oldco.tsv'), 'old tsv\n');
+
+  const offerPath = writeOfferJson(tmp, {
+    url: 'https://x/7',
+    finalUrl: 'https://x/7',
+    status: 200,
+    body: 'Full JD text. We are looking for a senior engineer.',
+    company: 'NewCo',
+    title: 'Senior Engineer',
+    location: 'Paris',
+    metadata_source: 'json-input',
+  });
+
+  const proc = runScore(['--json-input', offerPath, '--re-score'], tmp, {
+    CLAUDE_APPLY_STUB_SCORE: '4.5',
+    CLAUDE_APPLY_STUB_REASON: 'much better fit now',
+  });
+
+  assert.equal(proc.status, 0, `stderr: ${proc.stderr}`);
+  const lines = fs
+    .readFileSync(evalPath, 'utf8')
+    .trim()
+    .split('\n')
+    .map((l) => JSON.parse(l));
+  assert.equal(lines.length, 2);
+  const updated = lines.find((l) => l.url === 'https://x/7');
+  assert.equal(updated.id, '007');
+  assert.equal(updated.score, 4.5);
+  assert.equal(updated.reason, 'much better fit now');
+  assert.equal(updated.company, 'NewCo');
+  assert.equal(updated.role, 'Senior Engineer');
+  assert.notEqual(updated.date, '2026-01-01');
+  assert.equal(fs.existsSync(path.join(tsvDir, '007-oldco.tsv')), false);
+  const newTsvs = fs.readdirSync(tsvDir).filter((f) => f.startsWith('007-'));
+  assert.equal(newTsvs.length, 1);
+  assert.match(newTsvs[0], /^007-newco\.tsv$/);
+});
+
+test('--re-score + --id NNN: --id ignoré, id existant préservé (warning stderr)', () => {
+  const tmp = mkTmp();
+  const evalPath = path.join(tmp, 'data', 'evaluations.jsonl');
+  fs.writeFileSync(
+    evalPath,
+    JSON.stringify({
+      id: '005',
+      url: 'https://x/5',
+      company: 'C',
+      role: 'R',
+      score: 3,
+    }) + '\n'
+  );
+  const offerPath = writeOfferJson(tmp, {
+    url: 'https://x/5',
+    body: 'jd',
+    company: 'C',
+    title: 'R',
+  });
+
+  const proc = runScore(['--json-input', offerPath, '--re-score', '--id', '999'], tmp, {
+    CLAUDE_APPLY_STUB_SCORE: '3.5',
+    CLAUDE_APPLY_STUB_REASON: 'ok',
+  });
+
+  assert.equal(proc.status, 0);
+  assert.match(proc.stderr, /--id ignored.*preserving existing id 005/);
+  const line = JSON.parse(fs.readFileSync(evalPath, 'utf8').trim());
+  assert.equal(line.id, '005');
+  assert.equal(line.score, 3.5);
+});
+```
+
+Note: these tests rely on a `CLAUDE_APPLY_STUB_SCORE` / `_REASON` stub for `callClaudeAsync`. This stub will be added in the same task as part of the implementation.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test tests/score/score-rescore.test.mjs`
+Expected: all 3 tests FAIL (exit status mismatches, missing behaviour).
+
+- [ ] **Step 3: Add the Claude stub for tests**
+
+In `src/score/index.mjs`, modify `callClaudeAsync` so that when `process.env.CLAUDE_APPLY_STUB_SCORE` is set it short-circuits the spawn and returns a stub result. Add at the top of `callClaudeAsync` (before the `spawn` call):
+
+```javascript
+export function callClaudeAsync(system, user) {
+  if (process.env.CLAUDE_APPLY_STUB_SCORE) {
+    const score = parseFloat(process.env.CLAUDE_APPLY_STUB_SCORE);
+    const reason = process.env.CLAUDE_APPLY_STUB_REASON || 'stubbed reason';
+    return Promise.resolve(JSON.stringify({ score, reason }));
+  }
+  const emptyMcpPath = path.join(os.tmpdir(), 'claude-apply-empty-mcp.json');
+  // ... rest unchanged
+```
+
+- [ ] **Step 4: Add imports for the new helpers**
+
+At the top of `src/score/index.mjs`, update the imports so `updateJsonlEntry` and `findEvaluationByUrl` and `removeTrackerTsvById` are available:
+
+```javascript
+import { appendJsonl, appendFilteredOut, updateJsonlEntry } from '../lib/jsonl-writer.mjs';
+import { writeTrackerTsv, removeTrackerTsvById } from '../lib/tsv-writer.mjs';
+```
+
+(`findEvaluationByUrl` is defined in this same file — no import needed.)
+
+- [ ] **Step 5: Implement the single-URL re-score branch in `main()`**
+
+In `src/score/index.mjs`, inside `main()`, after `requireConfig(...)` and `loadProfile(...)` calls in the **single-URL path** (i.e. after the `offer` is fully built and liveness has been checked), replace the final write block:
+
+Find the block that looks like:
+
+```javascript
+  const evalPath = path.join(DATA_DIR, 'evaluations.jsonl');
+  const id = flags.id || nextId(evalPath);
+  const date = new Date().toISOString().slice(0, 10);
+  const record = { /* ... */ };
+  appendJsonl(evalPath, record);
+
+  const tsvDir = path.join(DATA_DIR, 'tracker-additions');
+  writeTrackerTsv(tsvDir, { /* ... */ });
+
+  console.log(JSON.stringify(record));
+```
+
+Replace with:
+
+```javascript
+  const evalPath = path.join(DATA_DIR, 'evaluations.jsonl');
+  const tsvDir = path.join(DATA_DIR, 'tracker-additions');
+  const date = new Date().toISOString().slice(0, 10);
+
+  let id;
+  if (flags.reScore) {
+    const existing = findEvaluationByUrl(evalPath, offer.url);
+    if (!existing) {
+      console.error(`--re-score: url not found in ${evalPath}: ${offer.url}`);
+      process.exit(2);
+    }
+    if (flags.id) {
+      console.error(`[re-score] --id ignored: preserving existing id ${existing.id}`);
+    }
+    id = existing.id;
+  } else {
+    id = flags.id || nextId(evalPath);
+  }
+
+  const record = {
+    id,
+    date,
+    company: offer.company || 'unknown',
+    role: offer.title || 'unknown',
+    url: offer.url || '',
+    location: offer.location ?? null,
+    metadata_source: offer.metadata_source || 'unknown',
+    score: scored.score,
+    verdict,
+    reason: scored.reason,
+    status: 'Evaluated',
+  };
+
+  if (flags.reScore) {
+    updateJsonlEntry(evalPath, (e) => e.url === record.url, record);
+    removeTrackerTsvById(tsvDir, id);
+  } else {
+    appendJsonl(evalPath, record);
+  }
+
+  writeTrackerTsv(tsvDir, {
+    num: id,
+    date,
+    company: record.company,
+    role: record.role,
+    score: scored.score,
+    notes: scored.reason,
+  });
+
+  console.log(JSON.stringify(record));
+```
+
+Also: add a URL-not-found check **before** `detectClosedPage` and `callClaudeAsync` so we fail fast without spawning the CLI or hitting the network for a doomed run. Place this block right before the `const liveness = detectClosedPage(offer);` line in `main()`'s single-URL path (`offer.url` is always set at this point, regardless of json-input / fetch / from-pipeline / metadata-flags path):
+
+```javascript
+  if (flags.reScore) {
+    const evalPathEarly = path.join(DATA_DIR, 'evaluations.jsonl');
+    const existingEarly = findEvaluationByUrl(evalPathEarly, offer.url);
+    if (!existingEarly) {
+      console.error(`--re-score: url not found in ${evalPathEarly}: ${offer.url}`);
+      process.exit(2);
+    }
+  }
+```
+
+The duplicate check later (when building `record`) can then be simplified to trust the existing entry is present — but keep a defensive `if (!existing)` fallback that throws rather than exits 2 (should be unreachable).
+
+- [ ] **Step 6: Run the re-score tests to verify they pass**
+
+Run: `node --test tests/score/score-rescore.test.mjs`
+Expected: all 3 tests PASS.
+
+- [ ] **Step 7: Run the full score test suite (no regression)**
+
+Run: `node --test tests/score/**/*.test.mjs tests/lib/**/*.test.mjs`
+Expected: all PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/score/index.mjs tests/score/score-rescore.test.mjs
+git commit -m "feat(score): --re-score single URL updates entry in place (#76)"
+```
+
+---
+
+## Task 6: Single-URL `--re-score` preserves entry on closed page
+
+**Files:**
+- Modify: `src/score/index.mjs` (liveness branch in single-URL path)
+- Test: `tests/score/score-rescore.test.mjs` (append)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/score/score-rescore.test.mjs`:
+
+```javascript
+test('--re-score: page closed → entry inchangée, pas d\'écriture filtered-out', () => {
+  const tmp = mkTmp();
+  const evalPath = path.join(tmp, 'data', 'evaluations.jsonl');
+  const filteredPath = path.join(tmp, 'data', 'filtered-out.tsv');
+  const tsvDir = path.join(tmp, 'data', 'tracker-additions');
+
+  const original = {
+    id: '011',
+    date: '2026-01-01',
+    company: 'C',
+    role: 'R',
+    url: 'https://x/11',
+    score: 3.5,
+    verdict: 'skip',
+    reason: 'original',
+    status: 'Evaluated',
+  };
+  fs.writeFileSync(evalPath, JSON.stringify(original) + '\n');
+  fs.writeFileSync(path.join(tsvDir, '011-c.tsv'), 'original tsv\n');
+
+  const offerPath = writeOfferJson(tmp, {
+    url: 'https://x/11',
+    finalUrl: 'https://x/11',
+    status: 404,
+    body: '',
+  });
+
+  const proc = runScore(['--json-input', offerPath, '--re-score'], tmp);
+
+  assert.equal(proc.status, 0, `stderr: ${proc.stderr}`);
+  assert.match(proc.stderr, /page closed.*keeping existing score/);
+  const line = JSON.parse(fs.readFileSync(evalPath, 'utf8').trim());
+  assert.deepEqual(line, original);
+  assert.equal(fs.existsSync(filteredPath), false);
+  assert.equal(fs.existsSync(path.join(tsvDir, '011-c.tsv')), true);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `node --test tests/score/score-rescore.test.mjs`
+Expected: FAIL — current code writes to `filtered-out.tsv` regardless of re-score.
+
+- [ ] **Step 3: Branch the liveness handler on `flags.reScore`**
+
+In `src/score/index.mjs`, inside `main()`'s single-URL path, locate the block:
+
+```javascript
+  const liveness = detectClosedPage(offer);
+  if (liveness.closed) {
+    const date = new Date().toISOString().slice(0, 10);
+    appendFilteredOut(path.join(DATA_DIR, 'filtered-out.tsv'), { /* ... */ });
+    console.error(`[skip] page closed/broken — ${liveness.reason}`);
+    console.log(JSON.stringify({ skipped: true, reason: liveness.reason, url: offer.url }));
+    return;
+  }
+```
+
+Replace with:
+
+```javascript
+  const liveness = detectClosedPage(offer);
+  if (liveness.closed) {
+    if (flags.reScore) {
+      console.error(
+        `[re-score] ${offer.url}: page closed (${liveness.reason}), keeping existing score`
+      );
+      console.log(
+        JSON.stringify({ skipped: true, reason: liveness.reason, url: offer.url, kept: true })
+      );
+      return;
+    }
+    const date = new Date().toISOString().slice(0, 10);
+    appendFilteredOut(path.join(DATA_DIR, 'filtered-out.tsv'), {
+      date,
+      url: offer.url || '',
+      company: offer.company || 'unknown',
+      title: offer.title || '',
+      reason: `liveness: ${liveness.reason}`,
+    });
+    console.error(`[skip] page closed/broken — ${liveness.reason}`);
+    console.log(JSON.stringify({ skipped: true, reason: liveness.reason, url: offer.url }));
+    return;
+  }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `node --test tests/score/score-rescore.test.mjs`
+Expected: all re-score tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/score/index.mjs tests/score/score-rescore.test.mjs
+git commit -m "feat(score): --re-score preserves entry when page closed (#76)"
+```
+
+---
+
+## Task 7: `--batch --re-score` — mixed re-score + initial score
+
+**Files:**
+- Modify: `src/score/index.mjs` (batch branch in `main()`)
+- Test: `tests/score/score-rescore.test.mjs` (append)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/score/score-rescore.test.mjs`:
+
+```javascript
+test('--batch --re-score: mélange re-score et score initial, progress distinct', () => {
+  const tmp = mkTmp();
+  const evalPath = path.join(tmp, 'data', 'evaluations.jsonl');
+  const pipePath = path.join(tmp, 'data', 'pipeline.md');
+  const tsvDir = path.join(tmp, 'data', 'tracker-additions');
+
+  fs.writeFileSync(
+    evalPath,
+    [
+      JSON.stringify({
+        id: '001',
+        date: '2026-01-01',
+        company: 'Alpha',
+        role: 'RoleA',
+        url: 'https://a/1',
+        score: 2.0,
+        verdict: 'skip',
+        reason: 'old',
+        status: 'Evaluated',
+      }),
+      JSON.stringify({
+        id: '002',
+        date: '2026-01-01',
+        company: 'Beta',
+        role: 'RoleB',
+        url: 'https://b/1',
+        score: 3.0,
+        verdict: 'skip',
+        reason: 'old',
+        status: 'Evaluated',
+      }),
+    ].join('\n') + '\n'
+  );
+  fs.writeFileSync(path.join(tsvDir, '001-alpha.tsv'), 'old a\n');
+  fs.writeFileSync(path.join(tsvDir, '002-beta.tsv'), 'old b\n');
+  fs.writeFileSync(
+    pipePath,
+    [
+      '# Pipeline',
+      '',
+      '## Alpha (Paris)',
+      '',
+      '- [ ] https://a/1 | Alpha | RoleA',
+      '',
+      '## Beta (Paris)',
+      '',
+      '- [ ] https://b/1 | Beta | RoleB',
+      '',
+      '## Gamma (Paris)',
+      '',
+      '- [ ] https://c/1 | Gamma | RoleC',
+      '',
+    ].join('\n')
+  );
+
+  // Stub fetchOfferBody via a fake via --json-input is not wired for batch,
+  // so the batch test uses the STUB_FETCH env var instead — see impl.
+  const proc = runScore(['--batch', '--re-score', '--parallel', '1'], tmp, {
+    CLAUDE_APPLY_STUB_SCORE: '4.0',
+    CLAUDE_APPLY_STUB_REASON: 'refreshed',
+    CLAUDE_APPLY_STUB_FETCH: '1',
+  });
+
+  assert.equal(proc.status, 0, `stderr: ${proc.stderr}`);
+  const lines = fs
+    .readFileSync(evalPath, 'utf8')
+    .trim()
+    .split('\n')
+    .map((l) => JSON.parse(l));
+  assert.equal(lines.length, 3);
+
+  const a = lines.find((l) => l.url === 'https://a/1');
+  const b = lines.find((l) => l.url === 'https://b/1');
+  const c = lines.find((l) => l.url === 'https://c/1');
+
+  assert.equal(a.id, '001');
+  assert.equal(a.score, 4.0);
+  assert.equal(a.reason, 'refreshed');
+  assert.equal(b.id, '002');
+  assert.equal(b.score, 4.0);
+  assert.equal(c.id, '003');
+  assert.equal(c.score, 4.0);
+
+  assert.match(proc.stderr, /↻.*Alpha/);
+  assert.match(proc.stderr, /↻.*Beta/);
+  assert.match(proc.stderr, /✓.*Gamma/);
+  assert.match(proc.stderr, /2 re-scored, 1 scored/);
+
+  assert.equal(fs.existsSync(path.join(tsvDir, '001-alpha.tsv')), false);
+  assert.equal(fs.existsSync(path.join(tsvDir, '002-beta.tsv')), false);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `node --test tests/score/score-rescore.test.mjs`
+Expected: FAIL — `--re-score` is unknown in batch flow; counts/progress format missing.
+
+- [ ] **Step 3: Add `fetchOfferBody` stub behind env var**
+
+In `src/score/index.mjs`, at the top of `fetchOfferBody`, short-circuit when the stub env var is set:
+
+```javascript
+async function fetchOfferBody(url) {
+  if (process.env.CLAUDE_APPLY_STUB_FETCH) {
+    return {
+      finalUrl: url,
+      status: 200,
+      body: `Stub JD for ${url}. Senior Engineer role.`,
+      scrapedTitle: 'Stub Title',
+      scrapedCompany: '',
+      scrapedLocation: '',
+      ldJsonBlocks: [],
+      ogLocation: '',
+      cssLocation: '',
+    };
+  }
+  const { chromium } = await import('playwright');
+  // ... rest unchanged
+```
+
+- [ ] **Step 4: Implement the batch re-score logic**
+
+In `src/score/index.mjs`, find the `if (flags.batch)` block in `main()`. Replace the `pending = allOffers.filter(...)` and id allocation section with re-score-aware code.
+
+Near the start of the `if (flags.batch)` block:
+
+```javascript
+  if (flags.batch) {
+    const pipelinePath = path.join(DATA_DIR, 'pipeline.md');
+    const evalPath = path.join(DATA_DIR, 'evaluations.jsonl');
+
+    const allOffers = getAllPipelineOffers(pipelinePath);
+    const scored = getScoredUrls(evalPath);
+
+    const pending = flags.reScore ? allOffers : allOffers.filter((o) => !scored.has(o.url));
+
+    if (pending.length === 0) {
+      console.error(
+        flags.reScore
+          ? '[batch] Nothing in pipeline.md to re-score.'
+          : '[batch] Nothing to score — all offers already evaluated.'
+      );
+      return;
+    }
+
+    requireConfig(path.join(CONFIG_DIR, 'cv.md'));
+    const { profile, cvMarkdown } = await loadProfile(CONFIG_DIR);
+
+    let nextAvailId = parseInt(nextId(evalPath), 10);
+    const writeLock = pLimit(1);
+    const limit = pLimit(flags.parallel);
+    const startTime = Date.now();
+
+    let completed = 0;
+    let countScored = 0;
+    let countRescored = 0;
+    let countFiltered = 0;
+    let countKeptClosed = 0;
+    let countError = 0;
+    let countApply = 0;
+    let countSkip = 0;
+
+    console.error(
+      `[batch] ${flags.reScore ? 'Re-scoring' : 'Scoring'} ${pending.length} offers (${flags.parallel} parallel workers)...`
+    );
+```
+
+Then, inside the `tasks = pending.map(...)` loop, replace the existing closure with a version that branches on re-score vs new:
+
+```javascript
+    const tasks = pending.map((offer) => {
+      return limit(async () => {
+        try {
+          const existing = flags.reScore ? findEvaluationByUrl(evalPath, offer.url) : null;
+          const isRescore = !!existing;
+          const fetched = await fetchOfferBody(offer.url);
+          const extracted = extractLocation({
+            ldJsonBlocks: fetched.ldJsonBlocks,
+            ogLocation: fetched.ogLocation,
+            cssLocation: fetched.cssLocation,
+            bodyText: fetched.body,
+          });
+          const pipelineLoc = trimLoc(offer.location);
+          const fullOffer = {
+            ...offer,
+            finalUrl: fetched.finalUrl,
+            status: fetched.status,
+            body: fetched.body,
+            location: pipelineLoc || extracted.location,
+            metadata_source: 'pipeline',
+          };
+
+          const liveness = detectClosedPage(fullOffer);
+          if (liveness.closed) {
+            if (isRescore) {
+              completed++;
+              countKeptClosed++;
+              console.error(
+                `[batch]  [${completed}/${pending.length}] ⊘ ${offer.company} — ${offer.title}`.padEnd(
+                  60
+                ) + ` kept (closed: ${liveness.reason})`
+              );
+              return null;
+            }
+            const date = new Date().toISOString().slice(0, 10);
+            await writeLock(() =>
+              appendFilteredOut(path.join(DATA_DIR, 'filtered-out.tsv'), {
+                date,
+                url: offer.url,
+                company: offer.company || 'unknown',
+                title: offer.title || '',
+                reason: `liveness: ${liveness.reason}`,
+              })
+            );
+            completed++;
+            countFiltered++;
+            console.error(formatProgress(completed, pending.length, offer, { skipped: true, reason: liveness.reason }));
+            return null;
+          }
+
+          const { system, user } = buildPrompt({ cvMarkdown, offer: fullOffer, jdMaxTokens: 1500 });
+          const raw = await callClaudeAsync(system, user);
+          const scoredResult = parseScoreJson(raw);
+          const verdict = computeVerdict(
+            scoredResult.score,
+            profile?.auto_apply_min_score ?? DEFAULT_AUTO_APPLY_MIN_SCORE
+          );
+
+          const date = new Date().toISOString().slice(0, 10);
+          const tsvDir = path.join(DATA_DIR, 'tracker-additions');
+
+          let id;
+          await writeLock(() => {
+            if (isRescore) {
+              id = existing.id;
+            } else {
+              id = String(nextAvailId++).padStart(3, '0');
+            }
+          });
+
+          const record = {
+            id,
+            date,
+            company: fullOffer.company || 'unknown',
+            role: fullOffer.title || 'unknown',
+            url: fullOffer.url || '',
+            location: fullOffer.location ?? null,
+            metadata_source: 'pipeline',
+            score: scoredResult.score,
+            verdict,
+            reason: scoredResult.reason,
+            status: 'Evaluated',
+          };
+
+          await writeLock(() => {
+            if (isRescore) {
+              updateJsonlEntry(evalPath, (e) => e.url === record.url, record);
+              removeTrackerTsvById(tsvDir, id);
+            } else {
+              appendJsonl(evalPath, record);
+            }
+            writeTrackerTsv(tsvDir, {
+              num: id,
+              date,
+              company: record.company,
+              role: record.role,
+              score: scoredResult.score,
+              notes: scoredResult.reason,
+            });
+          });
+
+          completed++;
+          if (isRescore) countRescored++;
+          else countScored++;
+          if (verdict === 'apply') countApply++;
+          else countSkip++;
+          const marker = isRescore ? '↻' : '✓';
+          const label = `${offer.company} — ${offer.title}`;
+          console.error(
+            `[batch]  [${completed}/${pending.length}] ${marker} ${label.padEnd(45)} ${scoredResult.score} ${verdict}`
+          );
+          console.log(JSON.stringify(record));
+          return record;
+        } catch (err) {
+          completed++;
+          countError++;
+          console.error(formatProgress(completed, pending.length, offer, { error: err.message }));
+          return null;
+        }
+      });
+    });
+
+    await Promise.allSettled(tasks);
+
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(0);
+    console.error(
+      `[batch] Done: ${countRescored} re-scored, ${countScored} scored, ${countFiltered} filtered, ${countKeptClosed} kept (closed), ${countError} error (${pending.length} total)`
+    );
+    console.error(`[batch] Results: ${countApply} apply, ${countSkip} skip`);
+    console.error(`[batch] Time: ${elapsed}s (${flags.parallel} parallel workers)`);
+    return;
+  }
+```
+
+Keep `formatProgress` unchanged for error/filtered cases. The new `↻` / `✓` / `⊘` lines are inlined above because they need to distinguish the mode.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `node --test tests/score/score-rescore.test.mjs`
+Expected: all re-score tests PASS.
+
+- [ ] **Step 6: Run the full test suite to verify no regressions**
+
+Run: `npm test`
+Expected: all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/score/index.mjs tests/score/score-rescore.test.mjs
+git commit -m "feat(score): --batch --re-score updates existing entries in place (#76)"
+```
+
+---
+
+## Task 8: Update `/score` slash-command docs
+
+**Files:**
+- Modify: `.claude/commands/score.md`
+
+- [ ] **Step 1: Add `--re-score` to the Flags list**
+
+Edit `.claude/commands/score.md`, find the "## Flags" section. After the `--json-input` bullet, add:
+
+```markdown
+- `--re-score` — re-evaluate an offer already present in `data/evaluations.jsonl`. Preserves the existing `id`; refreshes `score`, `reason`, `date`, `verdict`, `company`, `role`, `location`. Compatible with single URL, `--from-pipeline`, and `--batch`. `--id` is ignored when `--re-score` is used.
+```
+
+- [ ] **Step 2: Add a "Re-scoring existing evaluations" section**
+
+After the "## Batch mode" section in `.claude/commands/score.md`, append:
+
+````markdown
+## Re-scoring existing evaluations
+
+Use `--re-score` after updating `config/cv.md`, changing the scoring prompt, or noticing a stale score. It re-fetches the page and rewrites the matching entry in `data/evaluations.jsonl` in place.
+
+```bash
+# Single URL (must already be in evaluations.jsonl)
+node src/score/index.mjs <url> --re-score
+
+# Preferred: pull metadata from pipeline.md
+node src/score/index.mjs <url> --from-pipeline --re-score
+
+# Batch: re-score every offer in pipeline.md.
+# Already-scored offers are overwritten; offers not yet scored are scored for the first time.
+node src/score/index.mjs --batch --re-score
+```
+
+Behaviour:
+- The `id` of the existing entry is preserved so report links do not break.
+- The old `data/tracker-additions/<id>-*.tsv` files are deleted before a new TSV is written.
+- If the page is now closed/broken during a re-score, the existing entry is **kept** (not overwritten, not moved to `filtered-out.tsv`). A warning is logged.
+- Single-URL re-score exits 2 if the URL is absent from `evaluations.jsonl`.
+````
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/commands/score.md
+git commit -m "docs(score): document --re-score flag (#76)"
+```
+
+---
+
+## Task 9: Final verification + push
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npm test`
+Expected: all PASS.
+
+- [ ] **Step 2: Run Prettier + PII check**
+
+Run: `npm run lint && npm run check:pii`
+Expected: both succeed.
+
+- [ ] **Step 3: Verify git log is clean and conventional**
+
+Run: `git log --oneline main..HEAD`
+Expected: 7–8 commits, all `feat(...)` or `docs(...)` with `(#76)` suffix.
+
+- [ ] **Step 4: Push and open PR**
+
+```bash
+git push -u origin worktree-issue-76-rescore
+gh pr create --title "feat(score): add --re-score flag to update existing evaluations (#76)" --body "$(cat <<'EOF'
+## Summary
+- Add `--re-score` flag to `src/score/index.mjs` for single URL and `--batch` modes
+- In-place updates of `evaluations.jsonl` via new atomic `updateJsonlEntry` helper
+- Refresh `tracker-additions/<id>-*.tsv` (glob-delete then rewrite) when slug changes
+- Preserve existing `id`; ignore `--id` with a warning when re-scoring
+- Keep existing entry intact when the page has become closed during a re-score
+- Batch mode interleaves re-scores and initial scores based on presence in `evaluations.jsonl`
+
+Closes #76.
+
+## Test plan
+- [ ] `npm test` passes
+- [ ] `node --test tests/lib/jsonl-writer.test.mjs tests/lib/tsv-writer.test.mjs tests/score/score-rescore.test.mjs` passes
+- [ ] Manual: single URL re-score with stubbed claude (STUB_SCORE env) updates the line
+- [ ] Manual: `--batch --re-score` mix of scored and unscored offers works
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-04-18-rescore-flag-design.md
+++ b/docs/superpowers/specs/2026-04-18-rescore-flag-design.md
@@ -1,0 +1,203 @@
+# Design — `--re-score` flag for `/score`
+
+Issue: [#76](https://github.com/anthropics/claude-apply/issues/76)
+Date: 2026-04-18
+
+## Problem
+
+`/score <url>` and `/score --batch` dedupe via `getScoredUrls(evaluationsPath)` and skip any URL already present in `data/evaluations.jsonl`. This is correct for normal use, but there is no supported workflow to **re-evaluate** an offer after:
+
+- Updating `config/cv.md` or `config/candidate-profile.yml`.
+- Changing the scoring prompt in `src/score/prompt-builder.mjs`.
+- Noticing the previous score was based on a closed/broken page (stale body).
+
+The only current workaround is to manually delete the line from `evaluations.jsonl` plus the corresponding `tracker-additions/<id>-<slug>.tsv`. This is error-prone, undocumented, and non-atomic.
+
+## Goals
+
+1. Provide a `--re-score` flag usable in single-URL and batch modes.
+2. Preserve the evaluation `id` so report links do not break.
+3. Keep existing `evaluations.jsonl` and `tracker-additions/` files in a consistent state (no duplicates, no orphans) after a re-score.
+4. Behave safely if the target page has since become unreachable/closed.
+
+## Non-goals
+
+- No changes to the JSONL schema (no new `rescored_date` field).
+- No partial re-scoring (e.g. "only re-score offers older than N days") — a `--re-score` run re-scores everything in scope.
+- No retention of previous scores / audit trail. A re-score overwrites. Users who want history can `git log data/evaluations.jsonl`.
+
+## User-facing behaviour
+
+### Single URL
+
+```bash
+node src/score/index.mjs <url> --re-score
+node src/score/index.mjs <url> --from-pipeline --re-score
+node src/score/index.mjs <url> --company X --role Y --location Z --re-score
+```
+
+- The URL **must** already be present in `data/evaluations.jsonl`. If absent → exit code 2 with message `--re-score: url not found in data/evaluations.jsonl: <url>`.
+- Re-fetch the page, re-run `detectClosedPage`, re-build the prompt, re-call `claude -p`.
+- Reuse the existing `id` from the matched entry. `--id NNN` is **ignored** in re-score mode (log a warning `[re-score] --id ignored: preserving existing id <id>`).
+- Update the entry in-place: same `id`, same `url`, new `date`, new `score`, new `reason`, new `verdict`, new `location` (re-extracted), refreshed `metadata_source` (matches the current flag set).
+- Delete the old `tracker-additions/<id>-*.tsv` files (glob by id prefix), then write a fresh TSV.
+
+### Batch
+
+```bash
+node src/score/index.mjs --batch --re-score [--parallel N]
+```
+
+- Reads all offers from `data/pipeline.md` (inchangé).
+- Does **not** filter by `getScoredUrls` — every offer in `pipeline.md` is processed.
+- For each offer:
+  - If the URL is already in `evaluations.jsonl` → re-score flow (reuse id, update entry, cleanup+rewrite TSV).
+  - If the URL is **not** in `evaluations.jsonl` → initial score flow (assign new id from `nextId`, append, write TSV).
+- Progress log distinguishes the two cases:
+  - `[batch]  [N/T] ↻ Acme — Senior Eng      7.5 apply` (re-score)
+  - `[batch]  [N/T] ✓ Bco — Junior Dev        6.0 skip` (initial score)
+  - `[batch]  [N/T] ✗ Cco — Role              error: ...`
+  - `[batch]  [N/T] ✗ Dco — Role              liveness: http-404` (filtered)
+  - `[batch]  [N/T] ⊘ Eco — Role              skipped: page closed, keeping existing score` (re-score on closed page)
+- End-of-run summary: `Done: X re-scored, Y scored, Z filtered, W kept (closed), E errors (T total)`.
+
+### Closed / broken pages during re-score
+
+If `detectClosedPage(offer)` returns `closed: true` **during a re-score**:
+- Keep the existing `evaluations.jsonl` entry intact.
+- Do **not** touch `tracker-additions/`.
+- Do **not** append to `filtered-out.tsv` (we already have a valid score; no need to duplicate signals).
+- Log `[re-score] <url>: page closed (<reason>), keeping existing score`.
+- Exit code 0 for the single-URL path; count under `kept (closed)` in batch summary.
+
+Rationale: an existing valid score is more useful than an erased entry, and a transient fetch failure or liveness false-positive must not destroy data.
+
+(Contrast: initial scoring in `--batch` continues to call `appendFilteredOut` for closed offers, because there is no prior evaluation to preserve. In `--batch --re-score`, the closed-page branch depends on which flow the offer took: a new offer with no prior entry still goes to `filtered-out.tsv`; a re-scored offer keeps its existing entry.)
+
+## Architecture
+
+### Changes by file
+
+**`src/lib/jsonl-writer.mjs`** — add:
+
+```js
+export function updateJsonlEntry(filePath, matchFn, newObj) {
+  // Read all lines, parse, find first index where matchFn(obj) is true.
+  // Replace that line with JSON.stringify(newObj) + '\n'.
+  // Write to `<filePath>.tmp` then fs.renameSync -> atomic.
+  // Return the previous entry (object) or null if no match.
+  // If no match: do NOT write; return null.
+}
+```
+
+- Atomic via tmp+rename, same pattern used elsewhere in the repo.
+- `matchFn` keeps the helper general (callers pass `(e) => e.url === url`).
+
+**`src/lib/tsv-writer.mjs`** — add:
+
+```js
+export function removeTrackerTsvById(tsvDir, id) {
+  // If tsvDir does not exist: no-op.
+  // Read dir, unlink every file matching `^${id}-.*\.tsv$`.
+  // Return array of removed filenames (for logging / tests).
+}
+```
+
+**`src/score/index.mjs`** — changes:
+
+1. `parseScoreArgs` parses `--re-score` into `flags.reScore: boolean`.
+2. `parseScoreArgs` accepts the new flag alongside `--batch`, `--from-pipeline`, single-URL, and metadata overrides. No new mutual-exclusion rule: `--re-score` is orthogonal.
+3. New helper `findEvaluationByUrl(evalPath, url)` — reads JSONL, returns the first matching entry or null.
+4. New helper `writeRescoredRecord(evalPath, tsvDir, record)` — calls `updateJsonlEntry` + `removeTrackerTsvById` + `writeTrackerTsv` under a mutex (see concurrency below).
+5. Single-URL path: when `flags.reScore`, branch to the re-score logic described above before the existing scoring block.
+6. Batch path: remove the `pending = allOffers.filter(...)` line when `flags.reScore`; for each offer, decide inside the task closure whether to re-score (URL found in JSONL) or score-new.
+
+**`.claude/commands/score.md`** — add:
+- `--re-score` in the flags list.
+- New section "Re-scoring existing evaluations" with three examples and a note about preserved ids.
+
+### Concurrency in `--batch --re-score`
+
+`updateJsonlEntry` is not safe under concurrent read-modify-write on the same file. The existing batch path uses `appendJsonl` (atomic append, safe concurrently because individual `appendFileSync` calls are atomic for short writes on POSIX). We lose that property when re-scoring.
+
+Solution: serialize all writes to `evaluations.jsonl` through a single-slot queue.
+
+```js
+const writeLock = pLimit(1);
+// inside each task:
+await writeLock(() => writeRescoredRecord(evalPath, tsvDir, record));
+// or for score-new:
+await writeLock(() => {
+  appendJsonl(evalPath, record);
+  writeTrackerTsv(tsvDir, tsvRow);
+});
+```
+
+The scoring itself (fetch + `claude -p`) still runs at `flags.parallel` width. Only the final write is serialized. The write is sub-millisecond compared to the multi-second LLM call, so the bottleneck is unchanged.
+
+### Id allocation in batch
+
+- For re-scored offers: reuse the existing id (found via `findEvaluationByUrl`).
+- For score-new offers: allocate from `nextId(evalPath)` at batch start, then distribute incrementally.
+- Because re-score does not change the id count, allocating ids purely from `nextId()` for new offers is safe, even if the new offers are interleaved with re-scores in the task queue. Ids remain dense and monotonic.
+
+Concretely: compute `let nextAvail = parseInt(nextId(evalPath), 10)` once, and inside each task lock, if the offer is score-new, consume `nextAvail++`.
+
+### Error handling
+
+- `--re-score` with a URL absent from `evaluations.jsonl` (single mode) → exit 2.
+- `--re-score` with `--id NNN` → warning logged, `--id` ignored.
+- Re-score fetch throws → count as error, original entry untouched.
+- Re-score page closed → original entry untouched, counted as `kept`.
+- `updateJsonlEntry` atomic tmp-rename: if rename fails, caller sees the exception; file state is unchanged.
+
+## Testing plan
+
+### Unit
+
+- `tests/jsonl-writer.test.mjs` (new cases):
+  - `updateJsonlEntry`: match found → line replaced, others untouched, return value is previous entry.
+  - `updateJsonlEntry`: no match → file unchanged, return null.
+  - `updateJsonlEntry`: atomic (simulate by checking no partial file after mid-write — or just trust tmp+rename semantics and test the happy path + a corrupted-line scenario where one existing line is not parseable JSON: it should be preserved as-is).
+
+- `tests/tsv-writer.test.mjs` (new cases):
+  - `removeTrackerTsvById`: removes `042-old-slug.tsv` and `042-other.tsv`, keeps `043-*.tsv`.
+  - `removeTrackerTsvById`: missing directory → no-op.
+
+- `tests/score-index.test.mjs` or new `tests/score-rescore.test.mjs`:
+  - `parseScoreArgs('--re-score')` → `flags.reScore === true`.
+  - `parseScoreArgs('--re-score --batch')` → both true.
+  - `parseScoreArgs('<url> --re-score --id 999')` → both parsed (warning emitted at runtime).
+
+### Integration (fixture-driven, no network)
+
+Using `--json-input` to bypass fetch, and isolated `CLAUDE_APPLY_DATA_DIR`:
+
+- Single re-score with URL present:
+  - Pre-seed `evaluations.jsonl` with one entry (id 007), one TSV `007-old-slug.tsv`.
+  - Run re-score with stubbed `callClaudeAsync` returning a new score.
+  - Assert: `evaluations.jsonl` has one line, id `007`, new score, new date. TSV `007-old-slug.tsv` is gone, a new TSV `007-<new-slug>.tsv` exists.
+
+- Single re-score with URL absent → exit code 2.
+
+- Single re-score on closed page:
+  - Pre-seed entry. Stub `detectClosedPage` to return `closed: true`.
+  - Assert: entry unchanged, no TSV changes, log contains `page closed, keeping existing score`, exit 0.
+
+- Batch re-score mixing cases:
+  - Pre-seed: `pipeline.md` with 3 offers (A, B, C). `evaluations.jsonl` already has A (id 001) and B (id 002). C is new.
+  - Run `--batch --re-score`.
+  - Assert: 2 re-scored (A, B kept their ids), 1 scored (C assigned id 003). Summary counts match.
+
+## Rollout
+
+- No migration needed: `evaluations.jsonl` schema unchanged.
+- Existing users pick up the flag after pulling; old runs without `--re-score` keep current dedup behaviour.
+
+## Alternatives considered
+
+- **Delete-and-re-run** (status quo): rejected per issue — error-prone, leaves dangling TSVs.
+- **Add `rescored_date` field**: rejected — schema change, complicates downstream readers (dashboard, tracker). If the distinction between original and re-score dates matters, `git log` is authoritative.
+- **Re-score without preserving id**: rejected — breaks deep links in reports and trackers.
+- **Batch re-score that skips new offers** (Q1 option B/C): rejected per user decision — the common case is "I changed my CV, re-evaluate everything".
+- **Batch writes collected then flushed**: rejected in favour of a write mutex — avoids holding the whole dataset in memory during long batches and makes partial-progress on crash straightforward to reason about.

--- a/src/lib/jsonl-writer.mjs
+++ b/src/lib/jsonl-writer.mjs
@@ -21,3 +21,36 @@ export function appendFilteredOut(filePath, entry) {
     .join('\t');
   fs.appendFileSync(filePath, cols + '\n', 'utf8');
 }
+
+export function updateJsonlEntry(filePath, matchFn, newObj) {
+  if (!fs.existsSync(filePath)) return null;
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const lines = raw.split('\n');
+  let previous = null;
+  let matchedIdx = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line) continue;
+    let obj;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (matchFn(obj)) {
+      previous = obj;
+      matchedIdx = i;
+      break;
+    }
+  }
+
+  if (matchedIdx === -1) return null;
+
+  lines[matchedIdx] = JSON.stringify(newObj);
+  const output = lines.join('\n');
+  const tmpPath = filePath + '.tmp';
+  fs.writeFileSync(tmpPath, output, 'utf8');
+  fs.renameSync(tmpPath, filePath);
+  return previous;
+}

--- a/src/lib/tsv-writer.mjs
+++ b/src/lib/tsv-writer.mjs
@@ -34,3 +34,16 @@ export function writeTrackerTsv(dir, { num, date, company, role, score, notes })
   fs.writeFileSync(filePath, line + '\n', 'utf8');
   return filePath;
 }
+
+export function removeTrackerTsvById(dir, id) {
+  if (!fs.existsSync(dir)) return [];
+  const prefix = `${id}-`;
+  const removed = [];
+  for (const name of fs.readdirSync(dir)) {
+    if (name.startsWith(prefix) && name.endsWith('.tsv')) {
+      fs.unlinkSync(path.join(dir, name));
+      removed.push(name);
+    }
+  }
+  return removed;
+}

--- a/src/score/index.mjs
+++ b/src/score/index.mjs
@@ -244,6 +244,18 @@ export function getScoredUrls(evaluationsPath) {
   return urls;
 }
 
+export function findEvaluationByUrl(evaluationsPath, url) {
+  if (!fs.existsSync(evaluationsPath)) return null;
+  const lines = fs.readFileSync(evaluationsPath, 'utf8').trim().split('\n').filter(Boolean);
+  for (const line of lines) {
+    try {
+      const obj = JSON.parse(line);
+      if (obj.url === url) return obj;
+    } catch {}
+  }
+  return null;
+}
+
 export function getAllPipelineOffers(pipelinePath) {
   if (!fs.existsSync(pipelinePath)) return [];
   const doc = readPipelineMd(pipelinePath);

--- a/src/score/index.mjs
+++ b/src/score/index.mjs
@@ -638,9 +638,7 @@ async function main() {
       process.exit(2);
     }
     if (flags.id) {
-      console.error(
-        `[re-score] --id ignored: preserving existing id ${existingRescore.id}`
-      );
+      console.error(`[re-score] --id ignored: preserving existing id ${existingRescore.id}`);
     }
   }
 

--- a/src/score/index.mjs
+++ b/src/score/index.mjs
@@ -28,6 +28,22 @@ import { extractCompanyFromUrl } from '../lib/extract-company.mjs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 async function fetchOfferBody(url) {
+  if (process.env.CLAUDE_APPLY_STUB_FETCH) {
+    const body =
+      `Stub JD for ${url}. Senior engineer role with a long description ` +
+      'that is long enough to pass the body-length liveness check. '.repeat(10);
+    return {
+      finalUrl: url,
+      status: 200,
+      body,
+      scrapedTitle: 'Stub Title',
+      scrapedCompany: '',
+      scrapedLocation: '',
+      ldJsonBlocks: [],
+      ogLocation: '',
+      cssLocation: '',
+    };
+  }
   const { chromium } = await import('playwright');
   const browser = await chromium.launch({ headless: true });
   try {
@@ -382,39 +398,47 @@ async function main() {
   if (flags.batch) {
     const pipelinePath = path.join(DATA_DIR, 'pipeline.md');
     const evalPath = path.join(DATA_DIR, 'evaluations.jsonl');
+    const tsvDir = path.join(DATA_DIR, 'tracker-additions');
 
     const allOffers = getAllPipelineOffers(pipelinePath);
     const scored = getScoredUrls(evalPath);
-    const pending = allOffers.filter((o) => !scored.has(o.url));
+    const pending = flags.reScore ? allOffers : allOffers.filter((o) => !scored.has(o.url));
 
     if (pending.length === 0) {
-      console.error('[batch] Nothing to score — all offers already evaluated.');
+      console.error(
+        flags.reScore
+          ? '[batch] Nothing in pipeline.md to re-score.'
+          : '[batch] Nothing to score — all offers already evaluated.'
+      );
       return;
     }
 
     requireConfig(path.join(CONFIG_DIR, 'cv.md'));
     const { profile, cvMarkdown } = await loadProfile(CONFIG_DIR);
 
-    const startId = parseInt(nextId(evalPath), 10);
+    let nextAvailId = parseInt(nextId(evalPath), 10);
+    const writeLock = pLimit(1);
     const limit = pLimit(flags.parallel);
     const startTime = Date.now();
 
     let completed = 0;
     let countScored = 0;
+    let countRescored = 0;
     let countFiltered = 0;
+    let countKeptClosed = 0;
     let countError = 0;
     let countApply = 0;
     let countSkip = 0;
 
     console.error(
-      `[batch] Scoring ${pending.length} offers (${flags.parallel} parallel workers)...`
+      `[batch] ${flags.reScore ? 'Re-scoring' : 'Scoring'} ${pending.length} offers (${flags.parallel} parallel workers)...`
     );
 
-    const tasks = pending.map((offer, idx) => {
-      const id = String(startId + idx).padStart(3, '0');
-
+    const tasks = pending.map((offer) => {
       return limit(async () => {
         try {
+          const existing = flags.reScore ? findEvaluationByUrl(evalPath, offer.url) : null;
+          const isRescore = !!existing;
           const fetched = await fetchOfferBody(offer.url);
           const extracted = extractLocation({
             ldJsonBlocks: fetched.ldJsonBlocks,
@@ -434,18 +458,33 @@ async function main() {
 
           const liveness = detectClosedPage(fullOffer);
           if (liveness.closed) {
+            if (isRescore) {
+              completed++;
+              countKeptClosed++;
+              const label = `${offer.company} — ${offer.title}`;
+              console.error(
+                `[batch]  [${completed}/${pending.length}] ⊘ ${label.padEnd(45)} kept (closed: ${liveness.reason})`
+              );
+              return null;
+            }
             const date = new Date().toISOString().slice(0, 10);
-            appendFilteredOut(path.join(DATA_DIR, 'filtered-out.tsv'), {
-              date,
-              url: offer.url,
-              company: offer.company || 'unknown',
-              title: offer.title || '',
-              reason: `liveness: ${liveness.reason}`,
-            });
-            const result = { skipped: true, reason: liveness.reason };
+            await writeLock(async () =>
+              appendFilteredOut(path.join(DATA_DIR, 'filtered-out.tsv'), {
+                date,
+                url: offer.url,
+                company: offer.company || 'unknown',
+                title: offer.title || '',
+                reason: `liveness: ${liveness.reason}`,
+              })
+            );
             completed++;
             countFiltered++;
-            console.error(formatProgress(completed, pending.length, offer, result));
+            console.error(
+              formatProgress(completed, pending.length, offer, {
+                skipped: true,
+                reason: liveness.reason,
+              })
+            );
             return null;
           }
 
@@ -462,6 +501,12 @@ async function main() {
           );
 
           const date = new Date().toISOString().slice(0, 10);
+
+          let id;
+          await writeLock(async () => {
+            id = isRescore ? existing.id : String(nextAvailId++).padStart(3, '0');
+          });
+
           const record = {
             id,
             date,
@@ -476,26 +521,32 @@ async function main() {
             status: 'Evaluated',
           };
 
-          appendJsonl(evalPath, record);
-          const tsvDir = path.join(DATA_DIR, 'tracker-additions');
-          writeTrackerTsv(tsvDir, {
-            num: id,
-            date,
-            company: record.company,
-            role: record.role,
-            score: scoredResult.score,
-            notes: scoredResult.reason,
+          await writeLock(async () => {
+            if (isRescore) {
+              updateJsonlEntry(evalPath, (e) => e.url === record.url, record);
+              removeTrackerTsvById(tsvDir, id);
+            } else {
+              appendJsonl(evalPath, record);
+            }
+            writeTrackerTsv(tsvDir, {
+              num: id,
+              date,
+              company: record.company,
+              role: record.role,
+              score: scoredResult.score,
+              notes: scoredResult.reason,
+            });
           });
 
           completed++;
-          countScored++;
+          if (isRescore) countRescored++;
+          else countScored++;
           if (verdict === 'apply') countApply++;
           else countSkip++;
+          const marker = isRescore ? '↻' : '✓';
+          const label = `${offer.company} — ${offer.title}`;
           console.error(
-            formatProgress(completed, pending.length, offer, {
-              score: scoredResult.score,
-              verdict,
-            })
+            `[batch]  [${completed}/${pending.length}] ${marker} ${label.padEnd(45)} ${scoredResult.score} ${verdict}`
           );
           console.log(JSON.stringify(record));
           return record;
@@ -511,9 +562,15 @@ async function main() {
     await Promise.allSettled(tasks);
 
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(0);
-    console.error(
-      `[batch] Done: ${countScored} scored, ${countFiltered} filtered, ${countError} error (${pending.length} total)`
-    );
+    if (flags.reScore) {
+      console.error(
+        `[batch] Done: ${countRescored} re-scored, ${countScored} scored, ${countFiltered} filtered, ${countKeptClosed} kept (closed), ${countError} error (${pending.length} total)`
+      );
+    } else {
+      console.error(
+        `[batch] Done: ${countScored} scored, ${countFiltered} filtered, ${countError} error (${pending.length} total)`
+      );
+    }
     console.error(`[batch] Results: ${countApply} apply, ${countSkip} skip`);
     console.error(`[batch] Time: ${elapsed}s (${flags.parallel} parallel workers)`);
     return;

--- a/src/score/index.mjs
+++ b/src/score/index.mjs
@@ -15,8 +15,8 @@ import { spawnSync, spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { buildPrompt } from './prompt-builder.mjs';
 import { extractLocation } from './location-extractor.mjs';
-import { appendJsonl, appendFilteredOut } from '../lib/jsonl-writer.mjs';
-import { writeTrackerTsv } from '../lib/tsv-writer.mjs';
+import { appendJsonl, appendFilteredOut, updateJsonlEntry } from '../lib/jsonl-writer.mjs';
+import { writeTrackerTsv, removeTrackerTsvById } from '../lib/tsv-writer.mjs';
 import { detectClosedPage } from '../lib/page-liveness.mjs';
 import { runPrefilter } from '../lib/prefilter-rules.mjs';
 import { loadProfile } from '../lib/load-profile.mjs';
@@ -113,6 +113,11 @@ async function buildOffer(url, overrides = {}) {
 }
 
 export function callClaudeAsync(system, user) {
+  if (process.env.CLAUDE_APPLY_STUB_SCORE) {
+    const score = parseFloat(process.env.CLAUDE_APPLY_STUB_SCORE);
+    const reason = process.env.CLAUDE_APPLY_STUB_REASON || 'stubbed reason';
+    return Promise.resolve(JSON.stringify({ score, reason }));
+  }
   const emptyMcpPath = path.join(os.tmpdir(), 'claude-apply-empty-mcp.json');
   if (!fs.existsSync(emptyMcpPath)) {
     fs.writeFileSync(emptyMcpPath, '{"mcpServers":{}}');
@@ -565,8 +570,34 @@ async function main() {
     }
   }
 
+  const evalPath = path.join(DATA_DIR, 'evaluations.jsonl');
+  const tsvDir = path.join(DATA_DIR, 'tracker-additions');
+
+  let existingRescore = null;
+  if (flags.reScore) {
+    existingRescore = findEvaluationByUrl(evalPath, offer.url);
+    if (!existingRescore) {
+      console.error(`--re-score: url not found in ${evalPath}: ${offer.url}`);
+      process.exit(2);
+    }
+    if (flags.id) {
+      console.error(
+        `[re-score] --id ignored: preserving existing id ${existingRescore.id}`
+      );
+    }
+  }
+
   const liveness = detectClosedPage(offer);
   if (liveness.closed) {
+    if (flags.reScore) {
+      console.error(
+        `[re-score] ${offer.url}: page closed (${liveness.reason}), keeping existing score`
+      );
+      console.log(
+        JSON.stringify({ skipped: true, reason: liveness.reason, url: offer.url, kept: true })
+      );
+      return;
+    }
     const date = new Date().toISOString().slice(0, 10);
     appendFilteredOut(path.join(DATA_DIR, 'filtered-out.tsv'), {
       date,
@@ -596,8 +627,7 @@ async function main() {
     profile?.auto_apply_min_score ?? DEFAULT_AUTO_APPLY_MIN_SCORE
   );
 
-  const evalPath = path.join(DATA_DIR, 'evaluations.jsonl');
-  const id = flags.id || nextId(evalPath);
+  const id = flags.reScore ? existingRescore.id : flags.id || nextId(evalPath);
   const date = new Date().toISOString().slice(0, 10);
   const record = {
     id,
@@ -612,9 +642,14 @@ async function main() {
     reason: scored.reason,
     status: 'Evaluated',
   };
-  appendJsonl(evalPath, record);
 
-  const tsvDir = path.join(DATA_DIR, 'tracker-additions');
+  if (flags.reScore) {
+    updateJsonlEntry(evalPath, (e) => e.url === record.url, record);
+    removeTrackerTsvById(tsvDir, id);
+  } else {
+    appendJsonl(evalPath, record);
+  }
+
   writeTrackerTsv(tsvDir, {
     num: id,
     date,

--- a/src/score/index.mjs
+++ b/src/score/index.mjs
@@ -5,8 +5,9 @@
 //   --company X --role Y --location Z   Authoritative metadata overrides (all-or-nothing)
 //   --json-input <path>   Read pre-built offer JSON instead of fetching
 //   --id NNN          Force evaluation id (default: auto-increment)
+//   --re-score        Re-evaluate a URL already in evaluations.jsonl; preserves existing id
 // Builds prompt, calls `claude -p` CLI, parses JSON response,
-// appends to data/evaluations.jsonl + data/tracker-additions/<id>-<slug>.tsv.
+// appends or updates in-place data/evaluations.jsonl + data/tracker-additions/<id>-<slug>.tsv.
 
 import fs from 'node:fs';
 import os from 'node:os';

--- a/src/score/index.mjs
+++ b/src/score/index.mjs
@@ -276,6 +276,7 @@ export function parseScoreArgs(argv) {
     fromPipeline: false,
     batch: false,
     parallel: 5,
+    reScore: false,
   };
 
   function take(name) {
@@ -306,6 +307,11 @@ export function parseScoreArgs(argv) {
   if (fpIdx !== -1) {
     flags.fromPipeline = true;
     args.splice(fpIdx, 1);
+  }
+  const rsIdx = args.indexOf('--re-score');
+  if (rsIdx !== -1) {
+    flags.reScore = true;
+    args.splice(rsIdx, 1);
   }
   flags.url = args.find((a) => !a.startsWith('--')) || null;
 

--- a/tests/lib/jsonl-writer.test.mjs
+++ b/tests/lib/jsonl-writer.test.mjs
@@ -57,14 +57,18 @@ test('updateJsonlEntry — remplace la première ligne correspondante', () => {
   appendJsonl(p, { id: '002', url: 'https://a/2', score: 4.0 });
   appendJsonl(p, { id: '003', url: 'https://a/3', score: 5.0 });
 
-  const prev = updateJsonlEntry(
-    p,
-    (e) => e.url === 'https://a/2',
-    { id: '002', url: 'https://a/2', score: 4.5 }
-  );
+  const prev = updateJsonlEntry(p, (e) => e.url === 'https://a/2', {
+    id: '002',
+    url: 'https://a/2',
+    score: 4.5,
+  });
 
   assert.deepEqual(prev, { id: '002', url: 'https://a/2', score: 4.0 });
-  const lines = fs.readFileSync(p, 'utf8').trim().split('\n').map((l) => JSON.parse(l));
+  const lines = fs
+    .readFileSync(p, 'utf8')
+    .trim()
+    .split('\n')
+    .map((l) => JSON.parse(l));
   assert.equal(lines.length, 3);
   assert.deepEqual(lines[0], { id: '001', url: 'https://a/1', score: 3.0 });
   assert.deepEqual(lines[1], { id: '002', url: 'https://a/2', score: 4.5 });

--- a/tests/lib/jsonl-writer.test.mjs
+++ b/tests/lib/jsonl-writer.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { appendJsonl, appendFilteredOut } from '../../src/lib/jsonl-writer.mjs';
+import { appendJsonl, appendFilteredOut, updateJsonlEntry } from '../../src/lib/jsonl-writer.mjs';
 
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'co-'));
 
@@ -49,4 +49,62 @@ test('appendFilteredOut échappe les tabs dans les champs', () => {
   });
   const line = fs.readFileSync(p, 'utf8').trim();
   assert.equal(line.split('\t').length, 5);
+});
+
+test('updateJsonlEntry — remplace la première ligne correspondante', () => {
+  const p = path.join(tmp, 'evals.jsonl');
+  appendJsonl(p, { id: '001', url: 'https://a/1', score: 3.0 });
+  appendJsonl(p, { id: '002', url: 'https://a/2', score: 4.0 });
+  appendJsonl(p, { id: '003', url: 'https://a/3', score: 5.0 });
+
+  const prev = updateJsonlEntry(
+    p,
+    (e) => e.url === 'https://a/2',
+    { id: '002', url: 'https://a/2', score: 4.5 }
+  );
+
+  assert.deepEqual(prev, { id: '002', url: 'https://a/2', score: 4.0 });
+  const lines = fs.readFileSync(p, 'utf8').trim().split('\n').map((l) => JSON.parse(l));
+  assert.equal(lines.length, 3);
+  assert.deepEqual(lines[0], { id: '001', url: 'https://a/1', score: 3.0 });
+  assert.deepEqual(lines[1], { id: '002', url: 'https://a/2', score: 4.5 });
+  assert.deepEqual(lines[2], { id: '003', url: 'https://a/3', score: 5.0 });
+});
+
+test('updateJsonlEntry — retourne null et ne modifie rien quand rien ne match', () => {
+  const p = path.join(tmp, 'evals.jsonl');
+  appendJsonl(p, { id: '001', url: 'https://a/1', score: 3.0 });
+  const before = fs.readFileSync(p, 'utf8');
+
+  const prev = updateJsonlEntry(p, (e) => e.url === 'https://missing', { id: '999' });
+
+  assert.equal(prev, null);
+  const after = fs.readFileSync(p, 'utf8');
+  assert.equal(before, after);
+});
+
+test('updateJsonlEntry — préserve les lignes JSON invalides sans crasher', () => {
+  const p = path.join(tmp, 'evals.jsonl');
+  fs.writeFileSync(
+    p,
+    [
+      JSON.stringify({ id: '001', url: 'https://a/1' }),
+      'this is not json',
+      JSON.stringify({ id: '002', url: 'https://a/2' }),
+    ].join('\n') + '\n'
+  );
+
+  updateJsonlEntry(p, (e) => e.url === 'https://a/2', { id: '002', url: 'https://a/2', score: 9 });
+
+  const lines = fs.readFileSync(p, 'utf8').trim().split('\n');
+  assert.equal(lines.length, 3);
+  assert.equal(lines[1], 'this is not json');
+  assert.deepEqual(JSON.parse(lines[2]), { id: '002', url: 'https://a/2', score: 9 });
+});
+
+test('updateJsonlEntry — file manquant retourne null', () => {
+  const p = path.join(tmp, 'missing.jsonl');
+  const prev = updateJsonlEntry(p, () => true, {});
+  assert.equal(prev, null);
+  assert.equal(fs.existsSync(p), false);
 });

--- a/tests/lib/tsv-writer.test.mjs
+++ b/tests/lib/tsv-writer.test.mjs
@@ -1,9 +1,15 @@
-import { test } from 'node:test';
+import { test, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { writeTrackerTsv } from '../../src/lib/tsv-writer.mjs';
+import { writeTrackerTsv, removeTrackerTsvById } from '../../src/lib/tsv-writer.mjs';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tsv-writer-'));
+
+afterEach(() => {
+  for (const f of fs.readdirSync(tmp)) fs.unlinkSync(path.join(tmp, f));
+});
 
 test('writeTrackerTsv — formats score as X.X/10', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tsv-writer-'));
@@ -19,4 +25,30 @@ test('writeTrackerTsv — formats score as X.X/10', () => {
   const cells = line.trimEnd().split('\t');
   assert.equal(cells[5], '8.4/10');
   assert.ok(!line.includes('8.4/5'));
+});
+
+test('removeTrackerTsvById — supprime les fichiers préfixés par <id>-', () => {
+  fs.writeFileSync(path.join(tmp, '042-acme.tsv'), 'x\n');
+  fs.writeFileSync(path.join(tmp, '042-other-slug.tsv'), 'x\n');
+  fs.writeFileSync(path.join(tmp, '043-kept.tsv'), 'x\n');
+  fs.writeFileSync(path.join(tmp, '042.tsv'), 'x\n');
+
+  const removed = removeTrackerTsvById(tmp, '042');
+  assert.equal(removed.length, 2);
+  assert.ok(removed.includes('042-acme.tsv'));
+  assert.ok(removed.includes('042-other-slug.tsv'));
+  const remaining = fs.readdirSync(tmp).sort();
+  assert.deepEqual(remaining, ['042.tsv', '043-kept.tsv']);
+});
+
+test('removeTrackerTsvById — dir manquant renvoie tableau vide', () => {
+  const removed = removeTrackerTsvById(path.join(tmp, 'missing-dir'), '001');
+  assert.deepEqual(removed, []);
+});
+
+test('removeTrackerTsvById — aucun fichier matchant renvoie tableau vide', () => {
+  fs.writeFileSync(path.join(tmp, '010-keep.tsv'), 'x\n');
+  const removed = removeTrackerTsvById(tmp, '042');
+  assert.deepEqual(removed, []);
+  assert.equal(fs.existsSync(path.join(tmp, '010-keep.tsv')), true);
 });

--- a/tests/score/metadata-source.test.mjs
+++ b/tests/score/metadata-source.test.mjs
@@ -213,3 +213,27 @@ test('parseScoreArgs — --parallel without value defaults to 5', () => {
 test('parseScoreArgs — --batch + --from-pipeline throws', () => {
   assert.throws(() => parseScoreArgs(['--batch', '--from-pipeline']), /mutually exclusive/);
 });
+
+test('parseScoreArgs — --re-score flag (single URL)', () => {
+  const f = parseScoreArgs(['https://jobs.example.com/a', '--re-score']);
+  assert.equal(f.reScore, true);
+  assert.equal(f.url, 'https://jobs.example.com/a');
+  assert.equal(f.batch, false);
+});
+
+test('parseScoreArgs — --re-score + --batch', () => {
+  const f = parseScoreArgs(['--batch', '--re-score']);
+  assert.equal(f.reScore, true);
+  assert.equal(f.batch, true);
+});
+
+test('parseScoreArgs — --re-score + --from-pipeline', () => {
+  const f = parseScoreArgs(['https://jobs.example.com/a', '--from-pipeline', '--re-score']);
+  assert.equal(f.reScore, true);
+  assert.equal(f.fromPipeline, true);
+});
+
+test('parseScoreArgs — --re-score absent → false par défaut', () => {
+  const f = parseScoreArgs(['https://jobs.example.com/a']);
+  assert.equal(f.reScore, false);
+});

--- a/tests/score/score-batch.test.mjs
+++ b/tests/score/score-batch.test.mjs
@@ -3,7 +3,11 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { getScoredUrls, getAllPipelineOffers } from '../../src/score/index.mjs';
+import {
+  getScoredUrls,
+  getAllPipelineOffers,
+  findEvaluationByUrl,
+} from '../../src/score/index.mjs';
 
 function mkTmp() {
   const d = fs.mkdtempSync(path.join(os.tmpdir(), 'score-batch-'));
@@ -98,4 +102,30 @@ test('batch ID pre-allocation — sequential from last ID', () => {
   const startId = max + 1;
   const ids = Array.from({ length: 3 }, (_, i) => String(startId + i).padStart(3, '0'));
   assert.deepEqual(ids, ['006', '007', '008']);
+});
+
+test("findEvaluationByUrl — retourne l'entrée quand l'URL existe", () => {
+  const tmp = mkTmp();
+  const evalPath = path.join(tmp, 'data', 'evaluations.jsonl');
+  fs.writeFileSync(
+    evalPath,
+    [
+      JSON.stringify({ id: '001', url: 'https://a/1', score: 3 }),
+      JSON.stringify({ id: '002', url: 'https://a/2', score: 4 }),
+    ].join('\n') + '\n'
+  );
+  const hit = findEvaluationByUrl(evalPath, 'https://a/2');
+  assert.equal(hit.id, '002');
+  assert.equal(hit.score, 4);
+});
+
+test("findEvaluationByUrl — null quand l'URL est absente", () => {
+  const tmp = mkTmp();
+  const evalPath = path.join(tmp, 'data', 'evaluations.jsonl');
+  fs.writeFileSync(evalPath, JSON.stringify({ id: '001', url: 'https://a/1' }) + '\n');
+  assert.equal(findEvaluationByUrl(evalPath, 'https://missing'), null);
+});
+
+test("findEvaluationByUrl — null quand le fichier n'existe pas", () => {
+  assert.equal(findEvaluationByUrl('/tmp/nonexistent-evals-abc123.jsonl', 'https://x'), null);
 });

--- a/tests/score/score-rescore.test.mjs
+++ b/tests/score/score-rescore.test.mjs
@@ -176,6 +176,100 @@ test("--re-score: page closed → entry inchangée, pas d'écriture filtered-out
   assert.equal(fs.existsSync(path.join(tsvDir, '011-c.tsv')), true);
 });
 
+test('--batch --re-score: mélange re-score et score initial, progress distinct', () => {
+  const tmp = mkTmp();
+  const evalPath = path.join(tmp, 'data', 'evaluations.jsonl');
+  const pipePath = path.join(tmp, 'data', 'pipeline.md');
+  const tsvDir = path.join(tmp, 'data', 'tracker-additions');
+
+  fs.writeFileSync(
+    evalPath,
+    [
+      JSON.stringify({
+        id: '001',
+        date: '2026-01-01',
+        company: 'Alpha',
+        role: 'RoleA',
+        url: 'https://a/1',
+        score: 2.0,
+        verdict: 'skip',
+        reason: 'old',
+        status: 'Evaluated',
+      }),
+      JSON.stringify({
+        id: '002',
+        date: '2026-01-01',
+        company: 'Beta',
+        role: 'RoleB',
+        url: 'https://b/1',
+        score: 3.0,
+        verdict: 'skip',
+        reason: 'old',
+        status: 'Evaluated',
+      }),
+    ].join('\n') + '\n'
+  );
+  fs.writeFileSync(path.join(tsvDir, '001-alpha.tsv'), 'old a\n');
+  fs.writeFileSync(path.join(tsvDir, '002-beta.tsv'), 'old b\n');
+  fs.writeFileSync(
+    pipePath,
+    [
+      '# Pipeline',
+      '',
+      '## Alpha (Paris)',
+      '',
+      '- [ ] https://a/1 | Alpha | RoleA',
+      '',
+      '## Beta (Paris)',
+      '',
+      '- [ ] https://b/1 | Beta | RoleB',
+      '',
+      '## Gamma (Paris)',
+      '',
+      '- [ ] https://c/1 | Gamma | RoleC',
+      '',
+    ].join('\n')
+  );
+
+  const proc = runScore(['--batch', '--re-score', '--parallel', '1'], tmp, {
+    CLAUDE_APPLY_STUB_SCORE: '4.0',
+    CLAUDE_APPLY_STUB_REASON: 'refreshed',
+    CLAUDE_APPLY_STUB_FETCH: '1',
+  });
+
+  assert.equal(proc.status, 0, `stderr: ${proc.stderr}`);
+  const lines = fs
+    .readFileSync(evalPath, 'utf8')
+    .trim()
+    .split('\n')
+    .map((l) => JSON.parse(l));
+  assert.equal(lines.length, 3);
+
+  const a = lines.find((l) => l.url === 'https://a/1');
+  const b = lines.find((l) => l.url === 'https://b/1');
+  const c = lines.find((l) => l.url === 'https://c/1');
+
+  assert.equal(a.id, '001');
+  assert.equal(a.score, 4.0);
+  assert.equal(a.reason, 'refreshed');
+  assert.equal(b.id, '002');
+  assert.equal(b.score, 4.0);
+  assert.equal(c.id, '003');
+  assert.equal(c.score, 4.0);
+
+  assert.match(proc.stderr, /↻.*Alpha/);
+  assert.match(proc.stderr, /↻.*Beta/);
+  assert.match(proc.stderr, /✓.*Gamma/);
+  assert.match(proc.stderr, /2 re-scored, 1 scored/);
+
+  const tsvA = fs.readFileSync(path.join(tsvDir, '001-alpha.tsv'), 'utf8');
+  assert.match(tsvA, /refreshed/);
+  assert.doesNotMatch(tsvA, /old a/);
+  const tsvB = fs.readFileSync(path.join(tsvDir, '002-beta.tsv'), 'utf8');
+  assert.match(tsvB, /refreshed/);
+  assert.doesNotMatch(tsvB, /old b/);
+});
+
 test('--re-score + --id NNN: --id ignoré, id existant préservé (warning stderr)', () => {
   const tmp = mkTmp();
   const evalPath = path.join(tmp, 'data', 'evaluations.jsonl');

--- a/tests/score/score-rescore.test.mjs
+++ b/tests/score/score-rescore.test.mjs
@@ -139,6 +139,43 @@ test("--re-score: URL présente → remplace la ligne, préserve l'id, supprime 
   assert.match(newTsvs[0], /^007-newco\.tsv$/);
 });
 
+test("--re-score: page closed → entry inchangée, pas d'écriture filtered-out", () => {
+  const tmp = mkTmp();
+  const evalPath = path.join(tmp, 'data', 'evaluations.jsonl');
+  const filteredPath = path.join(tmp, 'data', 'filtered-out.tsv');
+  const tsvDir = path.join(tmp, 'data', 'tracker-additions');
+
+  const original = {
+    id: '011',
+    date: '2026-01-01',
+    company: 'C',
+    role: 'R',
+    url: 'https://x/11',
+    score: 3.5,
+    verdict: 'skip',
+    reason: 'original',
+    status: 'Evaluated',
+  };
+  fs.writeFileSync(evalPath, JSON.stringify(original) + '\n');
+  fs.writeFileSync(path.join(tsvDir, '011-c.tsv'), 'original tsv\n');
+
+  const offerPath = writeOfferJson(tmp, {
+    url: 'https://x/11',
+    finalUrl: 'https://x/11',
+    status: 404,
+    body: '',
+  });
+
+  const proc = runScore(['--json-input', offerPath, '--re-score'], tmp);
+
+  assert.equal(proc.status, 0, `stderr: ${proc.stderr}`);
+  assert.match(proc.stderr, /page closed.*keeping existing score/);
+  const line = JSON.parse(fs.readFileSync(evalPath, 'utf8').trim());
+  assert.deepEqual(line, original);
+  assert.equal(fs.existsSync(filteredPath), false);
+  assert.equal(fs.existsSync(path.join(tsvDir, '011-c.tsv')), true);
+});
+
 test('--re-score + --id NNN: --id ignoré, id existant préservé (warning stderr)', () => {
   const tmp = mkTmp();
   const evalPath = path.join(tmp, 'data', 'evaluations.jsonl');

--- a/tests/score/score-rescore.test.mjs
+++ b/tests/score/score-rescore.test.mjs
@@ -1,0 +1,174 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const scoreBin = path.join(repoRoot, 'src/score/index.mjs');
+
+const PROFILE_YAML = `first_name: Alice
+last_name: Martin
+email: alice.martin@example.com
+phone: '+33600000000'
+linkedin_url: https://linkedin.com/in/alice
+github_url: https://github.com/alice
+city: Paris
+country: France
+school: Example School
+degree: MEng
+graduation_year: 2026
+work_authorization: EU citizen
+requires_sponsorship: false
+availability_start: '2026-09-01'
+internship_duration_months: 6
+cv_path: cv.md
+auto_apply_min_score: 7
+`;
+
+function mkTmp() {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'score-rescore-'));
+  fs.mkdirSync(path.join(d, 'config'), { recursive: true });
+  fs.mkdirSync(path.join(d, 'data', 'tracker-additions'), { recursive: true });
+  fs.writeFileSync(path.join(d, 'config', 'cv.md'), '# CV\nDummy CV content.\n');
+  fs.writeFileSync(path.join(d, 'config', 'candidate-profile.yml'), PROFILE_YAML);
+  fs.mkdirSync(path.join(d, '.git'), { recursive: true });
+  return d;
+}
+
+function writeOfferJson(dir, offer) {
+  const p = path.join(dir, 'offer.json');
+  fs.writeFileSync(p, JSON.stringify(offer));
+  return p;
+}
+
+function runScore(args, tmp, extraEnv = {}) {
+  return spawnSync('node', [scoreBin, ...args], {
+    env: {
+      ...process.env,
+      CLAUDE_APPLY_CONFIG_DIR: path.join(tmp, 'config'),
+      CLAUDE_APPLY_DATA_DIR: path.join(tmp, 'data'),
+      ...extraEnv,
+    },
+    encoding: 'utf8',
+  });
+}
+
+test('--re-score: URL absente de evaluations.jsonl → exit 2', () => {
+  const tmp = mkTmp();
+  const evalPath = path.join(tmp, 'data', 'evaluations.jsonl');
+  fs.writeFileSync(
+    evalPath,
+    JSON.stringify({ id: '001', url: 'https://other/1', score: 3.0 }) + '\n'
+  );
+  const offerPath = writeOfferJson(tmp, { url: 'https://missing/1', body: 'x' });
+
+  const proc = runScore(['--json-input', offerPath, '--re-score'], tmp);
+
+  assert.equal(proc.status, 2);
+  assert.match(proc.stderr, /not found in .*evaluations\.jsonl/);
+});
+
+test("--re-score: URL présente → remplace la ligne, préserve l'id, supprime l'ancien TSV", () => {
+  const tmp = mkTmp();
+  const evalPath = path.join(tmp, 'data', 'evaluations.jsonl');
+  const tsvDir = path.join(tmp, 'data', 'tracker-additions');
+
+  fs.writeFileSync(
+    evalPath,
+    [
+      JSON.stringify({
+        id: '007',
+        date: '2026-01-01',
+        company: 'OldCo',
+        role: 'Old Role',
+        url: 'https://x/7',
+        score: 2.0,
+        verdict: 'skip',
+        reason: 'old reason',
+        status: 'Evaluated',
+      }),
+      JSON.stringify({ id: '008', url: 'https://x/8', score: 4.0 }),
+    ].join('\n') + '\n'
+  );
+  fs.writeFileSync(path.join(tsvDir, '007-oldco.tsv'), 'old tsv\n');
+
+  const offerPath = writeOfferJson(tmp, {
+    url: 'https://x/7',
+    finalUrl: 'https://x/7',
+    status: 200,
+    body:
+      'Full JD text. We are looking for a senior engineer to join our team. ' +
+      'The role involves building scalable systems, leading technical reviews, ' +
+      'collaborating with product managers, and mentoring junior engineers. ' +
+      'You will work on distributed systems, observability, and developer tools. ' +
+      'We offer a competitive salary, remote-friendly culture, and great benefits. ' +
+      'Required: 5+ years experience, strong CS fundamentals, cloud platforms. ' +
+      'Nice to have: open-source contributions, public speaking, mentorship.',
+    company: 'NewCo',
+    title: 'Senior Engineer',
+    location: 'Paris',
+    metadata_source: 'json-input',
+  });
+
+  const proc = runScore(['--json-input', offerPath, '--re-score'], tmp, {
+    CLAUDE_APPLY_STUB_SCORE: '4.5',
+    CLAUDE_APPLY_STUB_REASON: 'much better fit now',
+  });
+
+  assert.equal(proc.status, 0, `stderr: ${proc.stderr}`);
+  const lines = fs
+    .readFileSync(evalPath, 'utf8')
+    .trim()
+    .split('\n')
+    .map((l) => JSON.parse(l));
+  assert.equal(lines.length, 2);
+  const updated = lines.find((l) => l.url === 'https://x/7');
+  assert.equal(updated.id, '007');
+  assert.equal(updated.score, 4.5);
+  assert.equal(updated.reason, 'much better fit now');
+  assert.equal(updated.company, 'NewCo');
+  assert.equal(updated.role, 'Senior Engineer');
+  assert.notEqual(updated.date, '2026-01-01');
+  assert.equal(fs.existsSync(path.join(tsvDir, '007-oldco.tsv')), false);
+  const newTsvs = fs.readdirSync(tsvDir).filter((f) => f.startsWith('007-'));
+  assert.equal(newTsvs.length, 1);
+  assert.match(newTsvs[0], /^007-newco\.tsv$/);
+});
+
+test('--re-score + --id NNN: --id ignoré, id existant préservé (warning stderr)', () => {
+  const tmp = mkTmp();
+  const evalPath = path.join(tmp, 'data', 'evaluations.jsonl');
+  fs.writeFileSync(
+    evalPath,
+    JSON.stringify({
+      id: '005',
+      url: 'https://x/5',
+      company: 'C',
+      role: 'R',
+      score: 3,
+    }) + '\n'
+  );
+  const longBody = 'Full JD for role R at C. '.repeat(30);
+  const offerPath = writeOfferJson(tmp, {
+    url: 'https://x/5',
+    status: 200,
+    body: longBody,
+    company: 'C',
+    title: 'R',
+  });
+
+  const proc = runScore(['--json-input', offerPath, '--re-score', '--id', '999'], tmp, {
+    CLAUDE_APPLY_STUB_SCORE: '3.5',
+    CLAUDE_APPLY_STUB_REASON: 'ok',
+  });
+
+  assert.equal(proc.status, 0, `stderr: ${proc.stderr}`);
+  assert.match(proc.stderr, /--id ignored.*preserving existing id 005/);
+  const line = JSON.parse(fs.readFileSync(evalPath, 'utf8').trim());
+  assert.equal(line.id, '005');
+  assert.equal(line.score, 3.5);
+});


### PR DESCRIPTION
## Summary
- Add `--re-score` flag to `src/score/index.mjs` for single URL and `--batch` modes
- In-place updates of `evaluations.jsonl` via new atomic `updateJsonlEntry` helper (tmp + rename)
- Cleanup of `tracker-additions/<id>-*.tsv` via new `removeTrackerTsvById` helper (handles slug changes)
- Preserve existing `id`; ignore `--id` with a warning when re-scoring
- Keep existing entry intact when the page has become closed during a re-score
- Batch mode interleaves re-scores and initial scores based on presence in `evaluations.jsonl`; serialized writes via `pLimit(1)` mutex while keeping LLM calls parallel
- Stubs (`CLAUDE_APPLY_STUB_SCORE`, `CLAUDE_APPLY_STUB_FETCH`) allow full end-to-end integration tests without network or `claude` CLI

Closes #76.

Spec: docs/superpowers/specs/2026-04-18-rescore-flag-design.md
Plan: docs/superpowers/plans/2026-04-18-rescore-flag.md

## Test plan
- [x] \`npm test\` → 490/490 pass
- [x] \`npm run lint\` clean
- [x] \`npm run check:pii\` clean
- [x] \`tests/score/score-rescore.test.mjs\` covers: URL absent exits 2, single re-score with id preserved + old TSV cleanup, \`--id\` ignored warning, closed-page preserves entry, batch mix of re-score + initial score with distinct progress markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)