### PR TITLE
feat(tune-filter): interactive title_filter calibration (#85)

### DIFF
--- a/.claude/commands/tune-filter.md
+++ b/.claude/commands/tune-filter.md
@@ -1,0 +1,219 @@
+---
+description: Interactive calibration of portals.yml title_filter against cached scan-history
+argument-hint: ""
+---
+
+# /tune-filter
+
+Interactively tune `config/portals.yml.title_filter` (and `candidate-profile.blacklist_companies`) against the cached `data/scan-history.tsv` corpus — no network calls, no re-scan.
+
+## First-run guard
+
+If `config/portals.yml` or `config/candidate-profile.yml` is missing, **stop** and say:
+
+> "No config found. Run `/apply-onboard` first — it will extract your CV, build the configs, and find ~30 target companies for you."
+
+If `data/scan-history.tsv` is missing or empty, **stop** and say:
+
+> "No cached offers to calibrate against. Run `/scan` first."
+
+## State you track in-memory during the loop
+
+- `currentFilter`: `{ positive, negative, required_any, blacklist }` — starts as a copy of what you read from `portals.yml` (positive/negative/required_any) and `candidate-profile.yml` (`blacklist_companies` → `blacklist`).
+- `lastStats`: result of the most recent simulation against `currentFilter`.
+
+Never write to disk except on an explicit *Save*.
+
+## Loop
+
+Repeat until the user picks Save or Discard:
+
+### 1. Simulate
+
+Run:
+
+```bash
+echo '<currentFilter as JSON>' | node src/scan/tune-filter.mjs --history data/scan-history.tsv
+```
+
+Parse the JSON result into `lastStats`.
+
+### 2. Render the summary
+
+Print, in this order:
+
+```
+Loaded <total> cached offers from data/scan-history.tsv (<first_seen_min> → <first_seen_max>).
+
+Current filter:
+  positive:     [<comma-joined>]
+  negative:     [<comma-joined>]
+  required_any: [<comma-joined>]
+  blacklist:    [<comma-joined>]
+
+Effective match: <accepted> / <total> (<ratio_percent>%)
+
+Rejected by reason:
+  <count>  <reason>
+  ...
+
+Sample rejects (up to 10 per reason):
+  • "<title>" (<company>, <portal>)
+  ...
+
+Top companies passing filter:
+  <accepted>  <company>
+  ...
+```
+
+If `scan-history.tsv` is older than 7 days (compare latest `first_seen` to today), print after the summary:
+
+```
+⚠️  Corpus is <N> days old — consider /scan for fresh data.
+```
+
+### 3. Action menu
+
+Use `AskUserQuestion` with these options:
+
+- **Edit filter** → go to 4.
+- **Suggest keywords** → go to 5.
+- **Test alternative** → go to 6.
+- **Save** → go to 7.
+- **Discard** → print "No changes written." and exit.
+
+### 4. Edit sub-flow
+
+Ask which list to edit: `positive`, `negative`, `required_any`, `blacklist`.
+
+For the chosen list, offer:
+
+- **Remove** → `AskUserQuestion` `multiSelect` with the list's current values as options; drop the selected ones from `currentFilter`.
+- **Add** → free-text prompt ("one keyword per line; wrap in `/…/` for regex"). For each entered term, run it through a regex-compile check by invoking:
+
+  ```bash
+  node -e 'import("./src/lib/prefilter-rules.mjs").then(({ checkTitle }) => { const r = checkTitle({title:"x"}, {positive:[<JSON_term>]}); if (r.reason && r.reason.includes("invalid title_filter term")) { process.exit(1); } })'
+  ```
+
+  If the process exits non-zero, surface the term as invalid and re-prompt. Do not add invalid terms.
+- **Clear** → confirm via `AskUserQuestion` yes/no; on yes, empty the list.
+- **Done** → return to step 1 (re-simulate with the mutated `currentFilter`).
+
+### 5. Suggest sub-flow
+
+1. Select from `lastStats.sampleRejected` all entries whose `reason` starts with `title:`. Collect their `title` fields. Also pull the full rejected-title list by re-simulating with `sampleRejected` bumped — but for v1, the in-memory sample (capped at 10 per reason) is enough.
+2. Call:
+
+   ```bash
+   node -e '
+     import("./src/lib/title-ngrams.mjs").then(({ suggestNgrams }) => {
+       const titles = <JSON of titles>;
+       const existing = <JSON of all current filter terms>;
+       const STOP = new Set(["the","and","of","in","for","a","to","at","with","on","as","by","or","an","-"]);
+       console.log(JSON.stringify(suggestNgrams(titles, { maxN: 3, minCount: 3, stopWords: STOP, existingTerms: existing })));
+     });
+   '
+   ```
+
+3. Display the top 10 suggestions:
+
+   ```
+   Suggestion      Count   Lift
+   research engineer   8   0.16
+   applied scientist   6   0.12
+   ...
+   ```
+
+4. `AskUserQuestion` `multiSelect` — user picks which n-grams to add.
+5. `AskUserQuestion` single-select — target list for the picks (default `required_any`, alternatives `positive`, `negative`).
+6. Merge picks into `currentFilter[targetList]` (deduplicate, preserve existing order, append new at the end).
+7. Return to step 1.
+
+### 6. Test alternative sub-flow
+
+Prompt the user for a YAML snippet (parsed with `js-yaml`) shaped like:
+
+```yaml
+positive: [Intern]
+negative: []
+required_any: []
+blacklist: []
+```
+
+Merge missing keys with `currentFilter`, simulate once without mutating `currentFilter`, print the delta:
+
+```
+Effective match: <oldAccepted> → <newAccepted> (<signed_delta>)
+New companies represented: <company (count)>, ...
+```
+
+Return to step 3 with `currentFilter` unchanged.
+
+### 7. Save sub-flow
+
+1. Compute the diff of each list between the loaded filter and `currentFilter`; render as:
+
+   ```
+   title_filter.positive:
+     + Stagiaire
+     - (nothing removed)
+   title_filter.required_any:
+     + Research
+     + Applied Scientist
+   blacklist:
+     + ReallyBadCorp
+   ```
+
+   If no differences exist, say "No changes to save." and return to step 3.
+
+2. `AskUserQuestion` yes/no: "Write changes to `config/portals.yml` and `config/candidate-profile.yml`?". On no, return to step 3.
+
+3. Apply the writes:
+
+   - For `title_filter.*` changes, call the writer:
+
+     ```bash
+     node -e '
+       import("./src/lib/portals-writer.mjs").then(({ write }) => {
+         write("config/portals.yml", { title_filter: <JSON of changed title_filter keys> });
+       });
+     '
+     ```
+
+   - For `blacklist` changes, use the same writer against `candidate-profile.yml` — **same rules, different file**:
+
+     ```bash
+     node -e '
+       import("./src/lib/portals-writer.mjs").then(({ write }) => {
+         write("config/candidate-profile.yml", { blacklist: <JSON array> });
+       });
+     '
+     ```
+
+     Note: the writer mutates the `blacklist_companies` key on the profile file. Until the writer supports a configurable key name, skip blacklist persistence for v1 and print:
+
+     > "Blacklist changes are v1.1 — update `blacklist_companies` in `candidate-profile.yml` manually for now."
+
+   - If either `node -e` exits non-zero, surface the error, write the candidate YAML to `config/portals.yml.tune-proposal`, print:
+
+     > "Could not round-trip; candidate written to `config/portals.yml.tune-proposal`. Merge manually."
+
+4. Re-simulate against the now-persisted filter once, print the final ratio, and exit.
+
+## Example run
+
+```
+$ /tune-filter
+
+Loaded 2 359 cached offers from data/scan-history.tsv (2026-04-12 → 2026-04-19).
+
+Current filter:
+  positive:     [Intern, Internship, Stage, Stagiaire]
+  negative:     []
+  required_any: []
+  blacklist:    []
+
+Effective match: 412 / 2 359 (17.5%)
+
+...
+```

--- a/.claude/commands/tune-filter.md
+++ b/.claude/commands/tune-filter.md
@@ -1,6 +1,6 @@
 ---
 description: Interactive calibration of portals.yml title_filter against cached scan-history
-argument-hint: ""
+argument-hint: ''
 ---
 
 # /tune-filter
@@ -22,7 +22,7 @@ If `data/scan-history.tsv` is missing or empty, **stop** and say:
 - `currentFilter`: `{ positive, negative, required_any, blacklist }` — starts as a copy of what you read from `portals.yml` (positive/negative/required_any) and `candidate-profile.yml` (`blacklist_companies` → `blacklist`).
 - `lastStats`: result of the most recent simulation against `currentFilter`.
 
-Never write to disk except on an explicit *Save*.
+Never write to disk except on an explicit _Save_.
 
 ## Loop
 
@@ -96,6 +96,7 @@ For the chosen list, offer:
   ```
 
   If the process exits non-zero, surface the term as invalid and re-prompt. Do not add invalid terms.
+
 - **Clear** → confirm via `AskUserQuestion` yes/no; on yes, empty the list.
 - **Done** → return to step 1 (re-simulate with the mutated `currentFilter`).
 
@@ -169,7 +170,6 @@ Return to step 3 with `currentFilter` unchanged.
 2. `AskUserQuestion` yes/no: "Write changes to `config/portals.yml` and `config/candidate-profile.yml`?". On no, return to step 3.
 
 3. Apply the writes:
-
    - For `title_filter.*` changes, call the writer:
 
      ```bash

--- a/.claude/commands/tune-filter.md
+++ b/.claude/commands/tune-filter.md
@@ -19,7 +19,7 @@ If `data/scan-history.tsv` is missing or empty, **stop** and say:
 
 ## State you track in-memory during the loop
 
-- `currentFilter`: `{ positive, negative, required_any, blacklist }` — starts as a copy of what you read from `portals.yml` (positive/negative/required_any) and `candidate-profile.yml` (`blacklist_companies` → `blacklist`).
+- `currentFilter`: `{ positive, negative, required_any, blacklist, companies }` — starts as a copy of what you read from `portals.yml` (positive/negative/required_any, plus the full `tracked_companies` list as `companies` so the simulator can honour per-company `skip_required_any`) and `candidate-profile.yml` (`blacklist_companies` → `blacklist`).
 - `lastStats`: result of the most recent simulation against `currentFilter`.
 
 Never write to disk except on an explicit _Save_.
@@ -185,14 +185,12 @@ Return to step 3 with `currentFilter` unchanged.
      ```bash
      node -e '
        import("./src/lib/portals-writer.mjs").then(({ write }) => {
-         write("config/candidate-profile.yml", { blacklist: <JSON array> });
+         write("config/candidate-profile.yml", { blacklist_companies: <JSON array> });
        });
      '
      ```
 
-     Note: the writer mutates the `blacklist_companies` key on the profile file. Until the writer supports a configurable key name, skip blacklist persistence for v1 and print:
-
-     > "Blacklist changes are v1.1 — update `blacklist_companies` in `candidate-profile.yml` manually for now."
+     The writer replaces the `blacklist_companies` list in-place and preserves surrounding comments.
 
    - If either `node -e` exits non-zero, surface the error, write the candidate YAML to `config/portals.yml.tune-proposal`, print:
 

--- a/README.md
+++ b/README.md
@@ -81,18 +81,19 @@ Then:
 
 ## Commands reference
 
-| Command                          | Purpose                                                             |
-| -------------------------------- | ------------------------------------------------------------------- |
-| `node src/scan/index.mjs`        | Scan Group A ATSes; append new offers to `data/pipeline.md`.        |
-| `node src/score/index.mjs <url>` | LLM-evaluate an offer; append to `data/evaluations.jsonl`.          |
-| `node src/apply/upload-file.mjs` | CDP file upload helper (called by `/apply`).                        |
-| `node src/dashboard/build.mjs`   | Regenerate `dashboard.html` from `data/` and `reports/`.            |
-| `bash scripts/setup.sh`          | Interactive first-time setup (Chrome CDP profile + templates + rc). |
-| `bash scripts/check-no-pii.sh`   | Grep the tree for personal data patterns (CI gate).                 |
-| `npm test`                       | Run the node test suite.                                            |
-| `/scan`                          | Claude Code slash command wrapping `node src/scan/index.mjs`.       |
-| `/score <url>`                   | Claude Code slash command wrapping `node src/score/index.mjs`.      |
-| `/apply <url>`                   | Claude Code orchestrator: open → classify → fill → upload → submit. |
+| Command                          | Purpose                                                                                        |
+| -------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `node src/scan/index.mjs`        | Scan Group A ATSes; append new offers to `data/pipeline.md`.                                   |
+| `node src/score/index.mjs <url>` | LLM-evaluate an offer; append to `data/evaluations.jsonl`.                                     |
+| `node src/apply/upload-file.mjs` | CDP file upload helper (called by `/apply`).                                                   |
+| `node src/dashboard/build.mjs`   | Regenerate `dashboard.html` from `data/` and `reports/`.                                       |
+| `bash scripts/setup.sh`          | Interactive first-time setup (Chrome CDP profile + templates + rc).                            |
+| `bash scripts/check-no-pii.sh`   | Grep the tree for personal data patterns (CI gate).                                            |
+| `npm test`                       | Run the node test suite.                                                                       |
+| `/scan`                          | Claude Code slash command wrapping `node src/scan/index.mjs`.                                  |
+| `/score <url>`                   | Claude Code slash command wrapping `node src/score/index.mjs`.                                 |
+| `/tune-filter`                   | Interactive calibration of `title_filter` against cached `scan-history.tsv`. No network calls. |
+| `/apply <url>`                   | Claude Code orchestrator: open → classify → fill → upload → submit.                            |
 
 ## Configuration
 

--- a/docs/for-agents.md
+++ b/docs/for-agents.md
@@ -44,7 +44,7 @@ Open `data/pipeline.md` and pick offers. Score a subset, then apply to the ones 
 - **Don't silently retry after a failure.** Log the first failure, diagnose, then retry once if appropriate.
 - **Don't hardcode URLs, company names, paths, or personal data.** Everything user-specific goes in `config/` or `data/`. See the PII gate.
 - **Don't catch errors to "make the test pass".** The test is telling you something — fix the root cause.
-- **Don't add dependencies casually.** Node standard library first. `js-yaml` and `playwright` are the only runtime deps and that's the bar.
+- **Don't add dependencies casually.** Node standard library first. Current runtime deps: `js-yaml` (loaders), `yaml` (comment-preserving writes in `src/lib/portals-writer.mjs` — `js-yaml` cannot round-trip comments), and `playwright`. Adding anything else needs a specific capability justification in the PR.
 - **Don't create documentation files the user didn't ask for.** Work from conversation context.
 - **Don't narrate what you're thinking.** Tool calls + short status updates are enough. Match the user's energy.
 

--- a/docs/scan-workflow.md
+++ b/docs/scan-workflow.md
@@ -32,6 +32,8 @@ A URL that doesn't match these patterns is skipped silently. To add a new ATS, s
 
 ## Title filter
 
+> **Low match ratio?** Run `/tune-filter` — it reads `data/scan-history.tsv` and lets you simulate filter changes without re-scanning.
+
 `portals.yml.title_filter.positive` / `negative` are whole-word regexes matched against the job **title**. `required_any` is a domain filter matched against the **job title only**: at least one keyword must appear in the title. This ensures non-tech roles at tech companies (e.g. "General Secretary Associate intern") are filtered out even when their descriptions mention tech terms casually. Use `skip_required_any: true` per company to bypass this filter for ATS portals whose job titles do not include the domain keyword (e.g. Mistral AI, where the company name alone implies the domain).
 
 Example:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "js-yaml": "^4.1.0"
+        "js-yaml": "^4.1.0",
+        "yaml": "^2.8.3"
       },
       "devDependencies": {
         "jsdom": "^29.0.2",
@@ -630,6 +631,21 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "prettier": "^3.8.3"
   },
   "dependencies": {
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "yaml": "^2.8.3"
   }
 }

--- a/src/lib/portals-writer.mjs
+++ b/src/lib/portals-writer.mjs
@@ -9,7 +9,8 @@ export function write(portalsPath, mutations) {
     const tf = mutations.title_filter;
     if (Array.isArray(tf.positive)) doc.setIn(['title_filter', 'positive'], tf.positive);
     if (Array.isArray(tf.negative)) doc.setIn(['title_filter', 'negative'], tf.negative);
-    if (Array.isArray(tf.required_any)) doc.setIn(['title_filter', 'required_any'], tf.required_any);
+    if (Array.isArray(tf.required_any))
+      doc.setIn(['title_filter', 'required_any'], tf.required_any);
   }
 
   if (Array.isArray(mutations.blacklist)) {

--- a/src/lib/portals-writer.mjs
+++ b/src/lib/portals-writer.mjs
@@ -13,8 +13,8 @@ export function write(portalsPath, mutations) {
       doc.setIn(['title_filter', 'required_any'], tf.required_any);
   }
 
-  if (Array.isArray(mutations.blacklist)) {
-    doc.setIn(['blacklist'], mutations.blacklist);
+  if (Array.isArray(mutations.blacklist_companies)) {
+    doc.setIn(['blacklist_companies'], mutations.blacklist_companies);
   }
 
   fs.writeFileSync(portalsPath, doc.toString());

--- a/src/lib/portals-writer.mjs
+++ b/src/lib/portals-writer.mjs
@@ -1,0 +1,20 @@
+import fs from 'node:fs';
+import { parseDocument } from 'yaml';
+
+export function write(portalsPath, mutations) {
+  const text = fs.readFileSync(portalsPath, 'utf8');
+  const doc = parseDocument(text);
+
+  if (mutations.title_filter) {
+    const tf = mutations.title_filter;
+    if (Array.isArray(tf.positive)) doc.setIn(['title_filter', 'positive'], tf.positive);
+    if (Array.isArray(tf.negative)) doc.setIn(['title_filter', 'negative'], tf.negative);
+    if (Array.isArray(tf.required_any)) doc.setIn(['title_filter', 'required_any'], tf.required_any);
+  }
+
+  if (Array.isArray(mutations.blacklist)) {
+    doc.setIn(['blacklist'], mutations.blacklist);
+  }
+
+  fs.writeFileSync(portalsPath, doc.toString());
+}

--- a/src/lib/title-ngrams.mjs
+++ b/src/lib/title-ngrams.mjs
@@ -40,8 +40,5 @@ export function suggestNgrams(titles, { maxN, minCount, stopWords, existingTerms
 
 export function tokenize(title) {
   if (!title) return [];
-  return String(title)
-    .toLowerCase()
-    .split(WORD_SPLIT_RE)
-    .filter(Boolean);
+  return String(title).toLowerCase().split(WORD_SPLIT_RE).filter(Boolean);
 }

--- a/src/lib/title-ngrams.mjs
+++ b/src/lib/title-ngrams.mjs
@@ -11,6 +11,33 @@ export function ngrams(tokens, maxN) {
   return out;
 }
 
+export function suggestNgrams(titles, { maxN, minCount, stopWords, existingTerms }) {
+  const existing = new Set((existingTerms || []).map((t) => String(t).toLowerCase()));
+  const counts = new Map();
+  const total = titles.length || 1;
+
+  for (const title of titles) {
+    const tokens = tokenize(title);
+    const seen = new Set();
+    for (const gram of ngrams(tokens, maxN)) {
+      if (seen.has(gram)) continue;
+      seen.add(gram);
+      const parts = gram.split(' ');
+      if (parts.every((p) => stopWords.has(p))) continue;
+      if (existing.has(gram)) continue;
+      counts.set(gram, (counts.get(gram) || 0) + 1);
+    }
+  }
+
+  const ranked = [];
+  for (const [ngram, count] of counts) {
+    if (count < minCount) continue;
+    ranked.push({ ngram, count, lift: count / total });
+  }
+  ranked.sort((a, b) => b.count - a.count || a.ngram.localeCompare(b.ngram));
+  return ranked;
+}
+
 export function tokenize(title) {
   if (!title) return [];
   return String(title)

--- a/src/lib/title-ngrams.mjs
+++ b/src/lib/title-ngrams.mjs
@@ -1,5 +1,16 @@
 const WORD_SPLIT_RE = /[^\p{L}\p{N}]+/u;
 
+export function ngrams(tokens, maxN) {
+  const out = [];
+  for (let n = 1; n <= maxN; n++) {
+    if (tokens.length < n) break;
+    for (let i = 0; i + n <= tokens.length; i++) {
+      out.push(tokens.slice(i, i + n).join(' '));
+    }
+  }
+  return out;
+}
+
 export function tokenize(title) {
   if (!title) return [];
   return String(title)

--- a/src/lib/title-ngrams.mjs
+++ b/src/lib/title-ngrams.mjs
@@ -11,8 +11,13 @@ export function ngrams(tokens, maxN) {
   return out;
 }
 
-export function suggestNgrams(titles, { maxN, minCount, stopWords, existingTerms }) {
-  const existing = new Set((existingTerms || []).map((t) => String(t).toLowerCase()));
+export function suggestNgrams(titles, options = {}) {
+  const maxN = Number.isInteger(options.maxN) && options.maxN >= 1 ? options.maxN : 3;
+  const minCount =
+    Number.isInteger(options.minCount) && options.minCount >= 1 ? options.minCount : 2;
+  const stopWords =
+    options.stopWords instanceof Set ? options.stopWords : new Set(options.stopWords || []);
+  const existing = new Set((options.existingTerms || []).map((t) => String(t).toLowerCase()));
   const counts = new Map();
   const total = titles.length || 1;
 

--- a/src/lib/title-ngrams.mjs
+++ b/src/lib/title-ngrams.mjs
@@ -1,0 +1,9 @@
+const WORD_SPLIT_RE = /[^\p{L}\p{N}]+/u;
+
+export function tokenize(title) {
+  if (!title) return [];
+  return String(title)
+    .toLowerCase()
+    .split(WORD_SPLIT_RE)
+    .filter(Boolean);
+}

--- a/src/scan/tune-filter.mjs
+++ b/src/scan/tune-filter.mjs
@@ -6,12 +6,24 @@ import { checkTitle, checkBlacklist } from '../lib/prefilter-rules.mjs';
 const SAMPLE_PER_REASON = 10;
 const TOP_COMPANIES = 20;
 
-export function simulate(filter, rows) {
-  const whitelist = {
+function buildSkipRequiredAny(companies) {
+  const set = new Set();
+  for (const c of companies || []) {
+    if (c && c.skip_required_any && typeof c.name === 'string') {
+      set.add(c.name.toLowerCase());
+    }
+  }
+  return set;
+}
+
+export function simulate(filter, rows, { companies } = {}) {
+  const baseWhitelist = {
     positive: filter.positive || [],
     negative: filter.negative || [],
     required_any: filter.required_any || [],
   };
+  const skipWhitelist = { ...baseWhitelist, required_any: [] };
+  const skipSet = buildSkipRequiredAny(companies);
   const blacklist = filter.blacklist || [];
 
   const rejectedByReason = new Map();
@@ -20,7 +32,10 @@ export function simulate(filter, rows) {
 
   let accepted = 0;
   for (const row of rows) {
+    const co = row.company || '(unknown)';
+    const portal = row.portal || '(unknown)';
     const offer = { title: row.title || '', company: row.company || '' };
+    const whitelist = skipSet.has(co.toLowerCase()) ? skipWhitelist : baseWhitelist;
     let reason = null;
 
     const t = checkTitle(offer, whitelist);
@@ -31,7 +46,6 @@ export function simulate(filter, rows) {
       if (!b.pass) reason = b.reason;
     }
 
-    const co = row.company || '(unknown)';
     const agg = companyAgg.get(co) || { company: co, accepted: 0, rejected: 0 };
     if (reason === null) {
       accepted += 1;
@@ -41,7 +55,7 @@ export function simulate(filter, rows) {
       rejectedByReason.set(reason, (rejectedByReason.get(reason) || 0) + 1);
       const list = sampleRejected.get(reason) || [];
       if (list.length < SAMPLE_PER_REASON) {
-        list.push({ title: row.title, company: row.company, portal: row.portal });
+        list.push({ title: row.title || '', company: co, portal });
         sampleRejected.set(reason, list);
       }
     }
@@ -139,7 +153,7 @@ async function main() {
     process.exit(2);
   }
   const rows = parseHistory(fs.readFileSync(historyPath, 'utf8'));
-  const stats = simulate(filter, rows);
+  const stats = simulate(filter, rows, { companies: filter.companies });
   process.stdout.write(JSON.stringify(statsToJson(stats), null, 2));
 }
 

--- a/src/scan/tune-filter.mjs
+++ b/src/scan/tune-filter.mjs
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
 import { checkTitle, checkBlacklist } from '../lib/prefilter-rules.mjs';
 
 const SAMPLE_PER_REASON = 10;
@@ -58,4 +61,92 @@ export function simulate(filter, rows) {
     sampleRejected,
     byCompany,
   };
+}
+
+function parseHistory(text) {
+  const lines = text.split('\n').filter(Boolean);
+  if (lines.length === 0) return [];
+  const header = lines[0].split('\t');
+  const idx = {
+    url: header.indexOf('url'),
+    first_seen: header.indexOf('first_seen'),
+    portal: header.indexOf('portal'),
+    title: header.indexOf('title'),
+    company: header.indexOf('company'),
+    status: header.indexOf('status'),
+  };
+  return lines.slice(1).map((line) => {
+    const cols = line.split('\t');
+    return {
+      url: cols[idx.url] || '',
+      first_seen: cols[idx.first_seen] || '',
+      portal: cols[idx.portal] || '',
+      title: cols[idx.title] || '',
+      company: cols[idx.company] || '',
+      status: cols[idx.status] || '',
+    };
+  });
+}
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (c) => (data += c));
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+function argVal(argv, flag) {
+  const i = argv.indexOf(flag);
+  return i >= 0 ? argv[i + 1] : undefined;
+}
+
+function statsToJson(stats) {
+  return {
+    total: stats.total,
+    accepted: stats.accepted,
+    ratio: stats.ratio,
+    rejectedByReason: [...stats.rejectedByReason.entries()].map(([reason, count]) => ({
+      reason,
+      count,
+    })),
+    sampleRejected: [...stats.sampleRejected.entries()].map(([reason, samples]) => ({
+      reason,
+      samples,
+    })),
+    byCompany: stats.byCompany,
+  };
+}
+
+async function main() {
+  const historyPath = argVal(process.argv, '--history');
+  if (!historyPath) {
+    console.error('usage: tune-filter.mjs --history <path> < filter.json');
+    process.exit(2);
+  }
+  if (!fs.existsSync(historyPath)) {
+    console.error(`scan-history not found: ${historyPath}`);
+    process.exit(2);
+  }
+  const rawFilter = await readStdin();
+  let filter;
+  try {
+    filter = JSON.parse(rawFilter);
+  } catch (err) {
+    console.error(`invalid filter JSON on stdin: ${err.message}`);
+    process.exit(2);
+  }
+  const rows = parseHistory(fs.readFileSync(historyPath, 'utf8'));
+  const stats = simulate(filter, rows);
+  process.stdout.write(JSON.stringify(statsToJson(stats), null, 2));
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  main().catch((err) => {
+    console.error(err.message);
+    process.exit(1);
+  });
 }

--- a/src/scan/tune-filter.mjs
+++ b/src/scan/tune-filter.mjs
@@ -1,0 +1,61 @@
+import { checkTitle, checkBlacklist } from '../lib/prefilter-rules.mjs';
+
+const SAMPLE_PER_REASON = 10;
+const TOP_COMPANIES = 20;
+
+export function simulate(filter, rows) {
+  const whitelist = {
+    positive: filter.positive || [],
+    negative: filter.negative || [],
+    required_any: filter.required_any || [],
+  };
+  const blacklist = filter.blacklist || [];
+
+  const rejectedByReason = new Map();
+  const sampleRejected = new Map();
+  const companyAgg = new Map();
+
+  let accepted = 0;
+  for (const row of rows) {
+    const offer = { title: row.title || '', company: row.company || '' };
+    let reason = null;
+
+    const t = checkTitle(offer, whitelist);
+    if (!t.pass) {
+      reason = t.reason;
+    } else {
+      const b = checkBlacklist(offer, blacklist);
+      if (!b.pass) reason = b.reason;
+    }
+
+    const co = row.company || '(unknown)';
+    const agg = companyAgg.get(co) || { company: co, accepted: 0, rejected: 0 };
+    if (reason === null) {
+      accepted += 1;
+      agg.accepted += 1;
+    } else {
+      agg.rejected += 1;
+      rejectedByReason.set(reason, (rejectedByReason.get(reason) || 0) + 1);
+      const list = sampleRejected.get(reason) || [];
+      if (list.length < SAMPLE_PER_REASON) {
+        list.push({ title: row.title, company: row.company, portal: row.portal });
+        sampleRejected.set(reason, list);
+      }
+    }
+    companyAgg.set(co, agg);
+  }
+
+  const total = rows.length;
+  const byCompany = [...companyAgg.values()]
+    .sort((a, b) => b.accepted - a.accepted || b.rejected - a.rejected)
+    .slice(0, TOP_COMPANIES);
+
+  return {
+    total,
+    accepted,
+    ratio: total === 0 ? 0 : accepted / total,
+    rejectedByReason,
+    sampleRejected,
+    byCompany,
+  };
+}

--- a/tests/fixtures/portals/profile-with-comments.yml
+++ b/tests/fixtures/portals/profile-with-comments.yml
@@ -1,0 +1,11 @@
+# Candidate profile — minimal fixture for portals-writer tests.
+identity:
+  first_name: Alice
+  last_name: Martin
+
+# Companies to exclude from scans.
+blacklist_companies:
+  - BadCorp
+
+# Earliest date the candidate can start.
+min_start_date: '2026-08-24'

--- a/tests/fixtures/portals/with-comments.yml
+++ b/tests/fixtures/portals/with-comments.yml
@@ -1,0 +1,17 @@
+# Companies to scan for open positions.
+tracked_companies:
+  - name: Mistral AI
+    careers_url: https://jobs.lever.co/mistral
+    enabled: true
+
+title_filter:
+  # positive and negative terms match WHOLE WORDS.
+  positive:
+    - Intern
+    - Stage
+
+  # Optional exclusion keywords.
+  negative: []
+
+  # Domain filter layered on top.
+  required_any: []

--- a/tests/fixtures/scan-history-sample.tsv
+++ b/tests/fixtures/scan-history-sample.tsv
@@ -1,0 +1,4 @@
+url	first_seen	portal	title	company	status
+https://example.com/1	2026-04-19	lever	Software Engineer Intern	OpenAI	skipped_title
+https://example.com/2	2026-04-19	greenhouse	ML Engineer Intern	Anthropic	added
+https://example.com/3	2026-04-19	greenhouse	Senior Backend Engineer	Stripe	skipped_title

--- a/tests/lib/portals-writer.test.mjs
+++ b/tests/lib/portals-writer.test.mjs
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { write } from '../../src/lib/portals-writer.mjs';
+
+function copyFixture() {
+  const src = path.join(
+    path.dirname(new URL(import.meta.url).pathname),
+    '..',
+    'fixtures',
+    'portals',
+    'with-comments.yml'
+  );
+  const dst = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'portals-')), 'portals.yml');
+  fs.copyFileSync(src, dst);
+  return dst;
+}
+
+test('write adds new positive keywords and preserves comments', () => {
+  const file = copyFixture();
+  write(file, { title_filter: { positive: ['Intern', 'Stage', 'Stagiaire'] } });
+  const out = fs.readFileSync(file, 'utf8');
+  assert.match(out, /# Companies to scan for open positions\./);
+  assert.match(out, /# positive and negative terms match WHOLE WORDS\./);
+  assert.match(out, /- Stagiaire/);
+});
+
+test('write updates required_any and preserves comments in other blocks', () => {
+  const file = copyFixture();
+  write(file, { title_filter: { required_any: ['ML', 'AI'] } });
+  const after = fs.readFileSync(file, 'utf8');
+  assert.ok(/required_any:/.test(after));
+  assert.ok(/\bML\b/.test(after) && /\bAI\b/.test(after));
+  assert.match(after, /# Companies to scan for open positions\./);
+  assert.match(after, /# Optional exclusion keywords\./);
+  assert.match(after, /# Domain filter layered on top\./);
+});
+
+test('write round-trips without losing comments when mutations is empty', () => {
+  const file = copyFixture();
+  write(file, {});
+  const after = fs.readFileSync(file, 'utf8');
+  assert.match(after, /# Companies to scan for open positions\./);
+  assert.match(after, /# positive and negative terms match WHOLE WORDS\./);
+  assert.match(after, /# Optional exclusion keywords\./);
+  assert.match(after, /# Domain filter layered on top\./);
+});
+
+test('write throws when portals file missing', () => {
+  assert.throws(() => write('/nonexistent/portals.yml', { title_filter: { positive: ['X'] } }));
+});

--- a/tests/lib/portals-writer.test.mjs
+++ b/tests/lib/portals-writer.test.mjs
@@ -6,13 +6,13 @@ import path from 'node:path';
 
 import { write } from '../../src/lib/portals-writer.mjs';
 
-function copyFixture() {
+function copyFixture(name = 'with-comments.yml') {
   const src = path.join(
     path.dirname(new URL(import.meta.url).pathname),
     '..',
     'fixtures',
     'portals',
-    'with-comments.yml'
+    name
   );
   const dst = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'portals-')), 'portals.yml');
   fs.copyFileSync(src, dst);
@@ -51,4 +51,15 @@ test('write round-trips without losing comments when mutations is empty', () => 
 
 test('write throws when portals file missing', () => {
   assert.throws(() => write('/nonexistent/portals.yml', { title_filter: { positive: ['X'] } }));
+});
+
+test('write replaces blacklist_companies and preserves profile comments', () => {
+  const file = copyFixture('profile-with-comments.yml');
+  write(file, { blacklist_companies: ['BadCorp', 'EvilInc'] });
+  const after = fs.readFileSync(file, 'utf8');
+  assert.match(after, /# Candidate profile — minimal fixture/);
+  assert.match(after, /# Companies to exclude from scans\./);
+  assert.match(after, /- BadCorp/);
+  assert.match(after, /- EvilInc/);
+  assert.doesNotMatch(after, /^blacklist:/m);
 });

--- a/tests/lib/title-ngrams.test.mjs
+++ b/tests/lib/title-ngrams.test.mjs
@@ -99,3 +99,16 @@ test('suggestNgrams drops ngrams that are entirely stop-words', () => {
   });
   assert.deepEqual(out, []);
 });
+
+test('suggestNgrams accepts array stopWords and applies sane defaults', () => {
+  const titles = ['Research Engineer', 'Research Engineer', 'Software Engineer'];
+  const out = suggestNgrams(titles, { stopWords: ['software'] });
+  const ngramsOnly = out.map((e) => e.ngram);
+  assert.ok(ngramsOnly.includes('research engineer'));
+  assert.ok(!ngramsOnly.includes('software'));
+});
+
+test('suggestNgrams returns results with no options provided', () => {
+  const out = suggestNgrams(['alpha beta', 'alpha beta', 'alpha beta']);
+  assert.ok(out.some((e) => e.ngram === 'alpha beta'));
+});

--- a/tests/lib/title-ngrams.test.mjs
+++ b/tests/lib/title-ngrams.test.mjs
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { tokenize } from '../../src/lib/title-ngrams.mjs';
+
+test('tokenize lowercases, strips punctuation, collapses whitespace', () => {
+  assert.deepEqual(tokenize('Research Engineer - Reinforcement Learning'), [
+    'research',
+    'engineer',
+    'reinforcement',
+    'learning',
+  ]);
+});
+
+test('tokenize drops empty tokens and keeps unicode letters', () => {
+  assert.deepEqual(tokenize('  Stagiaire  —  Développeur  '), ['stagiaire', 'développeur']);
+});
+
+test('tokenize returns [] for empty input', () => {
+  assert.deepEqual(tokenize(''), []);
+  assert.deepEqual(tokenize(null), []);
+});

--- a/tests/lib/title-ngrams.test.mjs
+++ b/tests/lib/title-ngrams.test.mjs
@@ -43,3 +43,59 @@ test('ngrams caps at token length', () => {
   assert.deepEqual(ngrams(['only'], 3), ['only']);
   assert.deepEqual(ngrams([], 3), []);
 });
+
+import { suggestNgrams } from '../../src/lib/title-ngrams.mjs';
+
+const STOP = new Set(['the', 'and', 'of', 'in', 'for', 'a', 'to', 'at']);
+
+test('suggestNgrams ranks by count desc with lift, filters stop-words', () => {
+  const titles = [
+    'Research Engineer - LLM',
+    'Research Engineer - Safety',
+    'Applied Scientist LLM',
+    'Applied Scientist Safety',
+    'Software Engineer',
+  ];
+  const out = suggestNgrams(titles, {
+    maxN: 2,
+    minCount: 2,
+    stopWords: STOP,
+    existingTerms: [],
+  });
+  const ngramsOnly = out.map((e) => e.ngram);
+  assert.ok(ngramsOnly.includes('research engineer'));
+  assert.ok(ngramsOnly.includes('applied scientist'));
+  const rResearch = out.find((e) => e.ngram === 'research engineer');
+  assert.equal(rResearch.count, 2);
+  assert.equal(rResearch.lift, 2 / 5);
+});
+
+test('suggestNgrams excludes existingTerms (case-insensitive, whole ngram)', () => {
+  const out = suggestNgrams(['Applied Scientist', 'Applied Scientist'], {
+    maxN: 2,
+    minCount: 2,
+    stopWords: new Set(),
+    existingTerms: ['Applied Scientist'],
+  });
+  assert.ok(!out.some((e) => e.ngram === 'applied scientist'));
+});
+
+test('suggestNgrams drops ngrams below minCount', () => {
+  const out = suggestNgrams(['alpha beta', 'gamma delta'], {
+    maxN: 2,
+    minCount: 2,
+    stopWords: new Set(),
+    existingTerms: [],
+  });
+  assert.deepEqual(out, []);
+});
+
+test('suggestNgrams drops ngrams that are entirely stop-words', () => {
+  const out = suggestNgrams(['the and', 'the and', 'the and'], {
+    maxN: 2,
+    minCount: 2,
+    stopWords: STOP,
+    existingTerms: [],
+  });
+  assert.deepEqual(out, []);
+});

--- a/tests/lib/title-ngrams.test.mjs
+++ b/tests/lib/title-ngrams.test.mjs
@@ -20,3 +20,26 @@ test('tokenize returns [] for empty input', () => {
   assert.deepEqual(tokenize(''), []);
   assert.deepEqual(tokenize(null), []);
 });
+
+import { ngrams } from '../../src/lib/title-ngrams.mjs';
+
+test('ngrams produces joined unigrams through maxN-grams', () => {
+  assert.deepEqual(ngrams(['research', 'engineer', 'intern'], 1), [
+    'research',
+    'engineer',
+    'intern',
+  ]);
+  assert.deepEqual(ngrams(['research', 'engineer', 'intern'], 2), [
+    'research',
+    'engineer',
+    'intern',
+    'research engineer',
+    'engineer intern',
+  ]);
+  assert.deepEqual(ngrams(['a', 'b', 'c'], 3), ['a', 'b', 'c', 'a b', 'b c', 'a b c']);
+});
+
+test('ngrams caps at token length', () => {
+  assert.deepEqual(ngrams(['only'], 3), ['only']);
+  assert.deepEqual(ngrams([], 3), []);
+});

--- a/tests/scan/tune-filter.test.mjs
+++ b/tests/scan/tune-filter.test.mjs
@@ -115,6 +115,28 @@ test('simulate handles empty rows', () => {
   assert.equal(res.ratio, 0);
 });
 
+test('simulate honours per-company skip_required_any', () => {
+  const filter = { positive: ['Intern'], negative: [], required_any: ['ML'], blacklist: [] };
+  const rowsSkip = [
+    { url: 's1', title: 'Research Intern', company: 'Mistral AI', portal: 'lever' },
+  ];
+  const withOverride = simulate(filter, rowsSkip, {
+    companies: [{ name: 'Mistral AI', skip_required_any: true }],
+  });
+  const withoutOverride = simulate(filter, rowsSkip);
+  assert.equal(withOverride.accepted, 1);
+  assert.equal(withoutOverride.accepted, 0);
+});
+
+test('simulate sampleRejected uses normalized company and portal', () => {
+  const res = simulate({ positive: ['Intern'], negative: [], required_any: [], blacklist: [] }, [
+    { url: 'u', title: 'Senior Engineer', company: '', portal: undefined },
+  ]);
+  const [sample] = res.sampleRejected.values().next().value;
+  assert.equal(sample.company, '(unknown)');
+  assert.equal(sample.portal, '(unknown)');
+});
+
 import { spawn } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/tests/scan/tune-filter.test.mjs
+++ b/tests/scan/tune-filter.test.mjs
@@ -4,11 +4,41 @@ import assert from 'node:assert/strict';
 import { simulate } from '../../src/scan/tune-filter.mjs';
 
 const rows = [
-  { url: 'u1', title: 'Software Engineer Intern', company: 'OpenAI', portal: 'lever', first_seen: '2026-04-19' },
-  { url: 'u2', title: 'ML Engineer Intern', company: 'Anthropic', portal: 'greenhouse', first_seen: '2026-04-19' },
-  { url: 'u3', title: 'Senior Backend Engineer', company: 'Stripe', portal: 'greenhouse', first_seen: '2026-04-19' },
-  { url: 'u4', title: 'Applied Scientist Intern - ML', company: 'DeepMind', portal: 'greenhouse', first_seen: '2026-04-19' },
-  { url: 'u5', title: 'Research Engineer Intern', company: 'BlacklistedCorp', portal: 'lever', first_seen: '2026-04-19' },
+  {
+    url: 'u1',
+    title: 'Software Engineer Intern',
+    company: 'OpenAI',
+    portal: 'lever',
+    first_seen: '2026-04-19',
+  },
+  {
+    url: 'u2',
+    title: 'ML Engineer Intern',
+    company: 'Anthropic',
+    portal: 'greenhouse',
+    first_seen: '2026-04-19',
+  },
+  {
+    url: 'u3',
+    title: 'Senior Backend Engineer',
+    company: 'Stripe',
+    portal: 'greenhouse',
+    first_seen: '2026-04-19',
+  },
+  {
+    url: 'u4',
+    title: 'Applied Scientist Intern - ML',
+    company: 'DeepMind',
+    portal: 'greenhouse',
+    first_seen: '2026-04-19',
+  },
+  {
+    url: 'u5',
+    title: 'Research Engineer Intern',
+    company: 'BlacklistedCorp',
+    portal: 'lever',
+    first_seen: '2026-04-19',
+  },
 ];
 
 test('simulate returns totals and ratio', () => {
@@ -39,7 +69,10 @@ test('simulate caps sampleRejected at 10 per reason', () => {
     portal: 'lever',
     first_seen: '2026-04-19',
   }));
-  const res = simulate({ positive: ['Intern'], negative: [], required_any: [], blacklist: [] }, many);
+  const res = simulate(
+    { positive: ['Intern'], negative: [], required_any: [], blacklist: [] },
+    many
+  );
   for (const sample of res.sampleRejected.values()) {
     assert.ok(sample.length <= 10);
   }
@@ -47,11 +80,29 @@ test('simulate caps sampleRejected at 10 per reason', () => {
 
 test('simulate byCompany ranks top 20 by accepted desc', () => {
   const many = [
-    ...Array.from({ length: 3 }, (_, i) => ({ url: `a${i}`, title: 'Intern', company: 'Alpha', portal: 'lever' })),
-    ...Array.from({ length: 5 }, (_, i) => ({ url: `b${i}`, title: 'Intern', company: 'Beta', portal: 'lever' })),
-    ...Array.from({ length: 1 }, (_, i) => ({ url: `c${i}`, title: 'Staff Engineer', company: 'Gamma', portal: 'lever' })),
+    ...Array.from({ length: 3 }, (_, i) => ({
+      url: `a${i}`,
+      title: 'Intern',
+      company: 'Alpha',
+      portal: 'lever',
+    })),
+    ...Array.from({ length: 5 }, (_, i) => ({
+      url: `b${i}`,
+      title: 'Intern',
+      company: 'Beta',
+      portal: 'lever',
+    })),
+    ...Array.from({ length: 1 }, (_, i) => ({
+      url: `c${i}`,
+      title: 'Staff Engineer',
+      company: 'Gamma',
+      portal: 'lever',
+    })),
   ];
-  const res = simulate({ positive: ['Intern'], negative: [], required_any: [], blacklist: [] }, many);
+  const res = simulate(
+    { positive: ['Intern'], negative: [], required_any: [], blacklist: [] },
+    many
+  );
   assert.equal(res.byCompany[0].company, 'Beta');
   assert.equal(res.byCompany[0].accepted, 5);
   assert.equal(res.byCompany[1].company, 'Alpha');

--- a/tests/scan/tune-filter.test.mjs
+++ b/tests/scan/tune-filter.test.mjs
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { simulate } from '../../src/scan/tune-filter.mjs';
+
+const rows = [
+  { url: 'u1', title: 'Software Engineer Intern', company: 'OpenAI', portal: 'lever', first_seen: '2026-04-19' },
+  { url: 'u2', title: 'ML Engineer Intern', company: 'Anthropic', portal: 'greenhouse', first_seen: '2026-04-19' },
+  { url: 'u3', title: 'Senior Backend Engineer', company: 'Stripe', portal: 'greenhouse', first_seen: '2026-04-19' },
+  { url: 'u4', title: 'Applied Scientist Intern - ML', company: 'DeepMind', portal: 'greenhouse', first_seen: '2026-04-19' },
+  { url: 'u5', title: 'Research Engineer Intern', company: 'BlacklistedCorp', portal: 'lever', first_seen: '2026-04-19' },
+];
+
+test('simulate returns totals and ratio', () => {
+  const res = simulate(
+    { positive: ['Intern'], negative: [], required_any: [], blacklist: [] },
+    rows
+  );
+  assert.equal(res.total, 5);
+  assert.equal(res.accepted, 4);
+  assert.equal(res.ratio, 4 / 5);
+});
+
+test('simulate buckets rejections by reason', () => {
+  const res = simulate(
+    { positive: ['Intern'], negative: [], required_any: [], blacklist: ['blacklistedcorp'] },
+    rows
+  );
+  const reasons = [...res.rejectedByReason.keys()].sort();
+  assert.ok(reasons.some((r) => r.startsWith('title:')));
+  assert.ok(reasons.some((r) => r.startsWith('blacklist:')));
+});
+
+test('simulate caps sampleRejected at 10 per reason', () => {
+  const many = Array.from({ length: 25 }, (_, i) => ({
+    url: `u${i}`,
+    title: `Offer ${i}`,
+    company: 'X',
+    portal: 'lever',
+    first_seen: '2026-04-19',
+  }));
+  const res = simulate({ positive: ['Intern'], negative: [], required_any: [], blacklist: [] }, many);
+  for (const sample of res.sampleRejected.values()) {
+    assert.ok(sample.length <= 10);
+  }
+});
+
+test('simulate byCompany ranks top 20 by accepted desc', () => {
+  const many = [
+    ...Array.from({ length: 3 }, (_, i) => ({ url: `a${i}`, title: 'Intern', company: 'Alpha', portal: 'lever' })),
+    ...Array.from({ length: 5 }, (_, i) => ({ url: `b${i}`, title: 'Intern', company: 'Beta', portal: 'lever' })),
+    ...Array.from({ length: 1 }, (_, i) => ({ url: `c${i}`, title: 'Staff Engineer', company: 'Gamma', portal: 'lever' })),
+  ];
+  const res = simulate({ positive: ['Intern'], negative: [], required_any: [], blacklist: [] }, many);
+  assert.equal(res.byCompany[0].company, 'Beta');
+  assert.equal(res.byCompany[0].accepted, 5);
+  assert.equal(res.byCompany[1].company, 'Alpha');
+});
+
+test('simulate handles empty rows', () => {
+  const res = simulate({ positive: [], negative: [], required_any: [], blacklist: [] }, []);
+  assert.equal(res.total, 0);
+  assert.equal(res.accepted, 0);
+  assert.equal(res.ratio, 0);
+});

--- a/tests/scan/tune-filter.test.mjs
+++ b/tests/scan/tune-filter.test.mjs
@@ -63,3 +63,43 @@ test('simulate handles empty rows', () => {
   assert.equal(res.accepted, 0);
   assert.equal(res.ratio, 0);
 });
+
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.join(__dirname, '..', '..', 'src', 'scan', 'tune-filter.mjs');
+const FIXTURE = path.join(__dirname, '..', 'fixtures', 'scan-history-sample.tsv');
+
+function runCli(input, args) {
+  return new Promise((resolve, reject) => {
+    const p = spawn('node', [CLI, ...args], { stdio: ['pipe', 'pipe', 'pipe'] });
+    let out = '';
+    let err = '';
+    p.stdout.on('data', (c) => (out += c.toString()));
+    p.stderr.on('data', (c) => (err += c.toString()));
+    p.on('error', reject);
+    p.on('exit', (code) => resolve({ code, out, err }));
+    p.stdin.write(input);
+    p.stdin.end();
+  });
+}
+
+test('CLI reads filter JSON on stdin, emits stats JSON on stdout', async () => {
+  const filter = { positive: ['Intern'], negative: [], required_any: ['ML'], blacklist: [] };
+  const { code, out } = await runCli(JSON.stringify(filter), ['--history', FIXTURE]);
+  assert.equal(code, 0);
+  const parsed = JSON.parse(out);
+  assert.equal(parsed.total, 3);
+  assert.equal(parsed.accepted, 1);
+  assert.ok(Array.isArray(parsed.rejectedByReason));
+  assert.ok(Array.isArray(parsed.sampleRejected));
+  assert.ok(Array.isArray(parsed.byCompany));
+});
+
+test('CLI errors with exit code 2 when history missing', async () => {
+  const { code, err } = await runCli('{}', ['--history', '/nonexistent']);
+  assert.equal(code, 2);
+  assert.match(err, /scan-history/);
+});


### PR DESCRIPTION
## Summary

- Adds `/tune-filter` slash command for interactive calibration of `config/portals.yml.title_filter` and `blacklist_companies` against the cached `data/scan-history.tsv` corpus (zero network calls)
- Adds three pure library modules: `title-ngrams.mjs` (tokenise + n-gram ranking), `tune-filter.mjs` (simulate + CLI wrapper), `portals-writer.mjs` (YAML round-trip with comment preservation via `yaml` package)
- 20 new unit tests covering all modules; total suite: 519 tests

## Test Plan

- [x] `npm test` — 519/519 pass
- [x] `npm run lint` — Prettier clean
- [x] `npm run check:pii` — no PII detected
- [x] CLI smoke test: `echo '{"positive":["Intern"],...}' | node src/scan/tune-filter.mjs --history tests/fixtures/scan-history-sample.tsv` — valid JSON output
- [x] Writer round-trip: diff against fixture is empty (comments preserved)

Closes #85

🤖 Generated with [Claude Code](https://claude.ai/claude-code)