### PR TITLE
feat(scan): Workday registry — 31 FR/EU tenants + seed/validate scripts (#84)

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -114,3 +114,29 @@ npm run lint                # prettier
 ```
 
 If you add a dependency, prefer pure Node standard library. The only runtime deps currently shipped are `js-yaml` and `playwright` — new ones need a strong justification.
+
+## Maintaining the Workday registry
+
+`templates/known-workday-slugs.example.json` ships with ~30 pre-verified FR/EU Workday tenants. `scripts/setup.sh` copies it to `data/known-workday-slugs.json` on first run so `/apply-onboard:companies` step 4 can resolve companies whose Workday tenant name is not guessable from the company name (e.g. Renault → `alliancewd.wd3`, Airbus → `ag.wd3`).
+
+### Adding an entry
+
+Build a one-line TSV with `<company-name>\t<workday-url>` and merge it in:
+
+```bash
+printf "Decathlon\thttps://decathlon.wd3.myworkdayjobs.com/Decathlon_Careers\n" \
+  | npm run workday:seed -- --merge
+```
+
+The script parses the URL, calls `verifyCompany`, and adds the entry to `templates/known-workday-slugs.example.json` if the board is live. Failures land in `/tmp/workday-unresolved.txt`.
+
+### Re-validating the registry
+
+Before a release — or whenever a user reports that a Workday slug returns 404 — re-verify every entry:
+
+```bash
+npm run workday:validate          # exit 1 if any entry is dead
+npm run workday:validate -- --fix # rewrite the template with live entries only
+```
+
+Both subcommands call `verifyCompany` against each entry, with a 100 ms pause between calls and one retry on 5xx/network errors. Validation is intentionally **not** run in CI — it depends on live HTTP calls to third-party tenants and would make the build flaky.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "score": "node src/score/index.mjs",
     "score:batch": "node src/score/index.mjs --batch",
     "dashboard": "node src/dashboard/build.mjs",
-    "explain": "node src/scan/explain.mjs"
+    "explain": "node src/scan/explain.mjs",
+    "workday:seed": "node scripts/seed-workday-slugs.mjs",
+    "workday:validate": "node scripts/validate-workday-slugs.mjs"
   },
   "keywords": [
     "claude-code",

--- a/scripts/seed-workday-slugs.mjs
+++ b/scripts/seed-workday-slugs.mjs
@@ -117,10 +117,10 @@ async function main() {
   writeTemplate(registry);
   fs.writeFileSync(
     UNRESOLVED_PATH,
-    unresolved.map((u) => `${u.name}\t${u.url}\t${u.reason}`).join('\n') + '\n',
+    unresolved.map((u) => `${u.name}\t${u.url}\t${u.reason}`).join('\n') + '\n'
   );
   console.log(
-    `\n${Object.keys(registry).length} entries in ${TEMPLATE_PATH}, ${unresolved.length} unresolved (see ${UNRESOLVED_PATH})`,
+    `\n${Object.keys(registry).length} entries in ${TEMPLATE_PATH}, ${unresolved.length} unresolved (see ${UNRESOLVED_PATH})`
   );
 }
 

--- a/scripts/seed-workday-slugs.mjs
+++ b/scripts/seed-workday-slugs.mjs
@@ -104,21 +104,32 @@ async function main() {
     }
     await new Promise((r) => setTimeout(r, 100));
     const result = await verifyWithRetry(url);
-    if (result.ok) {
+    if (result.ok && !result.warning) {
       registry[key] = parsed;
       seenKeys.add(key);
       process.stdout.write(`✓ ${name} (${result.count ?? '?'})\n`);
     } else {
-      unresolved.push({ name, url, reason: result.reason ?? 'verify failed' });
-      process.stdout.write(`✗ ${name} — ${result.reason ?? 'verify failed'}\n`);
+      const reason = result.reason ?? result.warning ?? 'verify failed';
+      unresolved.push({ name, url, reason });
+      process.stdout.write(`✗ ${name} — ${reason}\n`);
     }
   }
 
+  if (unresolved.length > 0) {
+    fs.writeFileSync(
+      UNRESOLVED_PATH,
+      unresolved.map((u) => `${u.name}\t${u.url}\t${u.reason}`).join('\n') + '\n'
+    );
+  }
+
+  if (Object.keys(registry).length === 0) {
+    console.error(
+      `\nNo entries verified; refusing to overwrite ${TEMPLATE_PATH}. ${unresolved.length} unresolved (see ${UNRESOLVED_PATH}).`
+    );
+    process.exit(1);
+  }
+
   writeTemplate(registry);
-  fs.writeFileSync(
-    UNRESOLVED_PATH,
-    unresolved.map((u) => `${u.name}\t${u.url}\t${u.reason}`).join('\n') + '\n'
-  );
   console.log(
     `\n${Object.keys(registry).length} entries in ${TEMPLATE_PATH}, ${unresolved.length} unresolved (see ${UNRESOLVED_PATH})`
   );

--- a/scripts/seed-workday-slugs.mjs
+++ b/scripts/seed-workday-slugs.mjs
@@ -1,3 +1,8 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import readline from 'node:readline';
+import { verifyCompany } from '../src/scan/ats-detect.mjs';
+
 const WORKDAY_RE =
   /^https?:\/\/([a-z0-9-]+)\.(wd\d+)\.myworkdayjobs\.com\/(?:[a-z]{2}-[A-Z]{2}\/)?([A-Za-z0-9_-]+)(?:\/|$)/i;
 
@@ -6,4 +11,122 @@ export function parseWorkdayUrl(url) {
   const m = url.match(WORKDAY_RE);
   if (!m) return null;
   return { tenant: m[1].toLowerCase(), pod: m[2].toLowerCase(), slug: m[3] };
+}
+
+const TEMPLATE_PATH = 'templates/known-workday-slugs.example.json';
+const UNRESOLVED_PATH = '/tmp/workday-unresolved.txt';
+
+function normalizeKey(name) {
+  return name.trim().toLowerCase().replace(/\s+/g, '');
+}
+
+async function readInput(inputFile) {
+  const stream = inputFile ? fs.createReadStream(inputFile) : process.stdin;
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+  const rows = [];
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const [name, url] = trimmed.split('\t').map((s) => (s ?? '').trim());
+    if (!name || !url) continue;
+    rows.push({ name, url });
+  }
+  return rows;
+}
+
+function loadExistingTemplate() {
+  if (!fs.existsSync(TEMPLATE_PATH)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(TEMPLATE_PATH, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function writeTemplate(registry) {
+  const sorted = Object.keys(registry)
+    .sort()
+    .reduce((acc, k) => {
+      acc[k] = registry[k];
+      return acc;
+    }, {});
+  fs.mkdirSync(path.dirname(TEMPLATE_PATH), { recursive: true });
+  fs.writeFileSync(TEMPLATE_PATH, JSON.stringify(sorted, null, 2) + '\n');
+}
+
+async function verifyWithRetry(url) {
+  try {
+    const res = await verifyCompany(url);
+    if (res.ok) return res;
+    if (res.reason && /5\d\d|network|timeout/i.test(res.reason)) {
+      await new Promise((r) => setTimeout(r, 2000));
+      return await verifyCompany(url);
+    }
+    return res;
+  } catch (err) {
+    await new Promise((r) => setTimeout(r, 2000));
+    try {
+      return await verifyCompany(url);
+    } catch (err2) {
+      return { ok: false, reason: err2.message };
+    }
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const mergeIdx = args.indexOf('--merge');
+  const merge = mergeIdx !== -1;
+  if (merge) args.splice(mergeIdx, 1);
+  const inputIdx = args.indexOf('--input');
+  const inputFile = inputIdx !== -1 ? args[inputIdx + 1] : null;
+
+  const rows = await readInput(inputFile);
+  if (rows.length === 0) {
+    console.error('No input rows. Provide TSV via --input <file> or stdin.');
+    process.exit(1);
+  }
+
+  const registry = merge ? loadExistingTemplate() : {};
+  const unresolved = [];
+  const seenKeys = new Set(Object.keys(registry));
+
+  for (const { name, url } of rows) {
+    const key = normalizeKey(name);
+    if (seenKeys.has(key) && !merge) {
+      unresolved.push({ name, url, reason: 'duplicate key (first wins)' });
+      continue;
+    }
+    const parsed = parseWorkdayUrl(url);
+    if (!parsed) {
+      unresolved.push({ name, url, reason: 'url parse failed' });
+      continue;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+    const result = await verifyWithRetry(url);
+    if (result.ok) {
+      registry[key] = parsed;
+      seenKeys.add(key);
+      process.stdout.write(`✓ ${name} (${result.count ?? '?'})\n`);
+    } else {
+      unresolved.push({ name, url, reason: result.reason ?? 'verify failed' });
+      process.stdout.write(`✗ ${name} — ${result.reason ?? 'verify failed'}\n`);
+    }
+  }
+
+  writeTemplate(registry);
+  fs.writeFileSync(
+    UNRESOLVED_PATH,
+    unresolved.map((u) => `${u.name}\t${u.url}\t${u.reason}`).join('\n') + '\n',
+  );
+  console.log(
+    `\n${Object.keys(registry).length} entries in ${TEMPLATE_PATH}, ${unresolved.length} unresolved (see ${UNRESOLVED_PATH})`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 }

--- a/scripts/seed-workday-slugs.mjs
+++ b/scripts/seed-workday-slugs.mjs
@@ -1,0 +1,9 @@
+const WORKDAY_RE =
+  /^https?:\/\/([a-z0-9-]+)\.(wd\d+)\.myworkdayjobs\.com\/(?:[a-z]{2}-[A-Z]{2}\/)?([A-Za-z0-9_-]+)(?:\/|$)/i;
+
+export function parseWorkdayUrl(url) {
+  if (!url || typeof url !== 'string') return null;
+  const m = url.match(WORKDAY_RE);
+  if (!m) return null;
+  return { tenant: m[1].toLowerCase(), pod: m[2].toLowerCase(), slug: m[3] };
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -199,6 +199,7 @@ copy_if_missing "templates/candidate-profile.example.yml" "config/candidate-prof
 copy_if_missing "templates/cv.example.md"                  "config/cv.md"                 config
 copy_if_missing "templates/portals.example.yml"            "config/portals.yml"           config
 copy_if_missing "templates/applications.example.md"        "data/applications.md"         data
+copy_if_missing "templates/known-workday-slugs.example.json" "data/known-workday-slugs.json" data
 
 if [[ $configs_copied -eq 1 && $configs_preserved -eq 1 ]]; then
   echo "→ Some templates copied, existing configs preserved — edit the new files above"

--- a/scripts/validate-workday-slugs.mjs
+++ b/scripts/validate-workday-slugs.mjs
@@ -1,0 +1,6 @@
+export function buildWorkdayUrl({ tenant, pod, slug } = {}) {
+  if (!tenant) throw new Error('buildWorkdayUrl: missing tenant');
+  if (!pod) throw new Error('buildWorkdayUrl: missing pod');
+  if (!slug) throw new Error('buildWorkdayUrl: missing slug');
+  return `https://${tenant}.${pod}.myworkdayjobs.com/${slug}`;
+}

--- a/scripts/validate-workday-slugs.mjs
+++ b/scripts/validate-workday-slugs.mjs
@@ -1,6 +1,79 @@
+import fs from 'node:fs';
+import { verifyCompany } from '../src/scan/ats-detect.mjs';
+
 export function buildWorkdayUrl({ tenant, pod, slug } = {}) {
   if (!tenant) throw new Error('buildWorkdayUrl: missing tenant');
   if (!pod) throw new Error('buildWorkdayUrl: missing pod');
   if (!slug) throw new Error('buildWorkdayUrl: missing slug');
   return `https://${tenant}.${pod}.myworkdayjobs.com/${slug}`;
+}
+
+const TEMPLATE_PATH = 'templates/known-workday-slugs.example.json';
+
+async function verifyWithRetry(url) {
+  try {
+    const res = await verifyCompany(url);
+    if (res.ok) return res;
+    if (res.reason && /5\d\d|network|timeout/i.test(res.reason)) {
+      await new Promise((r) => setTimeout(r, 2000));
+      return await verifyCompany(url);
+    }
+    return res;
+  } catch (err) {
+    await new Promise((r) => setTimeout(r, 2000));
+    try {
+      return await verifyCompany(url);
+    } catch (err2) {
+      return { ok: false, reason: err2.message };
+    }
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const fix = args.includes('--fix');
+
+  if (!fs.existsSync(TEMPLATE_PATH)) {
+    console.error(`Template file not found: ${TEMPLATE_PATH}`);
+    process.exit(1);
+  }
+  const registry = JSON.parse(fs.readFileSync(TEMPLATE_PATH, 'utf8'));
+
+  const live = {};
+  const dead = [];
+
+  for (const [key, entry] of Object.entries(registry)) {
+    const url = buildWorkdayUrl(entry);
+    await new Promise((r) => setTimeout(r, 100));
+    const result = await verifyWithRetry(url);
+    if (result.ok) {
+      live[key] = entry;
+      process.stdout.write(`✓ ${key} (${result.count ?? '?'})\n`);
+    } else {
+      dead.push({ key, url, reason: result.reason ?? 'verify failed' });
+      process.stdout.write(`✗ ${key} — ${result.reason ?? 'verify failed'}\n`);
+    }
+  }
+
+  console.log(`\n${Object.keys(live).length} live, ${dead.length} dead`);
+
+  if (dead.length > 0) {
+    console.log('\nDead entries:');
+    for (const d of dead) console.log(`  ${d.key}\t${d.url}\t${d.reason}`);
+  }
+
+  if (fix) {
+    fs.writeFileSync(TEMPLATE_PATH, JSON.stringify(live, null, 2) + '\n');
+    console.log(`\nTemplate rewritten with ${Object.keys(live).length} live entries.`);
+    process.exit(0);
+  }
+
+  process.exit(dead.length > 0 ? 1 : 0);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 }

--- a/scripts/validate-workday-slugs.mjs
+++ b/scripts/validate-workday-slugs.mjs
@@ -46,12 +46,13 @@ async function main() {
     const url = buildWorkdayUrl(entry);
     await new Promise((r) => setTimeout(r, 100));
     const result = await verifyWithRetry(url);
-    if (result.ok) {
+    if (result.ok && !result.warning) {
       live[key] = entry;
       process.stdout.write(`✓ ${key} (${result.count ?? '?'})\n`);
     } else {
-      dead.push({ key, url, reason: result.reason ?? 'verify failed' });
-      process.stdout.write(`✗ ${key} — ${result.reason ?? 'verify failed'}\n`);
+      const reason = result.reason ?? result.warning ?? 'verify failed';
+      dead.push({ key, url, reason });
+      process.stdout.write(`✗ ${key} — ${reason}\n`);
     }
   }
 
@@ -63,6 +64,10 @@ async function main() {
   }
 
   if (fix) {
+    if (Object.keys(live).length === 0) {
+      console.error(`\nRefusing to rewrite ${TEMPLATE_PATH}: zero live entries.`);
+      process.exit(1);
+    }
     fs.writeFileSync(TEMPLATE_PATH, JSON.stringify(live, null, 2) + '\n');
     console.log(`\nTemplate rewritten with ${Object.keys(live).length} live entries.`);
     process.exit(0);

--- a/templates/known-workday-slugs.example.json
+++ b/templates/known-workday-slugs.example.json
@@ -1,0 +1,157 @@
+{
+  "accelleron": {
+    "tenant": "accelleron",
+    "pod": "wd3",
+    "slug": "Accelleron"
+  },
+  "airbus": {
+    "tenant": "ag",
+    "pod": "wd3",
+    "slug": "Airbus"
+  },
+  "airliquide": {
+    "tenant": "airliquidehr",
+    "pod": "wd3",
+    "slug": "AirLiquideExternalCareer"
+  },
+  "arianegroup": {
+    "tenant": "arianegroup",
+    "pod": "wd3",
+    "slug": "EXTERNALALL"
+  },
+  "astrazeneca": {
+    "tenant": "astrazeneca",
+    "pod": "wd3",
+    "slug": "Careers"
+  },
+  "bectondickinson": {
+    "tenant": "bdx",
+    "pod": "wd1",
+    "slug": "EXTERNAL_CAREER_SITE_FRANCE"
+  },
+  "criteo": {
+    "tenant": "criteo",
+    "pod": "wd3",
+    "slug": "Criteo_Career_Site"
+  },
+  "gsk": {
+    "tenant": "gsk",
+    "pod": "wd5",
+    "slug": "GSKCareers"
+  },
+  "ingbank": {
+    "tenant": "ing",
+    "pod": "wd3",
+    "slug": "ICSGBLCOR"
+  },
+  "ipsen": {
+    "tenant": "ipsen",
+    "pod": "wd103",
+    "slug": "Ipsen_Careers"
+  },
+  "kering": {
+    "tenant": "kering",
+    "pod": "wd3",
+    "slug": "Kering"
+  },
+  "michelin": {
+    "tenant": "michelinhr",
+    "pod": "wd3",
+    "slug": "Michelin"
+  },
+  "novartis": {
+    "tenant": "novartis",
+    "pod": "wd3",
+    "slug": "Novartis_Careers"
+  },
+  "orange": {
+    "tenant": "orange",
+    "pod": "wd3",
+    "slug": "Orange_Career"
+  },
+  "pernodricard": {
+    "tenant": "pernodricard",
+    "pod": "wd3",
+    "slug": "pernod-ricard"
+  },
+  "philips": {
+    "tenant": "philips",
+    "pod": "wd3",
+    "slug": "jobs-and-careers"
+  },
+  "pierrefabre": {
+    "tenant": "pierrefabre",
+    "pod": "wd3",
+    "slug": "External_Career_Site"
+  },
+  "pwc": {
+    "tenant": "pwc",
+    "pod": "wd3",
+    "slug": "Global_Campus_Careers"
+  },
+  "renault": {
+    "tenant": "alliancewd",
+    "pod": "wd3",
+    "slug": "renault-group-careers"
+  },
+  "roche": {
+    "tenant": "roche",
+    "pod": "wd3",
+    "slug": "roche-ext"
+  },
+  "sanofi": {
+    "tenant": "sanofi",
+    "pod": "wd3",
+    "slug": "SanofiCareers"
+  },
+  "shell": {
+    "tenant": "shell",
+    "pod": "wd3",
+    "slug": "ShellCareers"
+  },
+  "siemensgamesa": {
+    "tenant": "siemensgamesa",
+    "pod": "wd3",
+    "slug": "SGRE"
+  },
+  "siemenshealthineers": {
+    "tenant": "onehealthineers",
+    "pod": "wd3",
+    "slug": "SHSJB"
+  },
+  "signify": {
+    "tenant": "lighting",
+    "pod": "wd3",
+    "slug": "jobs-and-careers"
+  },
+  "stellantis": {
+    "tenant": "stellantis",
+    "pod": "wd3",
+    "slug": "External_Career_Site_ID01"
+  },
+  "thales": {
+    "tenant": "thales",
+    "pod": "wd3",
+    "slug": "Careers"
+  },
+  "unilever": {
+    "tenant": "unilever",
+    "pod": "wd3",
+    "slug": "Unilever_Experienced_Professionals"
+  },
+  "urw": {
+    "tenant": "urw",
+    "pod": "wd3",
+    "slug": "urw_career_site"
+  },
+  "valeo": {
+    "tenant": "valeo",
+    "pod": "wd3",
+    "slug": "valeo_jobs"
+  },
+  "veolia": {
+    "tenant": "veoliauki",
+    "pod": "wd3",
+    "slug": "VESCareers"
+  }
+}

--- a/tests/scripts/seed-workday-slugs.test.mjs
+++ b/tests/scripts/seed-workday-slugs.test.mjs
@@ -1,0 +1,53 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseWorkdayUrl } from '../../scripts/seed-workday-slugs.mjs';
+
+test('parseWorkdayUrl — plain URL without locale segment', () => {
+  const result = parseWorkdayUrl('https://airbus.wd3.myworkdayjobs.com/Airbus_Careers');
+  assert.deepEqual(result, { tenant: 'airbus', pod: 'wd3', slug: 'Airbus_Careers' });
+});
+
+test('parseWorkdayUrl — URL with locale segment (en-US)', () => {
+  const result = parseWorkdayUrl('https://sanofi.wd3.myworkdayjobs.com/en-US/SanofiCareers');
+  assert.deepEqual(result, { tenant: 'sanofi', pod: 'wd3', slug: 'SanofiCareers' });
+});
+
+test('parseWorkdayUrl — URL with locale segment (fr-FR)', () => {
+  const result = parseWorkdayUrl('https://michelinhr.wd3.myworkdayjobs.com/fr-FR/Michelin');
+  assert.deepEqual(result, { tenant: 'michelinhr', pod: 'wd3', slug: 'Michelin' });
+});
+
+test('parseWorkdayUrl — different pod number', () => {
+  const result = parseWorkdayUrl('https://tenant.wd5.myworkdayjobs.com/board');
+  assert.deepEqual(result, { tenant: 'tenant', pod: 'wd5', slug: 'board' });
+});
+
+test('parseWorkdayUrl — tenant with hyphen', () => {
+  const result = parseWorkdayUrl('https://alliance-wd.wd3.myworkdayjobs.com/renault-group-careers');
+  assert.deepEqual(result, { tenant: 'alliance-wd', pod: 'wd3', slug: 'renault-group-careers' });
+});
+
+test('parseWorkdayUrl — http (not https) accepted', () => {
+  const result = parseWorkdayUrl('http://ag.wd3.myworkdayjobs.com/Airbus');
+  assert.deepEqual(result, { tenant: 'ag', pod: 'wd3', slug: 'Airbus' });
+});
+
+test('parseWorkdayUrl — non-Workday URL returns null', () => {
+  assert.equal(parseWorkdayUrl('https://jobs.lever.co/mistral'), null);
+});
+
+test('parseWorkdayUrl — malformed URL returns null', () => {
+  assert.equal(parseWorkdayUrl('not a url'), null);
+});
+
+test('parseWorkdayUrl — URL missing slug returns null', () => {
+  assert.equal(parseWorkdayUrl('https://airbus.wd3.myworkdayjobs.com/'), null);
+});
+
+test('parseWorkdayUrl — empty string returns null', () => {
+  assert.equal(parseWorkdayUrl(''), null);
+});
+
+test('parseWorkdayUrl — null input returns null', () => {
+  assert.equal(parseWorkdayUrl(null), null);
+});

--- a/tests/scripts/validate-workday-slugs.test.mjs
+++ b/tests/scripts/validate-workday-slugs.test.mjs
@@ -1,0 +1,35 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildWorkdayUrl } from '../../scripts/validate-workday-slugs.mjs';
+
+test('buildWorkdayUrl — builds canonical URL', () => {
+  const url = buildWorkdayUrl({ tenant: 'airbus', pod: 'wd3', slug: 'Airbus_Careers' });
+  assert.equal(url, 'https://airbus.wd3.myworkdayjobs.com/Airbus_Careers');
+});
+
+test('buildWorkdayUrl — preserves slug casing', () => {
+  const url = buildWorkdayUrl({ tenant: 'sanofi', pod: 'wd3', slug: 'SanofiCareers' });
+  assert.equal(url, 'https://sanofi.wd3.myworkdayjobs.com/SanofiCareers');
+});
+
+test('buildWorkdayUrl — tenant with hyphen', () => {
+  const url = buildWorkdayUrl({ tenant: 'alliance-wd', pod: 'wd3', slug: 'renault' });
+  assert.equal(url, 'https://alliance-wd.wd3.myworkdayjobs.com/renault');
+});
+
+test('buildWorkdayUrl — different pod number', () => {
+  const url = buildWorkdayUrl({ tenant: 't', pod: 'wd5', slug: 's' });
+  assert.equal(url, 'https://t.wd5.myworkdayjobs.com/s');
+});
+
+test('buildWorkdayUrl — missing tenant throws', () => {
+  assert.throws(() => buildWorkdayUrl({ pod: 'wd3', slug: 's' }), /tenant/);
+});
+
+test('buildWorkdayUrl — missing pod throws', () => {
+  assert.throws(() => buildWorkdayUrl({ tenant: 't', slug: 's' }), /pod/);
+});
+
+test('buildWorkdayUrl — missing slug throws', () => {
+  assert.throws(() => buildWorkdayUrl({ tenant: 't', pod: 'wd3' }), /slug/);
+});


### PR DESCRIPTION
## Summary

- Adds `templates/known-workday-slugs.example.json` with 31 verified FR/EU Workday tenants (Sanofi, Airbus, Renault, Michelin, Kering, GSK, Novartis, Roche, Shell, Unilever, and 21 more)
- Adds `scripts/seed-workday-slugs.mjs` — reads TSV input, verifies each URL via `verifyCompany`, merges into the template; unresolved entries written to `/tmp/workday-unresolved.txt`
- Adds `scripts/validate-workday-slugs.mjs` — re-verifies all template entries; `--fix` rewrites with live entries only
- Wires `npm run workday:seed` and `npm run workday:validate` in `package.json`
- `scripts/setup.sh` copies the template to `data/known-workday-slugs.json` on first run (idempotent)
- Documents the maintenance workflow in `docs/extending.md`

## Test Plan

- [ ] `npm test` → 517 tests pass (18 new: 11 for `parseWorkdayUrl`, 7 for `buildWorkdayUrl`)
- [ ] `npm run check:pii` → no PII detected
- [ ] `npm run lint` → Prettier clean
- [ ] `bash scripts/setup.sh --yes --no-rc --no-clone-chrome-profile` → `data/known-workday-slugs.json` created from template
- [ ] `npm run workday:validate` → validates live entries (not in CI — requires live HTTP)

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)