### PR TITLE
chore(onboard): batch UX fixes for /apply-onboard (#87)

### DIFF
--- a/.claude/commands/apply-onboard.md
+++ b/.claude/commands/apply-onboard.md
@@ -30,7 +30,20 @@ The sub-skills contain the detailed hard rules for their own phase. You must fol
    - **(c) portals only** → skip phase 1, run phase 2, then skip phase 3 (Chrome is already set up from a previous run). If `node_modules/` is missing, run `bash scripts/setup.sh --yes --no-clone-chrome-profile` first.
 2. If `config/candidate-profile.yml` does **not** exist, run all three phases.
 
+After picking a mode, print this plan so the user knows what's coming:
+
+```
+Onboarding plan:
+  ▶ Phase 1/3 — Profile
+  ▶ Phase 2/3 — Companies
+  ▶ Phase 3/3 — Setup
+```
+
+For mode (c) ("portals only"), print the same plan with `(skip)` next to phases 1 and 3.
+
 ## 1. Phase 1 — profile (`/apply-onboard:profile`)
+
+Print `▶ Phase 1/3 — Profile` before delegating, and `✓ Phase 1/3 done` after the sub-skill returns.
 
 Follow the instructions in `.claude/commands/apply-onboard/profile.md` end-to-end. Pass `$ARGUMENTS` through as the CV path if the user provided one.
 
@@ -38,11 +51,15 @@ Phase 1 writes `config/cv.md`, `config/cv.<lang>.pdf`, `config/candidate-profile
 
 ## 2. Phase 2 — companies (`/apply-onboard:companies`)
 
+Print `▶ Phase 2/3 — Companies` before delegating, and `✓ Phase 2/3 done` after the sub-skill returns.
+
 Follow the instructions in `.claude/commands/apply-onboard/companies.md` end-to-end.
 
 Phase 2 reads `data/.onboard-state.json` for the user's job-type and domain answers, builds `title_filter`, runs WebSearch + `verifyCompany`, gets the user's approval on the final list, and writes `config/portals.yml`. Do not proceed until the file is written.
 
 ## 3. Phase 3 — setup (`/apply-onboard:setup`)
+
+Print `▶ Phase 3/3 — Setup` before delegating, and `✓ Phase 3/3 done` after the sub-skill returns.
 
 Follow the instructions in `.claude/commands/apply-onboard/setup.md` end-to-end.
 
@@ -50,7 +67,7 @@ Phase 3 runs `scripts/setup.sh`, launches Chrome in CDP mode, and prints the ext
 
 ## Absolute rules (recap)
 
-- **One question block per phase** — never pepper the user with follow-ups.
+- **Up to 3 question blocks in phase 1** (+ 1 conditional Block D for CV fields missing from extraction), one each in phases 2 and 3 — never pepper the user with follow-ups.
 - **Approve before writing `portals.yml`** — always.
 - **Validate the profile** before writing it — never write an invalid YAML.
 - **Never guess PII** — `null` is always a valid answer.

--- a/.claude/commands/apply-onboard/profile.md
+++ b/.claude/commands/apply-onboard/profile.md
@@ -73,35 +73,45 @@ Behaviour:
 
 If step 1 extracted **zero** of the four fields, skip this section entirely and go straight to step 3.
 
-## 3. One question block
+## 3. Question blocks (up to 3, plus one conditional)
 
-Use **`AskUserQuestion`** once with everything you could not extract, grouped logically. Do not loop back with follow-ups unless the user's answer is internally inconsistent.
+Use **`AskUserQuestion`** up to **3** times, grouping questions logically (Block A job search / Block B location+admin / Block C setup+scoring). A 4th call (Block D) is only allowed to fill required fields missing from the CV. Never loop back with follow-ups unless the user's answer is internally inconsistent.
 
-**Job search** (skip the entire sub-block if step 2.5 confirmed all four fields. Otherwise, only include the bullets whose value is still `null`.)
+Each `AskUserQuestion` call accepts at most 4 questions.
+
+**Block A — Job search** (skip the entire block if step 2.5 confirmed all four fields; otherwise include only the bullets whose value is still `null`; max 4 questions total)
 
 - **Job type**: internship / apprenticeship / entry-level / mid-level / senior / other
 - **Target start date** (ISO date)
 - **Duration** (if internship/apprenticeship): months
 - **Target role / domain keywords**: free text — drives both `title_filter` and company discovery (phase 2). Example: "AI/ML engineering", "backend Python", "devtools".
 
-**Location & remote**
+**Block B — Location + admin core** (4 questions)
 
 - **Locations**: cities or regions, comma-separated
 - **Remote preference**: onsite / hybrid / remote
-
-**Admin**
-
-- **Date of birth** (may skip if user refuses)
-- **Nationality**
 - **Work authorization** — free text (e.g. "EU citizen — no sponsorship needed")
 - **Requires visa sponsorship**: yes / no
 
-**Setup choices** (used later by `/apply-onboard:setup`)
+**Block C — Setup + scoring** (up to 4 questions)
 
-- **Clone your existing Chrome profile** into the CDP profile? yes / no
-- **Cover letter auto-generation**: enable now? yes / no (default no)
+- **Auto-apply minimum score** (drives `/apply --auto`): options `6` / `7` / `8`, default `7`. Stored as `auto_apply_min_score`.
+- **Clone your existing Chrome profile** into the CDP profile? yes / no.
+  - `yes`: copies cookies, sessions, and extensions from your current Chrome profile — you stay logged in to ATSes and keep your existing extensions.
+  - `no`: starts from scratch — every ATS will ask you to log in once.
+- **Cover letter auto-generation**: yes / no (default no). Stored as `auto_generate_cover_letter` in both `candidate-profile.yml` and `.onboard-state.json`.
+- **Date of birth** (optional — may skip).
 
-Anything the user declines → `null`.
+`nationality` is no longer asked in Block C; set it to `null` by default (users can fill it later if a specific form requires it).
+
+**Block D — Required fields missing from CV** (conditional; skipped if all extracted; at most 2 questions)
+
+Trigger when **at least one** of `city`, `graduation_year` is `null` after extraction.
+
+- **City**: *"Your CV didn't state a residential city. Please provide one (used for form pre-fill on Workday/Greenhouse)."*
+- **Graduation year**: *"Your CV didn't state a graduation year. Based on your degree start year N, a typical 5-year cycle ends in N+5 — correct? Or enter a different year."*
+
+Anything the user declines in optional fields → `null`. Required fields (city, graduation_year, locations, remote_preference, work_authorization, requires_sponsorship, auto_apply_min_score) cannot be skipped — if the user refuses, stop and ask again clearly.
 
 ## 4. Ensure npm dependencies are installed
 

--- a/.claude/commands/apply-onboard/profile.md
+++ b/.claude/commands/apply-onboard/profile.md
@@ -63,7 +63,7 @@ Use `AskUserQuestion` with a single question:
 - **Options**:
   - `confirm` — "Use these values"
   - `edit all` — "Re-ask all four"
-  - `edit missing only` — "Only re-ask fields that came back `<not found>`" *(show this option only when at least one of the four extracted fields is `null`; hide it otherwise)*
+  - `edit missing only` — "Only re-ask fields that came back `<not found>`" _(show this option only when at least one of the four extracted fields is `null`; hide it otherwise)_
 
 Behaviour:
 
@@ -108,8 +108,8 @@ Each `AskUserQuestion` call accepts at most 4 questions.
 
 Trigger when **at least one** of `city`, `graduation_year` is `null` after extraction.
 
-- **City**: *"Your CV didn't state a residential city. Please provide one (used for form pre-fill on Workday/Greenhouse)."*
-- **Graduation year**: *"Your CV didn't state a graduation year. Based on your degree start year N, a typical 5-year cycle ends in N+5 — correct? Or enter a different year."*
+- **City**: _"Your CV didn't state a residential city. Please provide one (used for form pre-fill on Workday/Greenhouse)."_
+- **Graduation year**: _"Your CV didn't state a graduation year. Based on your degree start year N, a typical 5-year cycle ends in N+5 — correct? Or enter a different year."_
 
 Anything the user declines in optional fields → `null`. Required fields (city, graduation_year, locations, remote_preference, work_authorization, requires_sponsorship, auto_apply_min_score) cannot be skipped — if the user refuses, stop and ask again clearly.
 

--- a/.claude/commands/apply-onboard/profile.md
+++ b/.claude/commands/apply-onboard/profile.md
@@ -111,7 +111,7 @@ Trigger when **at least one** of `city`, `graduation_year` is `null` after extra
 - **City**: _"Your CV didn't state a residential city. Please provide one (used for form pre-fill on Workday/Greenhouse)."_
 - **Graduation year**: _"Your CV didn't state a graduation year. Based on your degree start year N, a typical 5-year cycle ends in N+5 — correct? Or enter a different year."_
 
-Anything the user declines in optional fields → `null`. Required fields (city, graduation_year, locations, remote_preference, work_authorization, requires_sponsorship, auto_apply_min_score) cannot be skipped — if the user refuses, stop and ask again clearly.
+Anything the user declines in optional fields → `null`. Required fields for `candidate-profile.yml` (city, graduation_year, work_authorization, requires_sponsorship, auto_apply_min_score) cannot be skipped — if the user refuses, stop and ask again clearly. Note: `locations` and `remote_preference` are required for `.onboard-state.json` (not `candidate-profile.yml`) and are collected in step 2.5.
 
 ## 4. Ensure npm dependencies are installed
 

--- a/.claude/commands/apply-onboard/profile.md
+++ b/.claude/commands/apply-onboard/profile.md
@@ -62,12 +62,14 @@ Use `AskUserQuestion` with a single question:
 
 - **Options**:
   - `confirm` — "Use these values"
-  - `edit` — "Re-ask all four"
+  - `edit all` — "Re-ask all four"
+  - `edit missing only` — "Only re-ask fields that came back `<not found>`" *(show this option only when at least one of the four extracted fields is `null`; hide it otherwise)*
 
 Behaviour:
 
 - `confirm` → the extracted values are locked. Treat them as already-answered for step 3.
-- `edit` → reset **all four** extracted values to `null`. Step 3 will re-ask the entire "Job search" sub-block. (Per-field correction is intentionally not offered — the all-or-nothing reset keeps the UX one click and reuses step 3 verbatim.)
+- `edit all` → reset **all four** extracted values to `null`. Step 3 will re-ask the entire "Job search" sub-block.
+- `edit missing only` → keep non-null extracted values; reset to `null` **only** the fields that came back `<not found>`. Step 3 will re-ask just those.
 
 If step 1 extracted **zero** of the four fields, skip this section entirely and go straight to step 3.
 

--- a/.claude/commands/apply-onboard/profile.md
+++ b/.claude/commands/apply-onboard/profile.md
@@ -128,7 +128,7 @@ Assemble one **flat** YAML file — no nested `identity:` / `address:` / `availa
 Sources:
 
 - Extracted from the CV: `first_name`, `last_name`, `email`, `phone`, `linkedin_url`, `github_url`, `city`, `country`, `school`, `degree`, `graduation_year`, `education[]`, `experiences[]`, `languages[]`.
-- From the question block: `availability_start`, `internship_duration_months`, `work_authorization`, `requires_sponsorship`, `auto_apply_min_score`, optionally `blacklist_companies` and `min_start_date`.
+- From the question blocks: `availability_start`, `internship_duration_months` (only when `job_type` is internship/apprenticeship), `work_authorization`, `requires_sponsorship`, `auto_apply_min_score`, `auto_generate_cover_letter`, `date_of_birth`, optionally `blacklist_companies` and `min_start_date`.
 - From step 2: `cv_path`.
 - EEO fields default to `null` unless explicitly provided: `gender`, `ethnicity`, `veteran_status`, `disability_status`.
 
@@ -146,7 +146,8 @@ Write the job-search answers to `data/.onboard-state.json` so `/apply-onboard:co
   "target_role": "free-text domain keywords",
   "locations": ["Paris", "Remote EU"],
   "remote_preference": "onsite|hybrid|remote",
-  "clone_chrome_profile": true
+  "clone_chrome_profile": true,
+  "auto_generate_cover_letter": false
 }
 ```
 

--- a/.claude/commands/apply-onboard/setup.md
+++ b/.claude/commands/apply-onboard/setup.md
@@ -22,6 +22,8 @@ Read `data/.onboard-state.json` (written by `/apply-onboard:profile`) to get `cl
 
 ## 2. Run `scripts/setup.sh`
 
+(The `--clone-chrome-profile` flag below uses the answer the user gave in phase 1. "yes" copies cookies/sessions/extensions from their current Chrome profile — they stay logged in to ATSes. "no" starts from scratch.)
+
 Run one of:
 
 ```bash
@@ -105,6 +107,61 @@ After you click "Add to Chrome" and approve the install:
 ```
 
 **Wait for the user to confirm permissions are granted** before continuing.
+
+### 5a. Verify host permissions via a minimal probe
+
+After the user confirms, run a one-shot probe against a representative ATS host. This catches the common case where the user installed the extension but forgot to grant host permissions — which otherwise fails only on the first `/apply` call.
+
+1. Load the MCP tools if not yet available:
+
+   ```
+   ToolSearch query: select:mcp__claude-in-chrome__navigate,mcp__claude-in-chrome__find
+   ```
+
+2. Navigate to the probe host and run a benign `find`:
+
+   ```
+   mcp__claude-in-chrome__navigate(url: "https://jobs.lever.co/anthropic")
+   mcp__claude-in-chrome__find(selector: "body")
+   ```
+
+3. Feed the results into the probe interpreter:
+
+   ```bash
+   node -e "
+     import('./src/lib/extension-permission-probe.mjs').then(m => {
+       const r = m.interpretProbeResult({
+         navigateResult: <paste JSON result of navigate, or null>,
+         findResult: <paste JSON result of find, or null>,
+         findError: <paste error message if find threw, or null>,
+         navigateError: <paste error message if navigate threw, or null>,
+       });
+       console.log(JSON.stringify(r));
+     });
+   "
+   ```
+
+4. Based on `{ok, reason}`:
+
+   - `{ok: true}` → print: `✓ Permissions OK — extension can read ATS hosts.`
+   - `{ok: false, reason: 'missing_permission'}` → print:
+     ```
+     ✗ Missing host permission.
+       Reopen the extension menu and re-check the host list shown above.
+       Then rerun /apply-onboard:setup step 5 only.
+     ```
+   - `{ok: false, reason: 'extension_not_installed'}` → print:
+     ```
+     ✗ Extension not detected.
+       Did you complete the "Add to Chrome" install? Retry step 5.
+     ```
+   - `{ok: false, reason: 'navigation_failed' | 'timeout' | 'unknown'}` → print:
+     ```
+     ⚠ Could not reach the probe host (reason: <reason>).
+       Skipping verification — test with /apply when ready.
+     ```
+
+This probe is **non-blocking**: print the final summary (step 6) regardless of the probe result. The user can always rerun setup step 5 later if needed.
 
 ## 6. Final summary
 

--- a/.claude/commands/apply-onboard/setup.md
+++ b/.claude/commands/apply-onboard/setup.md
@@ -142,7 +142,6 @@ After the user confirms, run a one-shot probe against a representative ATS host.
    ```
 
 4. Based on `{ok, reason}`:
-
    - `{ok: true}` → print: `✓ Permissions OK — extension can read ATS hosts.`
    - `{ok: false, reason: 'missing_permission'}` → print:
      ```

--- a/docs/superpowers/plans/2026-04-21-issue-89-discoverability-plan.md
+++ b/docs/superpowers/plans/2026-04-21-issue-89-discoverability-plan.md
@@ -1,0 +1,1067 @@
+# Issue #89 — Slash-command discoverability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface the tools (`/explain`, `/dashboard`, `--dry-run`, flags) the user needs after `/scan` and during onboarding, and add `--help` to every slash command.
+
+**Architecture:** Four additive deliverables — (L1) enrich the `/scan` summary footer; (L2) intercept `--help` / `-h` at the top of each node CLI before any I/O, plus a documented `--help` convention in `.claude/commands/apply.md`; (L3) link `docs/scan-workflow.md#title-filter` from `/scan`; (L4) rewrite the onboarding summary (`apply-onboard/setup.md`) with a `title_filter` recap, a `--dry-run --json` calibration preview, and the full command list.
+
+**Tech Stack:** Node 20 ESM (`.mjs`), `node:test`, `node:child_process.spawnSync` for CLI integration tests. Zero new dependencies.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-21-issue-89-discoverability-design.md`.
+
+**Deviation from spec noted during planning:** the spec's `/score --help` template listed only `--re-score` as a flag. The real `parseScoreArgs()` accepts many more (`--json-input`, `--id`, `--company`/`--role`/`--location`, `--from-pipeline`, `--batch`, `--parallel`). A `--help` that hides real flags is actively misleading, so Task 2b lists all of them. No spec change requested; flag for reviewer attention.
+
+---
+
+## File map
+
+**Modify:**
+- `src/scan/index.mjs` — add `printScanHelp()`, intercept `--help`/`-h` at top of `main()`, append `Next steps` block to `formatSummary()` (suppressed under `--json`).
+- `src/score/index.mjs` — add `printScoreHelp()`, intercept at top of `main()`.
+- `src/scan/explain.mjs` — add `printExplainHelp()`, intercept at top of `main()`.
+- `src/dashboard/build.mjs` — add `printDashboardHelp()`, intercept inside the `import.meta.url === …` CLI guard.
+- `.claude/commands/scan.md` — remove the `## Next step` section; add the `docs/scan-workflow.md#title-filter` pointer line in `## Interpreting the output`.
+- `.claude/commands/apply.md` — add the `--help` preamble block (skill-level, not CLI).
+- `.claude/commands/apply-onboard/setup.md` — step 2 (print `setup.sh --help` once), insert step 5.5 (dry-run calibration), rewrite step 6 (summary).
+- `tests/scan/scan.test.mjs` — two new tests on `formatSummary` (with/without `--json`).
+- `docs/testing.md` — one line in the E2E checklist.
+
+**Create:**
+- `tests/scan/scan-help.test.mjs`
+- `tests/score/score-help.test.mjs`
+- `tests/scan/explain-help.test.mjs`
+- `tests/dashboard/dashboard-help.test.mjs`
+
+---
+
+## Task 1 — L1: `/scan` footer `Next steps` block
+
+**Files:**
+- Modify: `src/scan/index.mjs:311-360` (`formatSummary`)
+- Modify: `src/scan/index.mjs` (`main()` — pass a `format` flag through so `--json` suppresses the block)
+- Test: `tests/scan/scan.test.mjs` (append two new `test(...)` blocks at the end)
+
+- [ ] **Step 1.1 — Write failing tests in `tests/scan/scan.test.mjs`**
+
+Append these two tests at the very end of the file (after the last existing `test(...)` block):
+
+```js
+test('formatSummary — emits Next steps block in default path', () => {
+  const result = {
+    scanned: 2,
+    eligibleTotal: 2,
+    raw: 10,
+    perCompany: [
+      { company: 'mistral', platform: 'lever', rawCount: 5, afterFilterCount: 1, newCount: 1 },
+      { company: 'anthropic', platform: 'greenhouse', rawCount: 5, afterFilterCount: 0, newCount: 0 },
+    ],
+    filtered: {
+      skipped_dup: 0,
+      skipped_title: 4,
+      skipped_blacklist: 0,
+      skipped_location: 0,
+      skipped_date: 0,
+    },
+    added: [{ company: 'mistral', title: 'ML Engineer Intern' }],
+    historyWrites: 1,
+    filteredWrites: 4,
+    errors: [],
+  };
+  const out = formatSummary(result, false);
+  assert.match(out, /Next steps :/);
+  assert.match(out, /\/score <url>/);
+  assert.match(out, /\/explain/);
+  assert.match(out, /\/dashboard/);
+  assert.match(out, /\/scan --help/);
+});
+
+test('formatSummary — Next steps block is present even when nothing was added', () => {
+  const result = {
+    scanned: 1,
+    eligibleTotal: 1,
+    raw: 2359,
+    perCompany: [
+      { company: 'big-co', platform: 'greenhouse', rawCount: 2359, afterFilterCount: 0, newCount: 0 },
+    ],
+    filtered: {
+      skipped_dup: 0,
+      skipped_title: 2359,
+      skipped_blacklist: 0,
+      skipped_location: 0,
+      skipped_date: 0,
+    },
+    added: [],
+    historyWrites: 0,
+    filteredWrites: 2359,
+    errors: [],
+  };
+  const out = formatSummary(result, false);
+  assert.match(out, /Next steps :/);
+  assert.match(out, /\/explain/);
+});
+```
+
+- [ ] **Step 1.2 — Run the new tests; expect failure**
+
+```bash
+node --test --test-name-pattern="Next steps" tests/scan/scan.test.mjs
+```
+
+Expected: both tests FAIL — the assertions on `/Next steps :/`, `/explain`, `/dashboard`, `/scan --help` do not yet appear in `formatSummary` output.
+
+- [ ] **Step 1.3 — Implement the `Next steps` block in `formatSummary()`**
+
+Open `src/scan/index.mjs`. Locate the current `formatSummary` function ending at the `return lines.join('\n');` on line 359. Insert the new block **before** `return lines.join('\n');`:
+
+```js
+  lines.push('');
+  lines.push('Next steps :');
+  lines.push('  /score <url>        # évalue une offre via LLM (data/evaluations.jsonl)');
+  lines.push('  /explain "<title>"  # trace pourquoi une offre passe/échoue le filtre');
+  lines.push('  /dashboard          # régénère dashboard.html');
+  lines.push('');
+  lines.push('Plus de flags : /scan --help  (--dry-run, --only <slug>, --json)');
+```
+
+- [ ] **Step 1.4 — Run the two tests; expect pass**
+
+```bash
+node --test --test-name-pattern="Next steps" tests/scan/scan.test.mjs
+```
+
+Expected: both PASS.
+
+- [ ] **Step 1.5 — Run the two existing `formatSummary` tests to verify no regression**
+
+```bash
+node --test --test-name-pattern="formatSummary" tests/scan/scan.test.mjs
+```
+
+Expected: all `formatSummary` tests PASS (the two original + the two new).
+
+- [ ] **Step 1.6 — Add test that `--json` path does NOT include the block**
+
+Append at the end of `tests/scan/scan.test.mjs`:
+
+```js
+test('scan CLI --json — stdout is parseable JSON and contains no Next steps block', () => {
+  const cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-json-'));
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-json-data-'));
+  fs.writeFileSync(
+    path.join(cfgDir, 'portals.yml'),
+    'tracked_companies: []\ntitle_filter:\n  required_any: []\n  excluded_any: []\n',
+  );
+  fs.writeFileSync(
+    path.join(cfgDir, 'candidate-profile.yml'),
+    'target_locations: [Paris]\nblacklist: []\nmin_start_date: 2026-01-01\n',
+  );
+
+  try {
+    const res = spawnSync(
+      process.execPath,
+      [path.resolve('src/scan/index.mjs'), '--dry-run', '--json'],
+      {
+        env: {
+          ...process.env,
+          CLAUDE_APPLY_CONFIG_DIR: cfgDir,
+          CLAUDE_APPLY_DATA_DIR: dataDir,
+        },
+        encoding: 'utf8',
+      },
+    );
+    assert.equal(res.status, 0, `stderr=${res.stderr}`);
+    assert.doesNotMatch(res.stdout, /Next steps/);
+    const parsed = JSON.parse(res.stdout);
+    assert.ok(typeof parsed === 'object' && parsed !== null);
+  } finally {
+    fs.rmSync(cfgDir, { recursive: true, force: true });
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+```
+
+If `spawnSync`, `fs`, `os`, `path` are not yet imported at the top of `tests/scan/scan.test.mjs`, add the imports. Check the first ~10 lines of the file; copy the style used by the existing `scan CLI — missing candidate-profile.yml` test at line 578, which already imports these.
+
+- [ ] **Step 1.7 — Run the new test; expect pass**
+
+```bash
+node --test --test-name-pattern="Next steps block" tests/scan/scan.test.mjs
+```
+
+The current `formatSummary` call is unconditional in `main()`, but the `--json` branch emits JSON instead (see existing behavior around line 414 — search for `--json`). Verify: when the current behavior under `--json` is to bypass `formatSummary` and output only JSON, the test passes without any further change because `formatSummary` is never called. Otherwise, wire the suppression explicitly. To confirm, read `src/scan/index.mjs` around lines 400–420:
+
+```bash
+grep -n "asJson\|--json\|formatSummary" src/scan/index.mjs
+```
+
+If the `--json` path still calls `formatSummary`, wrap the Next-steps block with a guard: accept a third arg `{ includeNextSteps = true } = {}` in `formatSummary`, skip the block when false, and set the option to false in the `--json` branch in `main()`. Update the Step 1.3 code to honor the flag.
+
+Expected after all fixes: the new test PASSES.
+
+- [ ] **Step 1.8 — Remove the `## Next step` section in `.claude/commands/scan.md`**
+
+Open `.claude/commands/scan.md` and delete the last section (lines 55–57):
+
+```
+## Next step
+
+Once `data/pipeline.md` has new rows, run `/score <url>` on each to get an LLM evaluation.
+```
+
+No replacement — the CLI footer is now the single source of truth.
+
+- [ ] **Step 1.9 — Commit**
+
+```bash
+git add src/scan/index.mjs tests/scan/scan.test.mjs .claude/commands/scan.md
+git commit -m "feat(scan): surface /explain, /dashboard, and flag hints in summary footer"
+```
+
+---
+
+## Task 2a — L2: `--help` for `/scan`
+
+**Files:**
+- Modify: `src/scan/index.mjs` (`printScanHelp()` + early intercept in `main()`)
+- Create: `tests/scan/scan-help.test.mjs`
+
+- [ ] **Step 2a.1 — Write failing test in `tests/scan/scan-help.test.mjs`**
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, '..', '..', 'src', 'scan', 'index.mjs');
+
+for (const flag of ['--help', '-h']) {
+  test(`/scan ${flag} exits 0 and prints usage — works without config`, () => {
+    // Deliberately point at empty dirs so config guard would fail if reached.
+    const res = spawnSync(process.execPath, [SCRIPT, flag], {
+      env: {
+        ...process.env,
+        CLAUDE_APPLY_CONFIG_DIR: '/nonexistent/cfg',
+        CLAUDE_APPLY_DATA_DIR: '/nonexistent/data',
+      },
+      encoding: 'utf8',
+    });
+    assert.equal(res.status, 0, `stderr=${res.stderr} stdout=${res.stdout}`);
+    assert.match(res.stdout, /^Usage: \/scan/m);
+    assert.match(res.stdout, /--dry-run/);
+    assert.match(res.stdout, /--only <slug>/);
+    assert.match(res.stdout, /--json/);
+    assert.match(res.stdout, /docs\/scan-workflow\.md/);
+    assert.match(res.stdout, /See also:/);
+  });
+}
+```
+
+- [ ] **Step 2a.2 — Run the test; expect failure**
+
+```bash
+node --test tests/scan/scan-help.test.mjs
+```
+
+Expected: FAIL — `--help` is not intercepted; either the script attempts to `requireConfig` and exits with 2, or it proceeds to fail for another reason.
+
+- [ ] **Step 2a.3 — Add `printScanHelp()` and the early intercept**
+
+Open `src/scan/index.mjs`. Just above the `async function main() {` declaration (currently around line 362), add:
+
+```js
+function printScanHelp() {
+  console.log(`Usage: /scan [--dry-run] [--only <slug>] [--json]
+
+Scan enabled ATS portals and append new offers to data/pipeline.md.
+
+Flags:
+  --dry-run         Compute everything, write nothing.
+  --only <slug>     Scan a single company by ATS slug (e.g. mistral).
+  --json            Emit machine-readable output to stdout.
+  --help, -h        Show this help and exit.
+
+Files:
+  reads:  config/portals.yml, config/candidate-profile.yml
+  writes: data/pipeline.md, data/scan-history.tsv, data/filtered-out.tsv
+
+See also: /explain, /dashboard
+          docs/scan-workflow.md  (title_filter format, per-company overrides)`);
+}
+```
+
+Inside `async function main()` as the **first two lines** of the body (before `const args = process.argv.slice(2);`):
+
+```js
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    printScanHelp();
+    process.exit(0);
+  }
+```
+
+If `const args = …` already exists on the first line of `main()`, merge: keep one declaration, add only the `if (...) { … }` right after it.
+
+- [ ] **Step 2a.4 — Run the test; expect pass**
+
+```bash
+node --test tests/scan/scan-help.test.mjs
+```
+
+Expected: both `--help` and `-h` tests PASS.
+
+- [ ] **Step 2a.5 — Commit**
+
+```bash
+git add src/scan/index.mjs tests/scan/scan-help.test.mjs
+git commit -m "feat(scan): add --help / -h flag with Usage / Flags / Files / See also"
+```
+
+---
+
+## Task 2b — L2: `--help` for `/score`
+
+**Files:**
+- Modify: `src/score/index.mjs` (`printScoreHelp()` + early intercept in `main()` at line 386)
+- Create: `tests/score/score-help.test.mjs`
+
+- [ ] **Step 2b.1 — Write failing test in `tests/score/score-help.test.mjs`**
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, '..', '..', 'src', 'score', 'index.mjs');
+
+for (const flag of ['--help', '-h']) {
+  test(`/score ${flag} exits 0 and prints usage — works without config`, () => {
+    const res = spawnSync(process.execPath, [SCRIPT, flag], {
+      env: {
+        ...process.env,
+        CLAUDE_APPLY_CONFIG_DIR: '/nonexistent/cfg',
+        CLAUDE_APPLY_DATA_DIR: '/nonexistent/data',
+      },
+      encoding: 'utf8',
+    });
+    assert.equal(res.status, 0, `stderr=${res.stderr} stdout=${res.stdout}`);
+    assert.match(res.stdout, /^Usage: \/score/m);
+    assert.match(res.stdout, /--re-score/);
+    assert.match(res.stdout, /--batch/);
+    assert.match(res.stdout, /--from-pipeline/);
+    assert.match(res.stdout, /docs\/score-workflow\.md/);
+  });
+}
+```
+
+- [ ] **Step 2b.2 — Run the test; expect failure**
+
+```bash
+node --test tests/score/score-help.test.mjs
+```
+
+Expected: FAIL — exit 2 (usage error from `parseScoreArgs`) or 3.
+
+- [ ] **Step 2b.3 — Add `printScoreHelp()` and the early intercept**
+
+Open `src/score/index.mjs`. Above `async function main()` (line 386), add:
+
+```js
+function printScoreHelp() {
+  console.log(`Usage: /score <url> [options]
+       /score --from-pipeline [--batch] [--parallel <n>]
+       /score --json-input <path>
+
+LLM-evaluate one or more offers against config/cv.md.
+
+Flags:
+  --re-score             Re-evaluate a URL already in evaluations.jsonl
+                         (preserves the existing id).
+  --batch                Score multiple offers from data/pipeline.md.
+  --parallel <n>         With --batch, run <n> evaluations concurrently.
+                         Implies --batch. Default: 5.
+  --from-pipeline        Take the offer URL from data/pipeline.md.
+  --json-input <path>    Read a pre-built offer JSON instead of fetching.
+  --id <id>              Override the generated id for this entry.
+  --company <name>       With --role and --location, override offer metadata
+                         (all three required together).
+  --role <title>         (see --company)
+  --location <loc>       (see --company)
+  --help, -h             Show this help and exit.
+
+Files:
+  reads:  config/cv.md, config/candidate-profile.yml
+  writes: data/evaluations.jsonl  (one JSON line per invocation)
+
+See also: /explain, /dashboard
+          docs/score-workflow.md`);
+}
+```
+
+Inside `main()`, as the **first lines** of the body (before the `const CONFIG_DIR = …` lines):
+
+```js
+  if (process.argv.slice(2).some((a) => a === '--help' || a === '-h')) {
+    printScoreHelp();
+    process.exit(0);
+  }
+```
+
+- [ ] **Step 2b.4 — Run the test; expect pass**
+
+```bash
+node --test tests/score/score-help.test.mjs
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 2b.5 — Commit**
+
+```bash
+git add src/score/index.mjs tests/score/score-help.test.mjs
+git commit -m "feat(score): add --help / -h flag listing all supported options"
+```
+
+---
+
+## Task 2c — L2: `--help` for `/explain`
+
+**Files:**
+- Modify: `src/scan/explain.mjs` (`printExplainHelp()` + early intercept in `main()` at line 107)
+- Create: `tests/scan/explain-help.test.mjs`
+
+- [ ] **Step 2c.1 — Write failing test**
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, '..', '..', 'src', 'scan', 'explain.mjs');
+
+for (const flag of ['--help', '-h']) {
+  test(`/explain ${flag} exits 0 and prints usage — works without config`, () => {
+    const res = spawnSync(process.execPath, [SCRIPT, flag], {
+      env: {
+        ...process.env,
+        CLAUDE_APPLY_CONFIG_DIR: '/nonexistent/cfg',
+      },
+      encoding: 'utf8',
+    });
+    assert.equal(res.status, 0, `stderr=${res.stderr} stdout=${res.stdout}`);
+    assert.match(res.stdout, /^Usage: \/explain/m);
+    assert.match(res.stdout, /--company <name>/);
+    assert.match(res.stdout, /--location <loc>/);
+    assert.match(res.stdout, /Exit codes/);
+    assert.match(res.stdout, /title-filter/);
+  });
+}
+```
+
+- [ ] **Step 2c.2 — Run the test; expect failure**
+
+```bash
+node --test tests/scan/explain-help.test.mjs
+```
+
+Expected: FAIL — currently exit 2 because `parseArgs` treats `--help` as a missing-title usage error.
+
+- [ ] **Step 2c.3 — Add `printExplainHelp()` and the early intercept**
+
+Open `src/scan/explain.mjs`. Just above `function main()` (line 107), add:
+
+```js
+function printExplainHelp() {
+  console.log(`Usage: /explain "<title>" [--company <name>] [--location <loc>]
+
+Trace which prefilter rule accepts or rejects a given title.
+
+Flags:
+  --company <name>    Apply blacklist check against this company.
+  --location <loc>    Apply location check against this string.
+  --help, -h          Show this help and exit.
+
+Files:
+  reads:  config/portals.yml, config/candidate-profile.yml
+  writes: (nothing)
+
+Exit codes: 0 = ACCEPTED, 1 = REJECTED, 2 = usage error.
+
+See also: /scan
+          docs/scan-workflow.md#title-filter`);
+}
+```
+
+Inside `main()` (line 107), as the **first lines**:
+
+```js
+function main() {
+  if (process.argv.slice(2).some((a) => a === '--help' || a === '-h')) {
+    printExplainHelp();
+    process.exit(0);
+  }
+  const parsed = parseArgs(process.argv);
+  // ... existing body unchanged
+```
+
+- [ ] **Step 2c.4 — Run the test; expect pass**
+
+```bash
+node --test tests/scan/explain-help.test.mjs
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 2c.5 — Commit**
+
+```bash
+git add src/scan/explain.mjs tests/scan/explain-help.test.mjs
+git commit -m "feat(explain): add --help / -h flag"
+```
+
+---
+
+## Task 2d — L2: `--help` for `/dashboard`
+
+**Files:**
+- Modify: `src/dashboard/build.mjs` (`printDashboardHelp()` + early intercept inside the CLI guard at line 321)
+- Create: `tests/dashboard/dashboard-help.test.mjs`
+
+- [ ] **Step 2d.1 — Write failing test**
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, '..', '..', 'src', 'dashboard', 'build.mjs');
+
+for (const flag of ['--help', '-h']) {
+  test(`/dashboard ${flag} exits 0 and prints usage — works without data`, () => {
+    const res = spawnSync(process.execPath, [SCRIPT, flag], {
+      env: {
+        ...process.env,
+        CLAUDE_APPLY_DATA_DIR: '/nonexistent/data',
+        CLAUDE_APPLY_REPORTS_DIR: '/nonexistent/reports',
+      },
+      encoding: 'utf8',
+    });
+    assert.equal(res.status, 0, `stderr=${res.stderr} stdout=${res.stdout}`);
+    assert.match(res.stdout, /^Usage: \/dashboard/m);
+    assert.match(res.stdout, /dashboard\.html/);
+    assert.match(res.stdout, /See also:/);
+  });
+}
+```
+
+- [ ] **Step 2d.2 — Run the test; expect failure**
+
+```bash
+node --test tests/dashboard/dashboard-help.test.mjs
+```
+
+Expected: FAIL — the script tries to read `data/` and crashes.
+
+- [ ] **Step 2d.3 — Add `printDashboardHelp()` and the intercept inside the CLI guard**
+
+Open `src/dashboard/build.mjs`. Just above the `// CLI guard — run directly as a script` comment (line 320), add:
+
+```js
+function printDashboardHelp() {
+  console.log(`Usage: /dashboard
+
+Regenerate dashboard.html from data/ and reports/.
+
+Flags:
+  --help, -h    Show this help and exit.
+
+Files:
+  reads:  data/pipeline.md, data/evaluations.jsonl, data/applications.md,
+          data/apply-log.jsonl, reports/
+  writes: dashboard.html  (at repo root)
+
+See also: /scan, /score`);
+}
+```
+
+Replace the current `if (import.meta.url === ...) { ... }` guard body so the help intercept runs **before** any `buildDashboard` call. Modified guard:
+
+```js
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    printDashboardHelp();
+    process.exit(0);
+  }
+  const dataDir = process.env.CLAUDE_APPLY_DATA_DIR || './data';
+  const reportsDir = process.env.CLAUDE_APPLY_REPORTS_DIR || './reports';
+  await buildDashboard({
+    applicationsPath: `${dataDir}/applications.md`,
+    reportsDir,
+    evaluationsPath: `${dataDir}/evaluations.jsonl`,
+    filteredOutPath: `${dataDir}/filtered-out.tsv`,
+    outputPath: './dashboard.html',
+    // ... preserve any existing properties unchanged
+  });
+}
+```
+
+Preserve any other fields already passed to `buildDashboard` (re-read lines 321–340 before editing).
+
+- [ ] **Step 2d.4 — Run the test; expect pass**
+
+```bash
+node --test tests/dashboard/dashboard-help.test.mjs
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 2d.5 — Commit**
+
+```bash
+git add src/dashboard/build.mjs tests/dashboard/dashboard-help.test.mjs
+git commit -m "feat(dashboard): add --help / -h flag"
+```
+
+---
+
+## Task 2e — L2: `--help` preamble for `/apply` (skill, not CLI)
+
+**Files:**
+- Modify: `.claude/commands/apply.md`
+
+- [ ] **Step 2e.1 — Read the current `apply.md` to find the right insertion point**
+
+```bash
+head -20 .claude/commands/apply.md
+```
+
+Note the frontmatter block (`---` … `---`) and the first `#` heading. The preamble must be inserted **between** them.
+
+- [ ] **Step 2e.2 — Insert the `--help` preamble**
+
+Immediately after the closing `---` of the frontmatter and before the first heading, insert the following block (plain markdown, no extra frontmatter):
+
+```markdown
+## `--help` / `-h`
+
+**Si `$ARGUMENTS` commence par `--help` ou `-h`, imprime uniquement le bloc ci-dessous et arrête-toi. N'ouvre pas Chrome, ne lis aucun fichier de `config/` ou `data/`.**
+
+```
+Usage: /apply <url>
+
+Open the URL in Chrome (CDP on port 9222), classify the form,
+fill from config/candidate-profile.yml, upload the CV, submit,
+and update data/applications.md + data/apply-log.jsonl.
+
+Stops and asks the user on: captcha, login wall,
+unknown required field.
+
+Prerequisites:
+  - chrome-apply alias launched (CDP port 9222 up)
+  - claude-in-chrome extension installed with host permissions
+
+Files:
+  reads:  config/candidate-profile.yml, config/cv.<lang>.pdf
+  writes: data/applications.md, data/apply-log.jsonl
+
+See also: /scan, /score, /dashboard
+          docs/apply-workflow.md, docs/cdp-setup.md
+```
+```
+
+Note the double-backtick nesting: the outer code fence in the spec is just for presentation. In `apply.md`, use triple-backticks around the `Usage:` block, and prose above it.
+
+- [ ] **Step 2e.3 — Manual verification**
+
+Not unit-testable (skill, not CLI). In a fresh Claude Code session, type `/apply --help`. Confirm that the block is printed and no browser tool is invoked. Record the result in the commit body if anything is off.
+
+- [ ] **Step 2e.4 — Commit**
+
+```bash
+git add .claude/commands/apply.md
+git commit -m "docs(apply): document --help / -h skill preamble for /apply"
+```
+
+---
+
+## Task 3 — L3: link `title_filter` docs from `scan.md`
+
+**Files:**
+- Modify: `.claude/commands/scan.md` (append one line in `## Interpreting the output`)
+
+- [ ] **Step 3.1 — Add the pointer line**
+
+Open `.claude/commands/scan.md`. In the `## Interpreting the output` section, after the paragraph ending with `Group B (custom career pages) companies are skipped silently.` (currently line 53), append one blank line and one pointer line:
+
+```markdown
+
+Pour comprendre en détail comment `title_filter` rejette une offre, voir [`docs/scan-workflow.md#title-filter`](../../docs/scan-workflow.md#title-filter) ou lance `/explain "<titre>"`.
+```
+
+Verify the relative path `../../docs/scan-workflow.md` is correct from `.claude/commands/scan.md`:
+
+```bash
+ls -la .claude/commands/scan.md docs/scan-workflow.md
+```
+
+Both must exist at those paths.
+
+- [ ] **Step 3.2 — Commit**
+
+```bash
+git add .claude/commands/scan.md
+git commit -m "docs(scan): link title_filter reference from /scan command page"
+```
+
+---
+
+## Task 4a — L4: print `setup.sh --help` once in onboarding step 2
+
+**Files:**
+- Modify: `.claude/commands/apply-onboard/setup.md` (step 2)
+
+- [ ] **Step 4a.1 — Locate step 2**
+
+The current step 2 is around lines 23–34 of `.claude/commands/apply-onboard/setup.md`. It reads:
+
+```markdown
+## 2. Run `scripts/setup.sh`
+
+Run one of:
+
+    bash scripts/setup.sh --yes --clone-chrome-profile       # if user said yes
+    bash scripts/setup.sh --yes --no-clone-chrome-profile    # if user said no
+
+This will: install npm deps if missing (`npm ci` / `npm install`), create the CDP Chrome profile (empty or cloned), append the `chrome-apply` alias to the user's shell rc (with a timestamped backup), and copy any missing templates into `config/` (harmless — `cv.md`, `candidate-profile.yml`, and `portals.yml` already exist from the earlier phases and are skipped).
+
+If the user is in an unusual shell setup, add `--no-rc` and print the alias to them manually. Run `bash scripts/setup.sh --help` for all flags.
+```
+
+- [ ] **Step 4a.2 — Rewrite step 2 to instruct Claude to print `--help` first**
+
+Replace the whole step 2 block with:
+
+```markdown
+## 2. Run `scripts/setup.sh`
+
+**First, print the script's usage once** so the user discovers flags like `--no-clone-chrome-profile` and `--no-rc`:
+
+    bash scripts/setup.sh --help
+
+Print the captured output verbatim, prefaced by one short line:
+
+> "Voici les flags supportés par le script (affichés une fois pour que tu saches ce qui est disponible) — je vais maintenant lancer le setup avec les flags correspondant à ton choix clone-chrome-profile."
+
+Then run one of:
+
+    bash scripts/setup.sh --yes --clone-chrome-profile       # if user said yes
+    bash scripts/setup.sh --yes --no-clone-chrome-profile    # if user said no
+
+This will: install npm deps if missing (`npm ci` / `npm install`), create the CDP Chrome profile (empty or cloned), append the `chrome-apply` alias to the user's shell rc (with a timestamped backup), and copy any missing templates into `config/` (harmless — `cv.md`, `candidate-profile.yml`, and `portals.yml` already exist from the earlier phases and are skipped).
+
+If the user is in an unusual shell setup, add `--no-rc` and print the alias to them manually.
+```
+
+(Use four-space indentation for the fenced commands, as shown, to match the existing style.)
+
+- [ ] **Step 4a.3 — Commit**
+
+```bash
+git add .claude/commands/apply-onboard/setup.md
+git commit -m "docs(onboard): print setup.sh --help once in step 2 for flag discoverability"
+```
+
+---
+
+## Task 4b — L4: new step 5.5 (dry-run calibration)
+
+**Files:**
+- Modify: `.claude/commands/apply-onboard/setup.md` (insert new step between current steps 5 and 6)
+
+- [ ] **Step 4b.1 — Insert the new step**
+
+In `.claude/commands/apply-onboard/setup.md`, immediately after the current step 5 block (which ends at the line `**Wait for the user to confirm permissions are granted** before continuing.`) and before `## 6. Final summary`, insert:
+
+````markdown
+## 5.5. Calibration dry-run (best-effort)
+
+Before printing the final summary, run a `/scan --dry-run --json` to give the user a realistic preview of what their first real scan will yield. The extension is not required for this step.
+
+```bash
+node src/scan/index.mjs --dry-run --json
+```
+
+Parse the JSON to extract:
+
+- `result.raw` — total raw offers across all companies
+- `result.added.length` — number of offers that would survive all filters
+- `result.perCompany.filter(c => c.newCount > 0)` — companies with at least one hit, sorted descending by `newCount`, top 3
+
+Cache these three values (or a single "skipped" flag on failure) so step 6 can reference them.
+
+**Failure mode (network error, ATS outage, any non-zero exit):** do **not** block onboarding. Set an internal "dry-run skipped" flag and let step 6 fall back to the "skipped" message. The user will still have a working install.
+````
+
+- [ ] **Step 4b.2 — Commit**
+
+```bash
+git add .claude/commands/apply-onboard/setup.md
+git commit -m "docs(onboard): add step 5.5 dry-run calibration before final summary"
+```
+
+---
+
+## Task 4c — L4: rewrite step 6 final summary
+
+**Files:**
+- Modify: `.claude/commands/apply-onboard/setup.md` (replace step 6 block)
+
+- [ ] **Step 4c.1 — Replace step 6**
+
+Open `.claude/commands/apply-onboard/setup.md`. Locate the `## 6. Final summary` section (currently lines 109–135). Replace the entire section with:
+
+````markdown
+## 6. Final summary
+
+Read `config/portals.yml` once to extract `title_filter.required_any` and `title_filter.excluded_any`. Use the dry-run values cached in step 5.5 (or the "skipped" flag).
+
+Print the following summary, substituting values where marked:
+
+```
+✅ Onboarding complete.
+
+Files written:
+  • config/cv.md
+  • config/cv.<lang>.pdf
+  • config/candidate-profile.yml
+  • config/portals.yml  (<N> companies)
+
+Your title_filter:
+  required_any  : <comma-separated list from portals.yml, or "(none)">
+  excluded_any  : <comma-separated list from portals.yml, or "(none)">
+  (source: config/portals.yml — edit there to re-tune,
+   or run /explain "<title>" to debug one title)
+
+First scan preview (dry-run):
+  <A> new offers after filter (from <R> raw).
+  Top hits: <company1> (<n1>), <company2> (<n2>), <company3> (<n3>).
+  → If 0 hits: your required_any is probably too strict.
+    Run /explain "<one of your target titles>" to trace it,
+    then edit config/portals.yml and re-run /scan.
+
+Chrome launched in CDP mode (port 9222) with the
+claude-in-chrome extension page open.
+
+One last manual step:
+  → Click "Add to Chrome" on the page that just opened,
+    then confirm the install dialog.
+
+Then you can run:
+  /scan                # fetch new offers into data/pipeline.md
+  /score <url>         # LLM-evaluate an offer
+  /apply <url>         # automated form fill + submit
+  /explain "<title>"   # debug why a title passes/fails the filter
+  /dashboard           # regenerate dashboard.html
+
+Tip: append --help to any command (e.g. /scan --help) to see its flags.
+```
+
+**Fallback when step 5.5 was skipped:** replace the "First scan preview" block with exactly:
+
+```
+First scan preview (dry-run):
+  (skipped — network issue during dry-run; run /scan --dry-run when ready.)
+```
+
+**Fallback when `raw === 0` across all companies** (likely ATS outage or empty `portals.yml`): replace the block with:
+
+```
+First scan preview (dry-run):
+  0 raw offers — likely an ATS outage or an empty portals.yml.
+  Run /scan after the extension install to retry.
+```
+
+**Fallback when `title_filter` is absent from `portals.yml`:** print `(none — every title accepted)` for both `required_any` and `excluded_any`.
+
+**Do not run `/scan` or `/apply` yourself** — the user still needs to install the extension manually. Your onboarding stops here.
+````
+
+- [ ] **Step 4c.2 — Commit**
+
+```bash
+git add .claude/commands/apply-onboard/setup.md
+git commit -m "docs(onboard): rewrite step 6 summary with title_filter recap and dry-run preview"
+```
+
+---
+
+## Task 5 — E2E checklist entry
+
+**Files:**
+- Modify: `docs/testing.md`
+
+- [ ] **Step 5.1 — Add the checklist line**
+
+Open `docs/testing.md`. Find the E2E section (likely headed `## E2E` or `## Manual testing`). Append one line:
+
+```markdown
+- `/apply-onboard` final summary shows the `Your title_filter` block and either a `First scan preview` (with raw + added counts) or the graceful "skipped" fallback when the dry-run fails.
+```
+
+If there is no E2E section, add the line at the end of the file under a new `## E2E onboarding` heading.
+
+- [ ] **Step 5.2 — Commit**
+
+```bash
+git add docs/testing.md
+git commit -m "docs(testing): add onboarding summary to E2E checklist"
+```
+
+---
+
+## Task 6 — Full test suite + lint
+
+- [ ] **Step 6.1 — Run the full suite**
+
+```bash
+npm test
+```
+
+Expected: all tests PASS. The five new test files (`scan-help`, `score-help`, `explain-help`, `dashboard-help`, plus the two appended `Next steps` tests in `scan.test.mjs`) contribute ~8 new passing tests. No existing test should regress.
+
+- [ ] **Step 6.2 — Run lint and format**
+
+```bash
+npm run lint
+npm run format
+```
+
+Expected: lint PASS, format no-op (or commit any whitespace corrections separately).
+
+- [ ] **Step 6.3 — Run the PII gate locally**
+
+```bash
+npm run check:pii
+```
+
+Expected: PASS — none of the new content contains PII (all examples use placeholder titles like `"<title>"` and generic company names).
+
+- [ ] **Step 6.4 — Commit formatting fixes if any**
+
+```bash
+git status
+# If prettier reformatted anything:
+git add -A
+git commit -m "style: prettier"
+```
+
+---
+
+## Task 7 — Manual smoke test
+
+- [ ] **Step 7.1 — Smoke-test each `--help`**
+
+```bash
+node src/scan/index.mjs --help
+node src/score/index.mjs --help
+node src/scan/explain.mjs --help
+node src/dashboard/build.mjs --help
+```
+
+For each: verify exit code 0 (`echo $?`) and that the `Usage:` / `Flags:` / `Files:` / `See also:` blocks appear.
+
+- [ ] **Step 7.2 — Smoke-test the `/scan` footer**
+
+```bash
+node src/scan/index.mjs --dry-run
+```
+
+Verify the tail of the output contains the `Next steps :` block with `/score`, `/explain`, `/dashboard`, and the `Plus de flags : /scan --help` line.
+
+- [ ] **Step 7.3 — Smoke-test `/scan --json`**
+
+```bash
+node src/scan/index.mjs --dry-run --json | tail -5
+```
+
+Verify the output ends with a JSON closing `}` and contains **no** `Next steps` text.
+
+```bash
+node src/scan/index.mjs --dry-run --json | python3 -m json.tool > /dev/null
+```
+
+Expected: exit 0 (parseable JSON).
+
+- [ ] **Step 7.4 — Open a PR**
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "feat(discoverability): surface /explain, /dashboard, flags, and --help (issue #89)" --body "$(cat <<'EOF'
+## Summary
+
+Addresses all seven discoverability gaps from issue #89 in one bundled PR:
+
+- **L1** `/scan` summary footer now lists `/score`, `/explain`, `/dashboard` and the flag hint (items 1, 5). Removed the obsolete `## Next step` section in `scan.md`.
+- **L2** `--help` / `-h` on every CLI entry point (`/scan`, `/score`, `/explain`, `/dashboard`) + documented preamble in `apply.md` (item 7). Works without config.
+- **L3** Linked `docs/scan-workflow.md#title-filter` from `.claude/commands/scan.md` and from `/scan --help` See-also (item 3).
+- **L4** Onboarding: step 2 prints `setup.sh --help` once (item 2); new step 5.5 runs `/scan --dry-run --json` for a calibration preview; step 6 summary now shows `Your title_filter`, a `First scan preview`, and the full command list including `/explain` and `/dashboard` (items 4, 6).
+
+Spec: `docs/superpowers/specs/2026-04-21-issue-89-discoverability-design.md`.
+
+## Test plan
+
+- [x] Unit: `formatSummary` emits/skips the `Next steps` block as expected.
+- [x] Unit: each of the 4 CLIs exits 0 on `--help` and `-h` with no config present.
+- [x] Unit: `/scan --dry-run --json` stdout is parseable JSON without the `Next steps` text.
+- [ ] Manual: `/apply --help` prints the skill preamble without opening Chrome.
+- [ ] Manual: fresh `/apply-onboard` run shows the new summary with the dry-run preview.
+
+Closes #89.
+EOF
+)"
+```
+
+Expected: PR URL returned. Print it to the user.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+
+| Spec requirement | Task |
+|---|---|
+| L1 `formatSummary` Next steps block | Task 1 steps 1.1–1.9 |
+| L1 suppression under `--json` | Task 1 steps 1.6–1.7 |
+| L1 remove `## Next step` in `scan.md` | Task 1 step 1.8 |
+| L2 `/scan --help` | Task 2a |
+| L2 `/score --help` | Task 2b |
+| L2 `/explain --help` | Task 2c |
+| L2 `/dashboard --help` | Task 2d |
+| L2 `/apply --help` preamble | Task 2e |
+| L3 `scan.md` pointer line | Task 3 |
+| L4 print `setup.sh --help` | Task 4a |
+| L4 dry-run calibration step | Task 4b |
+| L4 rewritten summary with fallbacks | Task 4c |
+| E2E checklist addition | Task 5 |
+
+All thirteen items mapped.
+
+**Placeholder scan:** none. Every code/text block is complete. Fallback text is explicit. Commands are copy-pasteable.
+
+**Type consistency:** `formatSummary(result, dryRun)` keeps its existing signature; the `--json` suppression is implemented via a conditional call site in `main()`, not a third argument, matching the current `export function formatSummary(result, dryRun)` line. If the implementation in step 1.7 discovers that `formatSummary` IS called under `--json`, the plan explicitly instructs adding an options argument — that is the one branch in the plan, and both variants are spelled out.
+
+**One known deviation from the spec (flagged in the plan header):** `/score --help` lists all real flags (`--batch`, `--parallel`, `--from-pipeline`, `--json-input`, `--id`, `--company`/`--role`/`--location`) in addition to the `--re-score` called out by the spec. Rationale: a `--help` that hides existing flags is worse than no `--help`. No spec change needed; reviewer can challenge during PR review.

--- a/docs/superpowers/specs/2026-04-21-issue-89-discoverability-design.md
+++ b/docs/superpowers/specs/2026-04-21-issue-89-discoverability-design.md
@@ -1,0 +1,307 @@
+# Issue #89 — Slash-command discoverability and post-action guidance
+
+**Date:** 2026-04-21
+**Issue:** [#89 — docs: improve slash-command discoverability and post-action guidance](https://github.com/LeoLaborie/claude-apply/issues/89)
+**Status:** Design approved, ready for implementation plan.
+
+## Context
+
+During an onboarding session (2026-04-19), `/scan` returned `1 hit out of 2 359 raw offers`. The user had no path from that result to the tools that would actually help diagnose it (`/explain`, `/dashboard`, `--dry-run`), and no concept of what to expect from the system over time. Issue #89 bundles the seven discoverability gaps surfaced during that single session.
+
+This spec addresses all seven items through four additive, locally-scoped deliverables. No architectural change, no data-format change, no new runtime dependencies.
+
+## Goals
+
+- Every slash command that wraps a node CLI (`/scan`, `/score`, `/explain`, `/dashboard`) accepts `--help` / `-h` and prints a deterministic usage block.
+- `/apply` (a skill, not a CLI) documents its usage in `.claude/commands/apply.md` with an explicit instruction to honor `--help` in `$ARGUMENTS`.
+- The `/scan` summary footer points the user to the next useful commands (`/score`, `/explain`, `/dashboard`) and surfaces the flags (`--dry-run`, `--only`, `--json`).
+- The onboarding summary shows the user's current `title_filter`, a dry-run calibration preview of their first scan, and the full command list (`/scan`, `/score`, `/apply`, `/explain`, `/dashboard`).
+- The `title_filter` format is documented in `docs/scan-workflow.md` (already true) and reachable from `/scan --help` and `/scan` (new).
+
+## Non-goals
+
+- No adoption of an argparse library. Manual inspection of `process.argv.slice(2)` stays the convention.
+- No mention of `/tune-filter` (issue #85) — not yet merged. The PR that merges it will add the pointer.
+- No internationalization of `--help` output (stays in English, matching the rest of the CLI).
+- No new `Next steps` footer on `/score`, `/explain`, or `/dashboard` output — their existing outputs are already fit-for-purpose; only `/scan` has the ambiguous `1/N` moment that needs a nudge.
+
+## Deliverables
+
+### L1 — `/scan` summary footer
+
+**File:** `src/scan/index.mjs` (`formatSummary()`)
+
+Append a `Next steps` block after the `Erreurs` section (if any). Always emit it, including when `result.added.length === 0` — that is precisely when `/explain` matters most. Do **not** emit the block when `--json` is active, to keep stdout strictly JSON-parseable.
+
+Exact text:
+
+```
+Next steps :
+  /score <url>        # évalue une offre via LLM (data/evaluations.jsonl)
+  /explain "<title>"  # trace pourquoi une offre passe/échoue le filtre
+  /dashboard          # régénère dashboard.html
+
+Plus de flags : /scan --help  (--dry-run, --only <slug>, --json)
+```
+
+**File:** `.claude/commands/scan.md`
+
+Remove the `## Next step` section (currently says only "run `/score <url>` on each"). The CLI footer becomes the single source of truth.
+
+**Covers issue items:** 1, 5.
+
+### L2 — `--help` on CLI entry points
+
+**Files:** `src/scan/index.mjs`, `src/score/index.mjs`, `src/scan/explain.mjs`, `src/dashboard/build.mjs`
+
+Add a local `printHelp()` function to each module. At the very top of `main()`, before `requireConfig()` or any I/O, intercept the flag:
+
+```js
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    printHelp();
+    process.exit(0);
+  }
+  // ... existing body unchanged
+}
+```
+
+This guarantees `/<cmd> --help` works without any config present — critical for first-time users who haven't run `/apply-onboard` yet.
+
+If both `--help` and another flag are passed, `--help` wins (Unix convention).
+
+**Template for each help block** — four fixed sections: Usage / Flags / Files / See also. Each block is emitted verbatim via `console.log(` a template string `)`.
+
+**`/scan --help`:**
+
+```
+Usage: /scan [--dry-run] [--only <slug>] [--json]
+
+Scan enabled ATS portals and append new offers to data/pipeline.md.
+
+Flags:
+  --dry-run         Compute everything, write nothing.
+  --only <slug>     Scan a single company by ATS slug (e.g. mistral).
+  --json            Emit machine-readable output to stdout.
+  --help, -h        Show this help and exit.
+
+Files:
+  reads:  config/portals.yml, config/candidate-profile.yml
+  writes: data/pipeline.md, data/scan-history.tsv, data/filtered-out.tsv
+
+See also: /explain, /dashboard
+          docs/scan-workflow.md  (title_filter format, per-company overrides)
+```
+
+**`/score --help`:**
+
+```
+Usage: /score <url> [--re-score]
+
+LLM-evaluate a single offer URL against config/cv.md.
+
+Flags:
+  --re-score    Re-evaluate an offer already present in evaluations.jsonl.
+  --help, -h    Show this help and exit.
+
+Files:
+  reads:  config/cv.md, config/candidate-profile.yml
+  writes: data/evaluations.jsonl  (one JSON line per invocation)
+
+See also: /explain, /dashboard
+          docs/score-workflow.md
+```
+
+**`/explain --help`:**
+
+```
+Usage: /explain "<title>" [--company <name>] [--location <loc>]
+
+Trace which prefilter rule accepts or rejects a given title.
+
+Flags:
+  --company <name>    Apply blacklist check against this company.
+  --location <loc>    Apply location check against this string.
+  --help, -h          Show this help and exit.
+
+Files:
+  reads:  config/portals.yml, config/candidate-profile.yml
+  writes: (nothing)
+
+Exit codes: 0 = ACCEPTED, 1 = REJECTED, 2 = usage error.
+
+See also: /scan
+          docs/scan-workflow.md#title-filter
+```
+
+**`/dashboard --help`:**
+
+```
+Usage: /dashboard
+
+Regenerate dashboard.html from data/ and reports/.
+
+Flags:
+  --help, -h    Show this help and exit.
+
+Files:
+  reads:  data/pipeline.md, data/evaluations.jsonl, data/applications.md,
+          data/apply-log.jsonl, reports/
+  writes: dashboard.html  (at repo root)
+
+See also: /scan, /score
+```
+
+**`/apply` — skill, not CLI.** Add to `.claude/commands/apply.md`, immediately after the frontmatter and before the first heading:
+
+> **Si `$ARGUMENTS` commence par `--help` ou `-h`, imprime uniquement le bloc Usage ci-dessous et arrête-toi — n'ouvre pas Chrome, ne lis aucun autre fichier.**
+>
+> ```
+> Usage: /apply <url>
+>
+> Open the URL in Chrome (CDP on port 9222), classify the form,
+> fill from config/candidate-profile.yml, upload the CV, submit,
+> and update data/applications.md + data/apply-log.jsonl.
+>
+> Stops and asks the user on: captcha, login wall, unknown required field.
+>
+> Prerequisites:
+>   - chrome-apply alias launched (CDP port 9222 up)
+>   - claude-in-chrome extension installed with host permissions
+>
+> Files:
+>   reads:  config/candidate-profile.yml, config/cv.<lang>.pdf
+>   writes: data/applications.md, data/apply-log.jsonl
+>
+> See also: /scan, /score, /dashboard
+>           docs/apply-workflow.md, docs/cdp-setup.md
+> ```
+
+**Covers issue item:** 7.
+
+### L3 — `title_filter` format documentation
+
+**Status:** Already documented in `docs/scan-workflow.md` under `## Title filter`, including the per-company overrides `skip_required_any` and `target_locations`. No rewrite needed.
+
+**Two additions only, to make it reachable:**
+
+1. **`/scan --help` See also** — explicit pointer: `docs/scan-workflow.md (title_filter format, per-company overrides)`. (Already in L2.)
+2. **`.claude/commands/scan.md`** — append one line to the `## Interpreting the output` section:
+
+   > Pour comprendre en détail comment `title_filter` rejette une offre, voir [`docs/scan-workflow.md#title-filter`](../../docs/scan-workflow.md#title-filter) ou lance `/explain "<titre>"`.
+
+**Covers issue item:** 3.
+
+### L4 — Onboarding summary
+
+**File:** `.claude/commands/apply-onboard/setup.md`
+
+Three changes, preserving the existing six-step flow.
+
+**Step 2 — print `setup.sh --help` once.** Before invoking `bash scripts/setup.sh --yes …`, run `bash scripts/setup.sh --help` and print its output, prefaced by one sentence:
+
+> *"Voici les flags supportés par le script (affichés une fois pour que tu saches ce qui est disponible) — je vais maintenant lancer le setup avec les flags correspondant à ton choix clone-chrome-profile."*
+
+Zero additional execution cost (help exits immediately).
+
+**New step 5.5 — dry-run calibration.** Inserted after the user confirms extension permissions (end of step 5) and before the final summary (step 6). The dry-run does not require the extension — only the configs, which exist by this point.
+
+```
+Before printing the summary, run:
+
+  node src/scan/index.mjs --dry-run --json
+
+Parse the JSON to extract:
+  - result.raw                              (total raw offers)
+  - result.added.length                     (new hits after all filters)
+  - result.perCompany.filter(c => c.newCount > 0)
+      sorted desc by newCount, top 3        (top companies)
+```
+
+**Failure mode:** if the dry-run fails (network issue, ATS down, any non-zero exit), do **not** block onboarding. Skip the preview block in the summary and substitute:
+
+> `(First scan preview skipped — network issue during dry-run; run /scan --dry-run when ready.)`
+
+**Step 6 — rewritten summary:**
+
+```
+✅ Onboarding complete.
+
+Files written:
+  • config/cv.md
+  • config/cv.<lang>.pdf
+  • config/candidate-profile.yml
+  • config/portals.yml  (N companies)
+
+Your title_filter:
+  required_any  : Intern, Internship, Stage, Stagiaire
+  excluded_any  : Senior, Manager
+  (source: config/portals.yml — edit there to re-tune,
+   or run /explain "<title>" to debug one title)
+
+First scan preview (dry-run):
+  3 new offers after filter (from 2 359 raw).
+  Top hits: mistral (1), anthropic (1), photoroom (1).
+  → If 0 hits: your required_any is probably too strict.
+    Run /explain "<one of your target titles>" to trace it,
+    then edit config/portals.yml and re-run /scan.
+
+Chrome launched in CDP mode (port 9222) with the
+claude-in-chrome extension page open.
+
+One last manual step:
+  → Click "Add to Chrome" on the page that just opened,
+    then confirm the install dialog.
+
+Then you can run:
+  /scan                # fetch new offers into data/pipeline.md
+  /score <url>         # LLM-evaluate an offer
+  /apply <url>         # automated form fill + submit
+  /explain "<title>"   # debug why a title passes/fails the filter
+  /dashboard           # regenerate dashboard.html
+
+Tip: append --help to any command (e.g. /scan --help) to see its flags.
+```
+
+**Edge cases:**
+
+- `portals.yml` without any `title_filter` → print `Your title_filter: (none — every title accepted)`. Unlikely in practice because `apply-onboard:companies` always writes a filter, but the fallback stays robust.
+- Dry-run succeeds with `raw === 0` for every company → print `First scan preview (dry-run): 0 raw offers — likely an ATS outage or empty portals.yml. Run /scan after the extension install to retry.`
+
+**Covers issue items:** 2, 4, 6.
+
+## Testing
+
+| Layer | Test |
+|---|---|
+| L1 `formatSummary` | Extend `tests/scan-format-summary.test.mjs`: assert `Next steps` block is present in the default path; assert absence in `--json` output. |
+| L2 `--help` | One new test file per CLI: `tests/scan-help.test.mjs`, `tests/score-help.test.mjs`, `tests/explain-help.test.mjs`, `tests/dashboard-help.test.mjs`. Each spawns the node script with `--help` (e.g. via `node:child_process.spawnSync`), asserts `exitCode === 0` and that stdout contains `Usage:` and the command name. |
+| L2 `/apply --help` | Not unit-testable (skill). Verified manually via `/apply --help` in a real session. |
+| L3 | No test — pure Markdown. |
+| L4 onboarding | No automated test (skill). Add one entry to `docs/testing.md` E2E checklist: "`/apply-onboard` final summary shows `Your title_filter` block and dry-run preview (or graceful fallback when network fails)." |
+
+Every new test must run without any config present — that is the scenario where `--help` matters most.
+
+## Migration
+
+None. Every change is additive:
+
+- `formatSummary` gains a trailing block; existing callers keep working.
+- CLIs gain a `--help` branch; any invocation without `--help` is unchanged.
+- `apply.md` gains a preamble block that is a no-op when `$ARGUMENTS` does not contain `--help`.
+- `setup.md` gains one new step and rewrites the final summary block; the external contract of the skill (files written, Chrome launched, permissions granted) is unchanged.
+
+No data-file migration, no config-file migration, no version bump.
+
+## Coverage matrix
+
+| Issue item | Deliverable |
+|---|---|
+| 1. End of `/scan` doesn't surface `/explain`/`/dashboard` | L1 |
+| 2. `bash scripts/setup.sh --help` is never shown | L4 (step 2) |
+| 3. `title_filter` format undocumented at slash-command level | L3 |
+| 4. No post-onboarding recap | L4 (step 6 + step 5.5 dry-run) |
+| 5. `--dry-run` and `--only` never surfaced | L1 |
+| 6. `/explain` and `/dashboard` silent during onboarding | L4 (step 6) |
+| 7. No `/scan --help` (or any `--help`) | L2 |

--- a/src/lib/candidate-profile.schema.mjs
+++ b/src/lib/candidate-profile.schema.mjs
@@ -37,6 +37,7 @@ const OPTIONAL_FIELDS = [
   'other_document_path',
   'internship_duration_months',
   'job_type',
+  'auto_generate_cover_letter',
 ];
 
 function validateEducationEntry(e, i) {

--- a/src/lib/candidate-profile.schema.mjs
+++ b/src/lib/candidate-profile.schema.mjs
@@ -13,7 +13,6 @@ export const REQUIRED_FIELDS = [
   'work_authorization',
   'requires_sponsorship',
   'availability_start',
-  'internship_duration_months',
   'cv_path',
   'auto_apply_min_score',
 ];
@@ -36,6 +35,8 @@ const OPTIONAL_FIELDS = [
   'transcript_path',
   'portfolio_path',
   'other_document_path',
+  'internship_duration_months',
+  'job_type',
 ];
 
 function validateEducationEntry(e, i) {
@@ -64,6 +65,24 @@ export function validateProfile(profile) {
   for (const f of REQUIRED_FIELDS) {
     if (profile[f] === undefined || profile[f] === null || profile[f] === '') {
       errors.push(`missing required field: ${f}`);
+    }
+  }
+  if (profile.job_type === 'internship' || profile.job_type === 'apprenticeship') {
+    if (!profile.internship_duration_months) {
+      errors.push(
+        'missing required field: internship_duration_months (required for internship/apprenticeship)'
+      );
+    }
+  }
+  if (
+    profile.internship_duration_months !== undefined &&
+    profile.internship_duration_months !== null
+  ) {
+    if (
+      typeof profile.internship_duration_months !== 'number' ||
+      profile.internship_duration_months < 1
+    ) {
+      errors.push('internship_duration_months must be a positive number');
     }
   }
   if (profile.email && !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(profile.email)) {

--- a/src/lib/extension-permission-probe.mjs
+++ b/src/lib/extension-permission-probe.mjs
@@ -1,0 +1,56 @@
+export function interpretProbeResult({
+  navigateResult,
+  findResult,
+  findError = null,
+  navigateError = null,
+} = {}) {
+  if (navigateError || !navigateResult) {
+    if (navigateError && /ERR_ABORTED|net::|failed to navigate/i.test(String(navigateError))) {
+      return { ok: false, reason: 'navigation_failed', detail: String(navigateError) };
+    }
+    if (!navigateResult) {
+      return { ok: false, reason: 'navigation_failed', detail: 'no navigate result' };
+    }
+  }
+  if (findError) {
+    const msg = String(findError);
+    if (/manifest must request permission/i.test(msg)) {
+      return { ok: false, reason: 'missing_permission', detail: msg };
+    }
+    if (/extension.*not.*installed|no response from extension|extension.*disconnected/i.test(msg)) {
+      return { ok: false, reason: 'extension_not_installed', detail: msg };
+    }
+    if (/timeout/i.test(msg)) {
+      return { ok: false, reason: 'timeout', detail: msg };
+    }
+    return { ok: false, reason: 'unknown', detail: msg };
+  }
+  if (!findResult) {
+    return { ok: false, reason: 'unknown', detail: 'no find result and no error' };
+  }
+  return { ok: true };
+}
+
+export async function probeExtensionPermission(
+  client,
+  { probeHost = 'https://jobs.lever.co/anthropic', findSelector = 'body' } = {}
+) {
+  let navigateResult = null;
+  let navigateError = null;
+  let findResult = null;
+  let findError = null;
+  try {
+    navigateResult = await client.navigate(probeHost);
+  } catch (err) {
+    navigateError = err?.message ?? String(err);
+  }
+  if (navigateError || !navigateResult) {
+    return interpretProbeResult({ navigateResult, navigateError, findResult, findError });
+  }
+  try {
+    findResult = await client.find(findSelector);
+  } catch (err) {
+    findError = err?.message ?? String(err);
+  }
+  return interpretProbeResult({ navigateResult, navigateError, findResult, findError });
+}

--- a/tests/apply/candidate-profile.test.mjs
+++ b/tests/apply/candidate-profile.test.mjs
@@ -224,6 +224,29 @@ test('validateProfile tolerates internship_duration_months on a senior profile',
   assert.equal(ok, true, `errors: ${JSON.stringify(errors)}`);
 });
 
+test('validateProfile accepts auto_generate_cover_letter as optional', () => {
+  const { ok, errors } = validateProfile({
+    first_name: 'Alice',
+    last_name: 'Martin',
+    email: 'alice@example.com',
+    phone: '+33600000000',
+    linkedin_url: 'https://linkedin.com/in/a',
+    github_url: 'https://github.com/a',
+    city: 'Paris',
+    country: 'France',
+    school: 'S',
+    degree: 'D',
+    graduation_year: 2026,
+    work_authorization: 'EU',
+    requires_sponsorship: false,
+    availability_start: '2026-09-01',
+    cv_path: 'cv.pdf',
+    auto_apply_min_score: 8,
+    auto_generate_cover_letter: true,
+  });
+  assert.equal(ok, true, `errors: ${JSON.stringify(errors)}`);
+});
+
 test('validateProfile rejects profile without cv_path', () => {
   const { ok, errors } = validateProfile({
     first_name: 'Alice',

--- a/tests/apply/candidate-profile.test.mjs
+++ b/tests/apply/candidate-profile.test.mjs
@@ -153,6 +153,77 @@ test('validateProfile accepts profile with cv_path only', () => {
   assert.equal(ok, true, `errors: ${JSON.stringify(errors)}`);
 });
 
+test('validateProfile requires internship_duration_months when job_type is internship', () => {
+  const { ok, errors } = validateProfile({
+    first_name: 'Alice',
+    last_name: 'Martin',
+    email: 'alice@example.com',
+    phone: '+33600000000',
+    linkedin_url: 'https://linkedin.com/in/a',
+    github_url: 'https://github.com/a',
+    city: 'Paris',
+    country: 'France',
+    school: 'S',
+    degree: 'D',
+    graduation_year: 2026,
+    work_authorization: 'EU',
+    requires_sponsorship: false,
+    availability_start: '2026-09-01',
+    cv_path: 'cv.pdf',
+    auto_apply_min_score: 8,
+    job_type: 'internship',
+  });
+  assert.equal(ok, false);
+  assert.ok(errors.some((e) => e.includes('internship_duration_months')));
+});
+
+test('validateProfile does not require internship_duration_months when job_type is mid-level', () => {
+  const { ok, errors } = validateProfile({
+    first_name: 'Alice',
+    last_name: 'Martin',
+    email: 'alice@example.com',
+    phone: '+33600000000',
+    linkedin_url: 'https://linkedin.com/in/a',
+    github_url: 'https://github.com/a',
+    city: 'Paris',
+    country: 'France',
+    school: 'S',
+    degree: 'D',
+    graduation_year: 2026,
+    work_authorization: 'EU',
+    requires_sponsorship: false,
+    availability_start: '2026-09-01',
+    cv_path: 'cv.pdf',
+    auto_apply_min_score: 8,
+    job_type: 'mid-level',
+  });
+  assert.equal(ok, true, `errors: ${JSON.stringify(errors)}`);
+});
+
+test('validateProfile tolerates internship_duration_months on a senior profile', () => {
+  const { ok, errors } = validateProfile({
+    first_name: 'Alice',
+    last_name: 'Martin',
+    email: 'alice@example.com',
+    phone: '+33600000000',
+    linkedin_url: 'https://linkedin.com/in/a',
+    github_url: 'https://github.com/a',
+    city: 'Paris',
+    country: 'France',
+    school: 'S',
+    degree: 'D',
+    graduation_year: 2026,
+    work_authorization: 'EU',
+    requires_sponsorship: false,
+    availability_start: '2026-09-01',
+    cv_path: 'cv.pdf',
+    auto_apply_min_score: 8,
+    job_type: 'senior',
+    internship_duration_months: 6,
+  });
+  assert.equal(ok, true, `errors: ${JSON.stringify(errors)}`);
+});
+
 test('validateProfile rejects profile without cv_path', () => {
   const { ok, errors } = validateProfile({
     first_name: 'Alice',

--- a/tests/lib/extension-permission-probe.test.mjs
+++ b/tests/lib/extension-permission-probe.test.mjs
@@ -1,0 +1,104 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  interpretProbeResult,
+  probeExtensionPermission,
+} from '../../src/lib/extension-permission-probe.mjs';
+
+test('interpretProbeResult returns ok when navigate and find succeed', () => {
+  const r = interpretProbeResult({
+    navigateResult: { url: 'https://jobs.lever.co/anthropic' },
+    findResult: { elements: 1 },
+    findError: null,
+  });
+  assert.deepEqual(r, { ok: true });
+});
+
+test('interpretProbeResult detects missing host permission', () => {
+  const r = interpretProbeResult({
+    navigateResult: { url: 'https://jobs.lever.co/anthropic' },
+    findResult: null,
+    findError: 'Extension manifest must request permission to access the respective host',
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, 'missing_permission');
+});
+
+test('interpretProbeResult detects extension not installed', () => {
+  const r = interpretProbeResult({
+    navigateResult: { url: 'https://jobs.lever.co/anthropic' },
+    findResult: null,
+    findError: 'No response from extension — is it installed?',
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, 'extension_not_installed');
+});
+
+test('interpretProbeResult detects navigation failure', () => {
+  const r = interpretProbeResult({
+    navigateResult: null,
+    findResult: null,
+    findError: null,
+    navigateError: 'net::ERR_ABORTED',
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, 'navigation_failed');
+});
+
+test('interpretProbeResult detects timeout', () => {
+  const r = interpretProbeResult({
+    navigateResult: { url: 'https://jobs.lever.co/anthropic' },
+    findResult: null,
+    findError: 'Operation timeout exceeded',
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, 'timeout');
+});
+
+test('probeExtensionPermission wires navigate+find through a mock client', async () => {
+  const calls = [];
+  const client = {
+    async navigate(url) {
+      calls.push({ tool: 'navigate', url });
+      return { url };
+    },
+    async find(selector) {
+      calls.push({ tool: 'find', selector });
+      return { elements: 1 };
+    },
+  };
+  const r = await probeExtensionPermission(client);
+  assert.deepEqual(r, { ok: true });
+  assert.equal(calls[0].tool, 'navigate');
+  assert.ok(calls[0].url.startsWith('https://jobs.lever.co/'));
+  assert.equal(calls[1].tool, 'find');
+  assert.equal(calls[1].selector, 'body');
+});
+
+test('probeExtensionPermission propagates find errors', async () => {
+  const client = {
+    async navigate(url) {
+      return { url };
+    },
+    async find() {
+      throw new Error('Extension manifest must request permission');
+    },
+  };
+  const r = await probeExtensionPermission(client);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, 'missing_permission');
+});
+
+test('probeExtensionPermission propagates navigate errors', async () => {
+  const client = {
+    async navigate() {
+      throw new Error('net::ERR_ABORTED');
+    },
+    async find() {
+      throw new Error('should not be called');
+    },
+  };
+  const r = await probeExtensionPermission(client);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, 'navigation_failed');
+});


### PR DESCRIPTION
## Summary

Resolves the ten UX / instruction inconsistencies in /apply-onboard listed in #87:

1. "One question block" rule replaced with "up to 3 blocks + conditional Block D".
2. `auto_apply_min_score` explicitly asked (options 6/7/8, default 7).
3. `internship_duration_months` conditional on `job_type` (only required for internship/apprenticeship).
4. `graduation_year` always asked when missing from CV (Block D).
5. `city` always asked when missing from CV (Block D).
6. Step 2.5 gains `edit missing only` third option.
7. Orchestrator prints `▶ Phase N/3` markers.
8. `--clone-chrome-profile` explained in profile.md Block C.
9. Extension permission probe after setup, non-blocking.
10. `auto_generate_cover_letter` persisted to both `candidate-profile.yml` and `.onboard-state.json`.

Spec: `docs/superpowers/specs/2026-04-21-issue-87-onboard-ux-batch-design.md`

## Test plan

- [x] `npm test` green (4 new candidate-profile tests + 8 new probe tests)
- [x] `npm run lint` green (only issue-89 in-progress file has warning)
- [x] `npm run check:pii` green
- [ ] Manual rerun on a fresh checkout: `rm -rf config data && /apply-onboard path/to/cv.pdf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)