### PR TITLE
feat(scan): add /add-company <name-or-url> command (#86)

### DIFF
--- a/.claude/commands/add-company.md
+++ b/.claude/commands/add-company.md
@@ -1,0 +1,57 @@
+---
+description: Discover and append a new company to config/portals.yml (no hand-editing YAML)
+argument-hint: "<name or URL>"
+---
+
+# /add-company $ARGUMENTS
+
+Add a company to `config/portals.yml` by name or by ATS careers URL, without editing YAML by hand.
+
+## First-run guard
+
+Before anything, check that `config/candidate-profile.yml` **and** `config/portals.yml` exist. If either is missing, stop and tell the user:
+
+> "No config found. Run `/apply-onboard` first — it will extract your CV, build the configs, and find ~30 target companies for you."
+
+## Step 1 — dry-run (discover & verify)
+
+Run:
+
+```bash
+node src/scan/add-company.mjs --input "$ARGUMENTS" --dry-run --json
+```
+
+Parse the JSON output and branch on `status`:
+
+| status                 | What to tell the user                                                                                   |
+| ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| `ok`                   | Show `platform / slug (careersUrl) — N offers`. If `warning: "empty board"`, ask explicitly: "Board is live but 0 offers — add anyway?" Otherwise: "Confirm name and add? [Yes / Edit name / Edit URL / No]" |
+| `duplicate`            | "Already in portals.yml: `<duplicateOf.name>` (enabled: true). Nothing to do."                          |
+| `disabled-duplicate`   | "Found existing entry `<duplicateOf.name>` with enabled: false. Enable it? [Yes / No]"                  |
+| `unknown-host`         | "Host not recognized. Supported: `<supportedHosts joined>`. Open an issue to add this ATS."             |
+| `unsupported-platform` | If `knownHost` is `workable`, say: "Workable is not yet supported — see issue #83." Otherwise generic.  |
+| `not-found`            | For URL form: "Slug 404 or empty. Double-check the URL." For name form: "No slug matched (tried N candidates). Try `/add-company <url>` with the full URL." |
+| `no-portals`           | "No portals config. Run `/apply-onboard` first."                                                        |
+
+## Step 2 — confirm & write
+
+Once the user confirms, run:
+
+```bash
+node src/scan/add-company.mjs --input "$ARGUMENTS" --name "<final-name>" --yes --json
+```
+
+- Use the name the user confirmed (which may differ from `suggestedName`).
+- If the user chose "Edit URL" in step 1, re-run step 1 with the new URL instead.
+- For the `disabled-duplicate` → "Yes" branch, run step 2 **without** `--name`; the script detects the toggle from the existing entry.
+
+Report back based on the returned `status`:
+
+- `written` → "Added `<entry.name>` — entry `<entryIndex+1>` of `<total>`."
+- `toggled` → "Enabled `<name>` in portals.yml."
+
+## Safety rules
+
+- **Never write without explicit user confirmation in the conversation.** Step 1 is always dry-run.
+- If the script returns a non-zero exit code, surface stderr and stop — do not retry blindly.
+- Never edit `config/portals.yml` yourself; the script is the only writer.

--- a/.claude/commands/add-company.md
+++ b/.claude/commands/add-company.md
@@ -1,6 +1,6 @@
 ---
 description: Discover and append a new company to config/portals.yml (no hand-editing YAML)
-argument-hint: "<name or URL>"
+argument-hint: '<name or URL>'
 ---
 
 # /add-company $ARGUMENTS
@@ -23,15 +23,15 @@ node src/scan/add-company.mjs --input "$ARGUMENTS" --dry-run --json
 
 Parse the JSON output and branch on `status`:
 
-| status                 | What to tell the user                                                                                   |
-| ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| status                 | What to tell the user                                                                                                                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `ok`                   | Show `platform / slug (careersUrl) — N offers`. If `warning: "empty board"`, ask explicitly: "Board is live but 0 offers — add anyway?" Otherwise: "Confirm name and add? [Yes / Edit name / Edit URL / No]" |
-| `duplicate`            | "Already in portals.yml: `<duplicateOf.name>` (enabled: true). Nothing to do."                          |
-| `disabled-duplicate`   | "Found existing entry `<duplicateOf.name>` with enabled: false. Enable it? [Yes / No]"                  |
-| `unknown-host`         | "Host not recognized. Supported: `<supportedHosts joined>`. Open an issue to add this ATS."             |
-| `unsupported-platform` | If `knownHost` is `workable`, say: "Workable is not yet supported — see issue #83." Otherwise generic.  |
-| `not-found`            | For URL form: "Slug 404 or empty. Double-check the URL." For name form: "No slug matched (tried N candidates). Try `/add-company <url>` with the full URL." |
-| `no-portals`           | "No portals config. Run `/apply-onboard` first."                                                        |
+| `duplicate`            | "Already in portals.yml: `<duplicateOf.name>` (enabled: true). Nothing to do."                                                                                                                               |
+| `disabled-duplicate`   | "Found existing entry `<duplicateOf.name>` with enabled: false. Enable it? [Yes / No]"                                                                                                                       |
+| `unknown-host`         | "Host not recognized. Supported: `<supportedHosts joined>`. Open an issue to add this ATS."                                                                                                                  |
+| `unsupported-platform` | If `knownHost` is `workable`, say: "Workable is not yet supported — see issue #83." Otherwise generic.                                                                                                       |
+| `not-found`            | For URL form: "Slug 404 or empty. Double-check the URL." For name form: "No slug matched (tried N candidates). Try `/add-company <url>` with the full URL."                                                  |
+| `no-portals`           | "No portals config. Run `/apply-onboard` first."                                                                                                                                                             |
 
 ## Step 2 — confirm & write
 

--- a/.claude/commands/add-company.md
+++ b/.claude/commands/add-company.md
@@ -29,7 +29,7 @@ Parse the JSON output and branch on `status`:
 | `duplicate`            | "Already in portals.yml: `<duplicateOf.name>` (enabled: true). Nothing to do."                                                                                                                               |
 | `disabled-duplicate`   | "Found existing entry `<duplicateOf.name>` with enabled: false. Enable it? [Yes / No]"                                                                                                                       |
 | `unknown-host`         | "Host not recognized. Supported: `<supportedHosts joined>`. Open an issue to add this ATS."                                                                                                                  |
-| `unsupported-platform` | If `knownHost` is `workable`, say: "Workable is not yet supported — see issue #83." Otherwise generic.                                                                                                       |
+| `unsupported-platform` | "Platform `<knownHost>` is recognized but not yet supported by `/add-company`. Open an issue to request support."                                                                                            |
 | `not-found`            | For URL form: "Slug 404 or empty. Double-check the URL." For name form: "No slug matched (tried N candidates). Try `/add-company <url>` with the full URL."                                                  |
 | `no-portals`           | "No portals config. Run `/apply-onboard` first."                                                                                                                                                             |
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+tests/fixtures/add-company/portals.broken.yml

--- a/docs/superpowers/plans/2026-04-21-issue-89-discoverability-plan.md
+++ b/docs/superpowers/plans/2026-04-21-issue-89-discoverability-plan.md
@@ -1,0 +1,1067 @@
+# Issue #89 — Slash-command discoverability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface the tools (`/explain`, `/dashboard`, `--dry-run`, flags) the user needs after `/scan` and during onboarding, and add `--help` to every slash command.
+
+**Architecture:** Four additive deliverables — (L1) enrich the `/scan` summary footer; (L2) intercept `--help` / `-h` at the top of each node CLI before any I/O, plus a documented `--help` convention in `.claude/commands/apply.md`; (L3) link `docs/scan-workflow.md#title-filter` from `/scan`; (L4) rewrite the onboarding summary (`apply-onboard/setup.md`) with a `title_filter` recap, a `--dry-run --json` calibration preview, and the full command list.
+
+**Tech Stack:** Node 20 ESM (`.mjs`), `node:test`, `node:child_process.spawnSync` for CLI integration tests. Zero new dependencies.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-21-issue-89-discoverability-design.md`.
+
+**Deviation from spec noted during planning:** the spec's `/score --help` template listed only `--re-score` as a flag. The real `parseScoreArgs()` accepts many more (`--json-input`, `--id`, `--company`/`--role`/`--location`, `--from-pipeline`, `--batch`, `--parallel`). A `--help` that hides real flags is actively misleading, so Task 2b lists all of them. No spec change requested; flag for reviewer attention.
+
+---
+
+## File map
+
+**Modify:**
+- `src/scan/index.mjs` — add `printScanHelp()`, intercept `--help`/`-h` at top of `main()`, append `Next steps` block to `formatSummary()` (suppressed under `--json`).
+- `src/score/index.mjs` — add `printScoreHelp()`, intercept at top of `main()`.
+- `src/scan/explain.mjs` — add `printExplainHelp()`, intercept at top of `main()`.
+- `src/dashboard/build.mjs` — add `printDashboardHelp()`, intercept inside the `import.meta.url === …` CLI guard.
+- `.claude/commands/scan.md` — remove the `## Next step` section; add the `docs/scan-workflow.md#title-filter` pointer line in `## Interpreting the output`.
+- `.claude/commands/apply.md` — add the `--help` preamble block (skill-level, not CLI).
+- `.claude/commands/apply-onboard/setup.md` — step 2 (print `setup.sh --help` once), insert step 5.5 (dry-run calibration), rewrite step 6 (summary).
+- `tests/scan/scan.test.mjs` — two new tests on `formatSummary` (with/without `--json`).
+- `docs/testing.md` — one line in the E2E checklist.
+
+**Create:**
+- `tests/scan/scan-help.test.mjs`
+- `tests/score/score-help.test.mjs`
+- `tests/scan/explain-help.test.mjs`
+- `tests/dashboard/dashboard-help.test.mjs`
+
+---
+
+## Task 1 — L1: `/scan` footer `Next steps` block
+
+**Files:**
+- Modify: `src/scan/index.mjs:311-360` (`formatSummary`)
+- Modify: `src/scan/index.mjs` (`main()` — pass a `format` flag through so `--json` suppresses the block)
+- Test: `tests/scan/scan.test.mjs` (append two new `test(...)` blocks at the end)
+
+- [ ] **Step 1.1 — Write failing tests in `tests/scan/scan.test.mjs`**
+
+Append these two tests at the very end of the file (after the last existing `test(...)` block):
+
+```js
+test('formatSummary — emits Next steps block in default path', () => {
+  const result = {
+    scanned: 2,
+    eligibleTotal: 2,
+    raw: 10,
+    perCompany: [
+      { company: 'mistral', platform: 'lever', rawCount: 5, afterFilterCount: 1, newCount: 1 },
+      { company: 'anthropic', platform: 'greenhouse', rawCount: 5, afterFilterCount: 0, newCount: 0 },
+    ],
+    filtered: {
+      skipped_dup: 0,
+      skipped_title: 4,
+      skipped_blacklist: 0,
+      skipped_location: 0,
+      skipped_date: 0,
+    },
+    added: [{ company: 'mistral', title: 'ML Engineer Intern' }],
+    historyWrites: 1,
+    filteredWrites: 4,
+    errors: [],
+  };
+  const out = formatSummary(result, false);
+  assert.match(out, /Next steps :/);
+  assert.match(out, /\/score <url>/);
+  assert.match(out, /\/explain/);
+  assert.match(out, /\/dashboard/);
+  assert.match(out, /\/scan --help/);
+});
+
+test('formatSummary — Next steps block is present even when nothing was added', () => {
+  const result = {
+    scanned: 1,
+    eligibleTotal: 1,
+    raw: 2359,
+    perCompany: [
+      { company: 'big-co', platform: 'greenhouse', rawCount: 2359, afterFilterCount: 0, newCount: 0 },
+    ],
+    filtered: {
+      skipped_dup: 0,
+      skipped_title: 2359,
+      skipped_blacklist: 0,
+      skipped_location: 0,
+      skipped_date: 0,
+    },
+    added: [],
+    historyWrites: 0,
+    filteredWrites: 2359,
+    errors: [],
+  };
+  const out = formatSummary(result, false);
+  assert.match(out, /Next steps :/);
+  assert.match(out, /\/explain/);
+});
+```
+
+- [ ] **Step 1.2 — Run the new tests; expect failure**
+
+```bash
+node --test --test-name-pattern="Next steps" tests/scan/scan.test.mjs
+```
+
+Expected: both tests FAIL — the assertions on `/Next steps :/`, `/explain`, `/dashboard`, `/scan --help` do not yet appear in `formatSummary` output.
+
+- [ ] **Step 1.3 — Implement the `Next steps` block in `formatSummary()`**
+
+Open `src/scan/index.mjs`. Locate the current `formatSummary` function ending at the `return lines.join('\n');` on line 359. Insert the new block **before** `return lines.join('\n');`:
+
+```js
+  lines.push('');
+  lines.push('Next steps :');
+  lines.push('  /score <url>        # évalue une offre via LLM (data/evaluations.jsonl)');
+  lines.push('  /explain "<title>"  # trace pourquoi une offre passe/échoue le filtre');
+  lines.push('  /dashboard          # régénère dashboard.html');
+  lines.push('');
+  lines.push('Plus de flags : /scan --help  (--dry-run, --only <slug>, --json)');
+```
+
+- [ ] **Step 1.4 — Run the two tests; expect pass**
+
+```bash
+node --test --test-name-pattern="Next steps" tests/scan/scan.test.mjs
+```
+
+Expected: both PASS.
+
+- [ ] **Step 1.5 — Run the two existing `formatSummary` tests to verify no regression**
+
+```bash
+node --test --test-name-pattern="formatSummary" tests/scan/scan.test.mjs
+```
+
+Expected: all `formatSummary` tests PASS (the two original + the two new).
+
+- [ ] **Step 1.6 — Add test that `--json` path does NOT include the block**
+
+Append at the end of `tests/scan/scan.test.mjs`:
+
+```js
+test('scan CLI --json — stdout is parseable JSON and contains no Next steps block', () => {
+  const cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-json-'));
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-json-data-'));
+  fs.writeFileSync(
+    path.join(cfgDir, 'portals.yml'),
+    'tracked_companies: []\ntitle_filter:\n  required_any: []\n  excluded_any: []\n',
+  );
+  fs.writeFileSync(
+    path.join(cfgDir, 'candidate-profile.yml'),
+    'target_locations: [Paris]\nblacklist: []\nmin_start_date: 2026-01-01\n',
+  );
+
+  try {
+    const res = spawnSync(
+      process.execPath,
+      [path.resolve('src/scan/index.mjs'), '--dry-run', '--json'],
+      {
+        env: {
+          ...process.env,
+          CLAUDE_APPLY_CONFIG_DIR: cfgDir,
+          CLAUDE_APPLY_DATA_DIR: dataDir,
+        },
+        encoding: 'utf8',
+      },
+    );
+    assert.equal(res.status, 0, `stderr=${res.stderr}`);
+    assert.doesNotMatch(res.stdout, /Next steps/);
+    const parsed = JSON.parse(res.stdout);
+    assert.ok(typeof parsed === 'object' && parsed !== null);
+  } finally {
+    fs.rmSync(cfgDir, { recursive: true, force: true });
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+```
+
+If `spawnSync`, `fs`, `os`, `path` are not yet imported at the top of `tests/scan/scan.test.mjs`, add the imports. Check the first ~10 lines of the file; copy the style used by the existing `scan CLI — missing candidate-profile.yml` test at line 578, which already imports these.
+
+- [ ] **Step 1.7 — Run the new test; expect pass**
+
+```bash
+node --test --test-name-pattern="Next steps block" tests/scan/scan.test.mjs
+```
+
+The current `formatSummary` call is unconditional in `main()`, but the `--json` branch emits JSON instead (see existing behavior around line 414 — search for `--json`). Verify: when the current behavior under `--json` is to bypass `formatSummary` and output only JSON, the test passes without any further change because `formatSummary` is never called. Otherwise, wire the suppression explicitly. To confirm, read `src/scan/index.mjs` around lines 400–420:
+
+```bash
+grep -n "asJson\|--json\|formatSummary" src/scan/index.mjs
+```
+
+If the `--json` path still calls `formatSummary`, wrap the Next-steps block with a guard: accept a third arg `{ includeNextSteps = true } = {}` in `formatSummary`, skip the block when false, and set the option to false in the `--json` branch in `main()`. Update the Step 1.3 code to honor the flag.
+
+Expected after all fixes: the new test PASSES.
+
+- [ ] **Step 1.8 — Remove the `## Next step` section in `.claude/commands/scan.md`**
+
+Open `.claude/commands/scan.md` and delete the last section (lines 55–57):
+
+```
+## Next step
+
+Once `data/pipeline.md` has new rows, run `/score <url>` on each to get an LLM evaluation.
+```
+
+No replacement — the CLI footer is now the single source of truth.
+
+- [ ] **Step 1.9 — Commit**
+
+```bash
+git add src/scan/index.mjs tests/scan/scan.test.mjs .claude/commands/scan.md
+git commit -m "feat(scan): surface /explain, /dashboard, and flag hints in summary footer"
+```
+
+---
+
+## Task 2a — L2: `--help` for `/scan`
+
+**Files:**
+- Modify: `src/scan/index.mjs` (`printScanHelp()` + early intercept in `main()`)
+- Create: `tests/scan/scan-help.test.mjs`
+
+- [ ] **Step 2a.1 — Write failing test in `tests/scan/scan-help.test.mjs`**
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, '..', '..', 'src', 'scan', 'index.mjs');
+
+for (const flag of ['--help', '-h']) {
+  test(`/scan ${flag} exits 0 and prints usage — works without config`, () => {
+    // Deliberately point at empty dirs so config guard would fail if reached.
+    const res = spawnSync(process.execPath, [SCRIPT, flag], {
+      env: {
+        ...process.env,
+        CLAUDE_APPLY_CONFIG_DIR: '/nonexistent/cfg',
+        CLAUDE_APPLY_DATA_DIR: '/nonexistent/data',
+      },
+      encoding: 'utf8',
+    });
+    assert.equal(res.status, 0, `stderr=${res.stderr} stdout=${res.stdout}`);
+    assert.match(res.stdout, /^Usage: \/scan/m);
+    assert.match(res.stdout, /--dry-run/);
+    assert.match(res.stdout, /--only <slug>/);
+    assert.match(res.stdout, /--json/);
+    assert.match(res.stdout, /docs\/scan-workflow\.md/);
+    assert.match(res.stdout, /See also:/);
+  });
+}
+```
+
+- [ ] **Step 2a.2 — Run the test; expect failure**
+
+```bash
+node --test tests/scan/scan-help.test.mjs
+```
+
+Expected: FAIL — `--help` is not intercepted; either the script attempts to `requireConfig` and exits with 2, or it proceeds to fail for another reason.
+
+- [ ] **Step 2a.3 — Add `printScanHelp()` and the early intercept**
+
+Open `src/scan/index.mjs`. Just above the `async function main() {` declaration (currently around line 362), add:
+
+```js
+function printScanHelp() {
+  console.log(`Usage: /scan [--dry-run] [--only <slug>] [--json]
+
+Scan enabled ATS portals and append new offers to data/pipeline.md.
+
+Flags:
+  --dry-run         Compute everything, write nothing.
+  --only <slug>     Scan a single company by ATS slug (e.g. mistral).
+  --json            Emit machine-readable output to stdout.
+  --help, -h        Show this help and exit.
+
+Files:
+  reads:  config/portals.yml, config/candidate-profile.yml
+  writes: data/pipeline.md, data/scan-history.tsv, data/filtered-out.tsv
+
+See also: /explain, /dashboard
+          docs/scan-workflow.md  (title_filter format, per-company overrides)`);
+}
+```
+
+Inside `async function main()` as the **first two lines** of the body (before `const args = process.argv.slice(2);`):
+
+```js
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    printScanHelp();
+    process.exit(0);
+  }
+```
+
+If `const args = …` already exists on the first line of `main()`, merge: keep one declaration, add only the `if (...) { … }` right after it.
+
+- [ ] **Step 2a.4 — Run the test; expect pass**
+
+```bash
+node --test tests/scan/scan-help.test.mjs
+```
+
+Expected: both `--help` and `-h` tests PASS.
+
+- [ ] **Step 2a.5 — Commit**
+
+```bash
+git add src/scan/index.mjs tests/scan/scan-help.test.mjs
+git commit -m "feat(scan): add --help / -h flag with Usage / Flags / Files / See also"
+```
+
+---
+
+## Task 2b — L2: `--help` for `/score`
+
+**Files:**
+- Modify: `src/score/index.mjs` (`printScoreHelp()` + early intercept in `main()` at line 386)
+- Create: `tests/score/score-help.test.mjs`
+
+- [ ] **Step 2b.1 — Write failing test in `tests/score/score-help.test.mjs`**
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, '..', '..', 'src', 'score', 'index.mjs');
+
+for (const flag of ['--help', '-h']) {
+  test(`/score ${flag} exits 0 and prints usage — works without config`, () => {
+    const res = spawnSync(process.execPath, [SCRIPT, flag], {
+      env: {
+        ...process.env,
+        CLAUDE_APPLY_CONFIG_DIR: '/nonexistent/cfg',
+        CLAUDE_APPLY_DATA_DIR: '/nonexistent/data',
+      },
+      encoding: 'utf8',
+    });
+    assert.equal(res.status, 0, `stderr=${res.stderr} stdout=${res.stdout}`);
+    assert.match(res.stdout, /^Usage: \/score/m);
+    assert.match(res.stdout, /--re-score/);
+    assert.match(res.stdout, /--batch/);
+    assert.match(res.stdout, /--from-pipeline/);
+    assert.match(res.stdout, /docs\/score-workflow\.md/);
+  });
+}
+```
+
+- [ ] **Step 2b.2 — Run the test; expect failure**
+
+```bash
+node --test tests/score/score-help.test.mjs
+```
+
+Expected: FAIL — exit 2 (usage error from `parseScoreArgs`) or 3.
+
+- [ ] **Step 2b.3 — Add `printScoreHelp()` and the early intercept**
+
+Open `src/score/index.mjs`. Above `async function main()` (line 386), add:
+
+```js
+function printScoreHelp() {
+  console.log(`Usage: /score <url> [options]
+       /score --from-pipeline [--batch] [--parallel <n>]
+       /score --json-input <path>
+
+LLM-evaluate one or more offers against config/cv.md.
+
+Flags:
+  --re-score             Re-evaluate a URL already in evaluations.jsonl
+                         (preserves the existing id).
+  --batch                Score multiple offers from data/pipeline.md.
+  --parallel <n>         With --batch, run <n> evaluations concurrently.
+                         Implies --batch. Default: 5.
+  --from-pipeline        Take the offer URL from data/pipeline.md.
+  --json-input <path>    Read a pre-built offer JSON instead of fetching.
+  --id <id>              Override the generated id for this entry.
+  --company <name>       With --role and --location, override offer metadata
+                         (all three required together).
+  --role <title>         (see --company)
+  --location <loc>       (see --company)
+  --help, -h             Show this help and exit.
+
+Files:
+  reads:  config/cv.md, config/candidate-profile.yml
+  writes: data/evaluations.jsonl  (one JSON line per invocation)
+
+See also: /explain, /dashboard
+          docs/score-workflow.md`);
+}
+```
+
+Inside `main()`, as the **first lines** of the body (before the `const CONFIG_DIR = …` lines):
+
+```js
+  if (process.argv.slice(2).some((a) => a === '--help' || a === '-h')) {
+    printScoreHelp();
+    process.exit(0);
+  }
+```
+
+- [ ] **Step 2b.4 — Run the test; expect pass**
+
+```bash
+node --test tests/score/score-help.test.mjs
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 2b.5 — Commit**
+
+```bash
+git add src/score/index.mjs tests/score/score-help.test.mjs
+git commit -m "feat(score): add --help / -h flag listing all supported options"
+```
+
+---
+
+## Task 2c — L2: `--help` for `/explain`
+
+**Files:**
+- Modify: `src/scan/explain.mjs` (`printExplainHelp()` + early intercept in `main()` at line 107)
+- Create: `tests/scan/explain-help.test.mjs`
+
+- [ ] **Step 2c.1 — Write failing test**
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, '..', '..', 'src', 'scan', 'explain.mjs');
+
+for (const flag of ['--help', '-h']) {
+  test(`/explain ${flag} exits 0 and prints usage — works without config`, () => {
+    const res = spawnSync(process.execPath, [SCRIPT, flag], {
+      env: {
+        ...process.env,
+        CLAUDE_APPLY_CONFIG_DIR: '/nonexistent/cfg',
+      },
+      encoding: 'utf8',
+    });
+    assert.equal(res.status, 0, `stderr=${res.stderr} stdout=${res.stdout}`);
+    assert.match(res.stdout, /^Usage: \/explain/m);
+    assert.match(res.stdout, /--company <name>/);
+    assert.match(res.stdout, /--location <loc>/);
+    assert.match(res.stdout, /Exit codes/);
+    assert.match(res.stdout, /title-filter/);
+  });
+}
+```
+
+- [ ] **Step 2c.2 — Run the test; expect failure**
+
+```bash
+node --test tests/scan/explain-help.test.mjs
+```
+
+Expected: FAIL — currently exit 2 because `parseArgs` treats `--help` as a missing-title usage error.
+
+- [ ] **Step 2c.3 — Add `printExplainHelp()` and the early intercept**
+
+Open `src/scan/explain.mjs`. Just above `function main()` (line 107), add:
+
+```js
+function printExplainHelp() {
+  console.log(`Usage: /explain "<title>" [--company <name>] [--location <loc>]
+
+Trace which prefilter rule accepts or rejects a given title.
+
+Flags:
+  --company <name>    Apply blacklist check against this company.
+  --location <loc>    Apply location check against this string.
+  --help, -h          Show this help and exit.
+
+Files:
+  reads:  config/portals.yml, config/candidate-profile.yml
+  writes: (nothing)
+
+Exit codes: 0 = ACCEPTED, 1 = REJECTED, 2 = usage error.
+
+See also: /scan
+          docs/scan-workflow.md#title-filter`);
+}
+```
+
+Inside `main()` (line 107), as the **first lines**:
+
+```js
+function main() {
+  if (process.argv.slice(2).some((a) => a === '--help' || a === '-h')) {
+    printExplainHelp();
+    process.exit(0);
+  }
+  const parsed = parseArgs(process.argv);
+  // ... existing body unchanged
+```
+
+- [ ] **Step 2c.4 — Run the test; expect pass**
+
+```bash
+node --test tests/scan/explain-help.test.mjs
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 2c.5 — Commit**
+
+```bash
+git add src/scan/explain.mjs tests/scan/explain-help.test.mjs
+git commit -m "feat(explain): add --help / -h flag"
+```
+
+---
+
+## Task 2d — L2: `--help` for `/dashboard`
+
+**Files:**
+- Modify: `src/dashboard/build.mjs` (`printDashboardHelp()` + early intercept inside the CLI guard at line 321)
+- Create: `tests/dashboard/dashboard-help.test.mjs`
+
+- [ ] **Step 2d.1 — Write failing test**
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, '..', '..', 'src', 'dashboard', 'build.mjs');
+
+for (const flag of ['--help', '-h']) {
+  test(`/dashboard ${flag} exits 0 and prints usage — works without data`, () => {
+    const res = spawnSync(process.execPath, [SCRIPT, flag], {
+      env: {
+        ...process.env,
+        CLAUDE_APPLY_DATA_DIR: '/nonexistent/data',
+        CLAUDE_APPLY_REPORTS_DIR: '/nonexistent/reports',
+      },
+      encoding: 'utf8',
+    });
+    assert.equal(res.status, 0, `stderr=${res.stderr} stdout=${res.stdout}`);
+    assert.match(res.stdout, /^Usage: \/dashboard/m);
+    assert.match(res.stdout, /dashboard\.html/);
+    assert.match(res.stdout, /See also:/);
+  });
+}
+```
+
+- [ ] **Step 2d.2 — Run the test; expect failure**
+
+```bash
+node --test tests/dashboard/dashboard-help.test.mjs
+```
+
+Expected: FAIL — the script tries to read `data/` and crashes.
+
+- [ ] **Step 2d.3 — Add `printDashboardHelp()` and the intercept inside the CLI guard**
+
+Open `src/dashboard/build.mjs`. Just above the `// CLI guard — run directly as a script` comment (line 320), add:
+
+```js
+function printDashboardHelp() {
+  console.log(`Usage: /dashboard
+
+Regenerate dashboard.html from data/ and reports/.
+
+Flags:
+  --help, -h    Show this help and exit.
+
+Files:
+  reads:  data/pipeline.md, data/evaluations.jsonl, data/applications.md,
+          data/apply-log.jsonl, reports/
+  writes: dashboard.html  (at repo root)
+
+See also: /scan, /score`);
+}
+```
+
+Replace the current `if (import.meta.url === ...) { ... }` guard body so the help intercept runs **before** any `buildDashboard` call. Modified guard:
+
+```js
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    printDashboardHelp();
+    process.exit(0);
+  }
+  const dataDir = process.env.CLAUDE_APPLY_DATA_DIR || './data';
+  const reportsDir = process.env.CLAUDE_APPLY_REPORTS_DIR || './reports';
+  await buildDashboard({
+    applicationsPath: `${dataDir}/applications.md`,
+    reportsDir,
+    evaluationsPath: `${dataDir}/evaluations.jsonl`,
+    filteredOutPath: `${dataDir}/filtered-out.tsv`,
+    outputPath: './dashboard.html',
+    // ... preserve any existing properties unchanged
+  });
+}
+```
+
+Preserve any other fields already passed to `buildDashboard` (re-read lines 321–340 before editing).
+
+- [ ] **Step 2d.4 — Run the test; expect pass**
+
+```bash
+node --test tests/dashboard/dashboard-help.test.mjs
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 2d.5 — Commit**
+
+```bash
+git add src/dashboard/build.mjs tests/dashboard/dashboard-help.test.mjs
+git commit -m "feat(dashboard): add --help / -h flag"
+```
+
+---
+
+## Task 2e — L2: `--help` preamble for `/apply` (skill, not CLI)
+
+**Files:**
+- Modify: `.claude/commands/apply.md`
+
+- [ ] **Step 2e.1 — Read the current `apply.md` to find the right insertion point**
+
+```bash
+head -20 .claude/commands/apply.md
+```
+
+Note the frontmatter block (`---` … `---`) and the first `#` heading. The preamble must be inserted **between** them.
+
+- [ ] **Step 2e.2 — Insert the `--help` preamble**
+
+Immediately after the closing `---` of the frontmatter and before the first heading, insert the following block (plain markdown, no extra frontmatter):
+
+```markdown
+## `--help` / `-h`
+
+**Si `$ARGUMENTS` commence par `--help` ou `-h`, imprime uniquement le bloc ci-dessous et arrête-toi. N'ouvre pas Chrome, ne lis aucun fichier de `config/` ou `data/`.**
+
+```
+Usage: /apply <url>
+
+Open the URL in Chrome (CDP on port 9222), classify the form,
+fill from config/candidate-profile.yml, upload the CV, submit,
+and update data/applications.md + data/apply-log.jsonl.
+
+Stops and asks the user on: captcha, login wall,
+unknown required field.
+
+Prerequisites:
+  - chrome-apply alias launched (CDP port 9222 up)
+  - claude-in-chrome extension installed with host permissions
+
+Files:
+  reads:  config/candidate-profile.yml, config/cv.<lang>.pdf
+  writes: data/applications.md, data/apply-log.jsonl
+
+See also: /scan, /score, /dashboard
+          docs/apply-workflow.md, docs/cdp-setup.md
+```
+```
+
+Note the double-backtick nesting: the outer code fence in the spec is just for presentation. In `apply.md`, use triple-backticks around the `Usage:` block, and prose above it.
+
+- [ ] **Step 2e.3 — Manual verification**
+
+Not unit-testable (skill, not CLI). In a fresh Claude Code session, type `/apply --help`. Confirm that the block is printed and no browser tool is invoked. Record the result in the commit body if anything is off.
+
+- [ ] **Step 2e.4 — Commit**
+
+```bash
+git add .claude/commands/apply.md
+git commit -m "docs(apply): document --help / -h skill preamble for /apply"
+```
+
+---
+
+## Task 3 — L3: link `title_filter` docs from `scan.md`
+
+**Files:**
+- Modify: `.claude/commands/scan.md` (append one line in `## Interpreting the output`)
+
+- [ ] **Step 3.1 — Add the pointer line**
+
+Open `.claude/commands/scan.md`. In the `## Interpreting the output` section, after the paragraph ending with `Group B (custom career pages) companies are skipped silently.` (currently line 53), append one blank line and one pointer line:
+
+```markdown
+
+Pour comprendre en détail comment `title_filter` rejette une offre, voir [`docs/scan-workflow.md#title-filter`](../../docs/scan-workflow.md#title-filter) ou lance `/explain "<titre>"`.
+```
+
+Verify the relative path `../../docs/scan-workflow.md` is correct from `.claude/commands/scan.md`:
+
+```bash
+ls -la .claude/commands/scan.md docs/scan-workflow.md
+```
+
+Both must exist at those paths.
+
+- [ ] **Step 3.2 — Commit**
+
+```bash
+git add .claude/commands/scan.md
+git commit -m "docs(scan): link title_filter reference from /scan command page"
+```
+
+---
+
+## Task 4a — L4: print `setup.sh --help` once in onboarding step 2
+
+**Files:**
+- Modify: `.claude/commands/apply-onboard/setup.md` (step 2)
+
+- [ ] **Step 4a.1 — Locate step 2**
+
+The current step 2 is around lines 23–34 of `.claude/commands/apply-onboard/setup.md`. It reads:
+
+```markdown
+## 2. Run `scripts/setup.sh`
+
+Run one of:
+
+    bash scripts/setup.sh --yes --clone-chrome-profile       # if user said yes
+    bash scripts/setup.sh --yes --no-clone-chrome-profile    # if user said no
+
+This will: install npm deps if missing (`npm ci` / `npm install`), create the CDP Chrome profile (empty or cloned), append the `chrome-apply` alias to the user's shell rc (with a timestamped backup), and copy any missing templates into `config/` (harmless — `cv.md`, `candidate-profile.yml`, and `portals.yml` already exist from the earlier phases and are skipped).
+
+If the user is in an unusual shell setup, add `--no-rc` and print the alias to them manually. Run `bash scripts/setup.sh --help` for all flags.
+```
+
+- [ ] **Step 4a.2 — Rewrite step 2 to instruct Claude to print `--help` first**
+
+Replace the whole step 2 block with:
+
+```markdown
+## 2. Run `scripts/setup.sh`
+
+**First, print the script's usage once** so the user discovers flags like `--no-clone-chrome-profile` and `--no-rc`:
+
+    bash scripts/setup.sh --help
+
+Print the captured output verbatim, prefaced by one short line:
+
+> "Voici les flags supportés par le script (affichés une fois pour que tu saches ce qui est disponible) — je vais maintenant lancer le setup avec les flags correspondant à ton choix clone-chrome-profile."
+
+Then run one of:
+
+    bash scripts/setup.sh --yes --clone-chrome-profile       # if user said yes
+    bash scripts/setup.sh --yes --no-clone-chrome-profile    # if user said no
+
+This will: install npm deps if missing (`npm ci` / `npm install`), create the CDP Chrome profile (empty or cloned), append the `chrome-apply` alias to the user's shell rc (with a timestamped backup), and copy any missing templates into `config/` (harmless — `cv.md`, `candidate-profile.yml`, and `portals.yml` already exist from the earlier phases and are skipped).
+
+If the user is in an unusual shell setup, add `--no-rc` and print the alias to them manually.
+```
+
+(Use four-space indentation for the fenced commands, as shown, to match the existing style.)
+
+- [ ] **Step 4a.3 — Commit**
+
+```bash
+git add .claude/commands/apply-onboard/setup.md
+git commit -m "docs(onboard): print setup.sh --help once in step 2 for flag discoverability"
+```
+
+---
+
+## Task 4b — L4: new step 5.5 (dry-run calibration)
+
+**Files:**
+- Modify: `.claude/commands/apply-onboard/setup.md` (insert new step between current steps 5 and 6)
+
+- [ ] **Step 4b.1 — Insert the new step**
+
+In `.claude/commands/apply-onboard/setup.md`, immediately after the current step 5 block (which ends at the line `**Wait for the user to confirm permissions are granted** before continuing.`) and before `## 6. Final summary`, insert:
+
+````markdown
+## 5.5. Calibration dry-run (best-effort)
+
+Before printing the final summary, run a `/scan --dry-run --json` to give the user a realistic preview of what their first real scan will yield. The extension is not required for this step.
+
+```bash
+node src/scan/index.mjs --dry-run --json
+```
+
+Parse the JSON to extract:
+
+- `result.raw` — total raw offers across all companies
+- `result.added.length` — number of offers that would survive all filters
+- `result.perCompany.filter(c => c.newCount > 0)` — companies with at least one hit, sorted descending by `newCount`, top 3
+
+Cache these three values (or a single "skipped" flag on failure) so step 6 can reference them.
+
+**Failure mode (network error, ATS outage, any non-zero exit):** do **not** block onboarding. Set an internal "dry-run skipped" flag and let step 6 fall back to the "skipped" message. The user will still have a working install.
+````
+
+- [ ] **Step 4b.2 — Commit**
+
+```bash
+git add .claude/commands/apply-onboard/setup.md
+git commit -m "docs(onboard): add step 5.5 dry-run calibration before final summary"
+```
+
+---
+
+## Task 4c — L4: rewrite step 6 final summary
+
+**Files:**
+- Modify: `.claude/commands/apply-onboard/setup.md` (replace step 6 block)
+
+- [ ] **Step 4c.1 — Replace step 6**
+
+Open `.claude/commands/apply-onboard/setup.md`. Locate the `## 6. Final summary` section (currently lines 109–135). Replace the entire section with:
+
+````markdown
+## 6. Final summary
+
+Read `config/portals.yml` once to extract `title_filter.required_any` and `title_filter.excluded_any`. Use the dry-run values cached in step 5.5 (or the "skipped" flag).
+
+Print the following summary, substituting values where marked:
+
+```
+✅ Onboarding complete.
+
+Files written:
+  • config/cv.md
+  • config/cv.<lang>.pdf
+  • config/candidate-profile.yml
+  • config/portals.yml  (<N> companies)
+
+Your title_filter:
+  required_any  : <comma-separated list from portals.yml, or "(none)">
+  excluded_any  : <comma-separated list from portals.yml, or "(none)">
+  (source: config/portals.yml — edit there to re-tune,
+   or run /explain "<title>" to debug one title)
+
+First scan preview (dry-run):
+  <A> new offers after filter (from <R> raw).
+  Top hits: <company1> (<n1>), <company2> (<n2>), <company3> (<n3>).
+  → If 0 hits: your required_any is probably too strict.
+    Run /explain "<one of your target titles>" to trace it,
+    then edit config/portals.yml and re-run /scan.
+
+Chrome launched in CDP mode (port 9222) with the
+claude-in-chrome extension page open.
+
+One last manual step:
+  → Click "Add to Chrome" on the page that just opened,
+    then confirm the install dialog.
+
+Then you can run:
+  /scan                # fetch new offers into data/pipeline.md
+  /score <url>         # LLM-evaluate an offer
+  /apply <url>         # automated form fill + submit
+  /explain "<title>"   # debug why a title passes/fails the filter
+  /dashboard           # regenerate dashboard.html
+
+Tip: append --help to any command (e.g. /scan --help) to see its flags.
+```
+
+**Fallback when step 5.5 was skipped:** replace the "First scan preview" block with exactly:
+
+```
+First scan preview (dry-run):
+  (skipped — network issue during dry-run; run /scan --dry-run when ready.)
+```
+
+**Fallback when `raw === 0` across all companies** (likely ATS outage or empty `portals.yml`): replace the block with:
+
+```
+First scan preview (dry-run):
+  0 raw offers — likely an ATS outage or an empty portals.yml.
+  Run /scan after the extension install to retry.
+```
+
+**Fallback when `title_filter` is absent from `portals.yml`:** print `(none — every title accepted)` for both `required_any` and `excluded_any`.
+
+**Do not run `/scan` or `/apply` yourself** — the user still needs to install the extension manually. Your onboarding stops here.
+````
+
+- [ ] **Step 4c.2 — Commit**
+
+```bash
+git add .claude/commands/apply-onboard/setup.md
+git commit -m "docs(onboard): rewrite step 6 summary with title_filter recap and dry-run preview"
+```
+
+---
+
+## Task 5 — E2E checklist entry
+
+**Files:**
+- Modify: `docs/testing.md`
+
+- [ ] **Step 5.1 — Add the checklist line**
+
+Open `docs/testing.md`. Find the E2E section (likely headed `## E2E` or `## Manual testing`). Append one line:
+
+```markdown
+- `/apply-onboard` final summary shows the `Your title_filter` block and either a `First scan preview` (with raw + added counts) or the graceful "skipped" fallback when the dry-run fails.
+```
+
+If there is no E2E section, add the line at the end of the file under a new `## E2E onboarding` heading.
+
+- [ ] **Step 5.2 — Commit**
+
+```bash
+git add docs/testing.md
+git commit -m "docs(testing): add onboarding summary to E2E checklist"
+```
+
+---
+
+## Task 6 — Full test suite + lint
+
+- [ ] **Step 6.1 — Run the full suite**
+
+```bash
+npm test
+```
+
+Expected: all tests PASS. The five new test files (`scan-help`, `score-help`, `explain-help`, `dashboard-help`, plus the two appended `Next steps` tests in `scan.test.mjs`) contribute ~8 new passing tests. No existing test should regress.
+
+- [ ] **Step 6.2 — Run lint and format**
+
+```bash
+npm run lint
+npm run format
+```
+
+Expected: lint PASS, format no-op (or commit any whitespace corrections separately).
+
+- [ ] **Step 6.3 — Run the PII gate locally**
+
+```bash
+npm run check:pii
+```
+
+Expected: PASS — none of the new content contains PII (all examples use placeholder titles like `"<title>"` and generic company names).
+
+- [ ] **Step 6.4 — Commit formatting fixes if any**
+
+```bash
+git status
+# If prettier reformatted anything:
+git add -A
+git commit -m "style: prettier"
+```
+
+---
+
+## Task 7 — Manual smoke test
+
+- [ ] **Step 7.1 — Smoke-test each `--help`**
+
+```bash
+node src/scan/index.mjs --help
+node src/score/index.mjs --help
+node src/scan/explain.mjs --help
+node src/dashboard/build.mjs --help
+```
+
+For each: verify exit code 0 (`echo $?`) and that the `Usage:` / `Flags:` / `Files:` / `See also:` blocks appear.
+
+- [ ] **Step 7.2 — Smoke-test the `/scan` footer**
+
+```bash
+node src/scan/index.mjs --dry-run
+```
+
+Verify the tail of the output contains the `Next steps :` block with `/score`, `/explain`, `/dashboard`, and the `Plus de flags : /scan --help` line.
+
+- [ ] **Step 7.3 — Smoke-test `/scan --json`**
+
+```bash
+node src/scan/index.mjs --dry-run --json | tail -5
+```
+
+Verify the output ends with a JSON closing `}` and contains **no** `Next steps` text.
+
+```bash
+node src/scan/index.mjs --dry-run --json | python3 -m json.tool > /dev/null
+```
+
+Expected: exit 0 (parseable JSON).
+
+- [ ] **Step 7.4 — Open a PR**
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "feat(discoverability): surface /explain, /dashboard, flags, and --help (issue #89)" --body "$(cat <<'EOF'
+## Summary
+
+Addresses all seven discoverability gaps from issue #89 in one bundled PR:
+
+- **L1** `/scan` summary footer now lists `/score`, `/explain`, `/dashboard` and the flag hint (items 1, 5). Removed the obsolete `## Next step` section in `scan.md`.
+- **L2** `--help` / `-h` on every CLI entry point (`/scan`, `/score`, `/explain`, `/dashboard`) + documented preamble in `apply.md` (item 7). Works without config.
+- **L3** Linked `docs/scan-workflow.md#title-filter` from `.claude/commands/scan.md` and from `/scan --help` See-also (item 3).
+- **L4** Onboarding: step 2 prints `setup.sh --help` once (item 2); new step 5.5 runs `/scan --dry-run --json` for a calibration preview; step 6 summary now shows `Your title_filter`, a `First scan preview`, and the full command list including `/explain` and `/dashboard` (items 4, 6).
+
+Spec: `docs/superpowers/specs/2026-04-21-issue-89-discoverability-design.md`.
+
+## Test plan
+
+- [x] Unit: `formatSummary` emits/skips the `Next steps` block as expected.
+- [x] Unit: each of the 4 CLIs exits 0 on `--help` and `-h` with no config present.
+- [x] Unit: `/scan --dry-run --json` stdout is parseable JSON without the `Next steps` text.
+- [ ] Manual: `/apply --help` prints the skill preamble without opening Chrome.
+- [ ] Manual: fresh `/apply-onboard` run shows the new summary with the dry-run preview.
+
+Closes #89.
+EOF
+)"
+```
+
+Expected: PR URL returned. Print it to the user.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+
+| Spec requirement | Task |
+|---|---|
+| L1 `formatSummary` Next steps block | Task 1 steps 1.1–1.9 |
+| L1 suppression under `--json` | Task 1 steps 1.6–1.7 |
+| L1 remove `## Next step` in `scan.md` | Task 1 step 1.8 |
+| L2 `/scan --help` | Task 2a |
+| L2 `/score --help` | Task 2b |
+| L2 `/explain --help` | Task 2c |
+| L2 `/dashboard --help` | Task 2d |
+| L2 `/apply --help` preamble | Task 2e |
+| L3 `scan.md` pointer line | Task 3 |
+| L4 print `setup.sh --help` | Task 4a |
+| L4 dry-run calibration step | Task 4b |
+| L4 rewritten summary with fallbacks | Task 4c |
+| E2E checklist addition | Task 5 |
+
+All thirteen items mapped.
+
+**Placeholder scan:** none. Every code/text block is complete. Fallback text is explicit. Commands are copy-pasteable.
+
+**Type consistency:** `formatSummary(result, dryRun)` keeps its existing signature; the `--json` suppression is implemented via a conditional call site in `main()`, not a third argument, matching the current `export function formatSummary(result, dryRun)` line. If the implementation in step 1.7 discovers that `formatSummary` IS called under `--json`, the plan explicitly instructs adding an options argument — that is the one branch in the plan, and both variants are spelled out.
+
+**One known deviation from the spec (flagged in the plan header):** `/score --help` lists all real flags (`--batch`, `--parallel`, `--from-pipeline`, `--json-input`, `--id`, `--company`/`--role`/`--location`) in addition to the `--re-score` called out by the spec. Rationale: a `--help` that hides existing flags is worse than no `--help`. No spec change needed; reviewer can challenge during PR review.

--- a/docs/superpowers/specs/2026-04-21-issue-89-discoverability-design.md
+++ b/docs/superpowers/specs/2026-04-21-issue-89-discoverability-design.md
@@ -1,0 +1,307 @@
+# Issue #89 — Slash-command discoverability and post-action guidance
+
+**Date:** 2026-04-21
+**Issue:** [#89 — docs: improve slash-command discoverability and post-action guidance](https://github.com/LeoLaborie/claude-apply/issues/89)
+**Status:** Design approved, ready for implementation plan.
+
+## Context
+
+During an onboarding session (2026-04-19), `/scan` returned `1 hit out of 2 359 raw offers`. The user had no path from that result to the tools that would actually help diagnose it (`/explain`, `/dashboard`, `--dry-run`), and no concept of what to expect from the system over time. Issue #89 bundles the seven discoverability gaps surfaced during that single session.
+
+This spec addresses all seven items through four additive, locally-scoped deliverables. No architectural change, no data-format change, no new runtime dependencies.
+
+## Goals
+
+- Every slash command that wraps a node CLI (`/scan`, `/score`, `/explain`, `/dashboard`) accepts `--help` / `-h` and prints a deterministic usage block.
+- `/apply` (a skill, not a CLI) documents its usage in `.claude/commands/apply.md` with an explicit instruction to honor `--help` in `$ARGUMENTS`.
+- The `/scan` summary footer points the user to the next useful commands (`/score`, `/explain`, `/dashboard`) and surfaces the flags (`--dry-run`, `--only`, `--json`).
+- The onboarding summary shows the user's current `title_filter`, a dry-run calibration preview of their first scan, and the full command list (`/scan`, `/score`, `/apply`, `/explain`, `/dashboard`).
+- The `title_filter` format is documented in `docs/scan-workflow.md` (already true) and reachable from `/scan --help` and `/scan` (new).
+
+## Non-goals
+
+- No adoption of an argparse library. Manual inspection of `process.argv.slice(2)` stays the convention.
+- No mention of `/tune-filter` (issue #85) — not yet merged. The PR that merges it will add the pointer.
+- No internationalization of `--help` output (stays in English, matching the rest of the CLI).
+- No new `Next steps` footer on `/score`, `/explain`, or `/dashboard` output — their existing outputs are already fit-for-purpose; only `/scan` has the ambiguous `1/N` moment that needs a nudge.
+
+## Deliverables
+
+### L1 — `/scan` summary footer
+
+**File:** `src/scan/index.mjs` (`formatSummary()`)
+
+Append a `Next steps` block after the `Erreurs` section (if any). Always emit it, including when `result.added.length === 0` — that is precisely when `/explain` matters most. Do **not** emit the block when `--json` is active, to keep stdout strictly JSON-parseable.
+
+Exact text:
+
+```
+Next steps :
+  /score <url>        # évalue une offre via LLM (data/evaluations.jsonl)
+  /explain "<title>"  # trace pourquoi une offre passe/échoue le filtre
+  /dashboard          # régénère dashboard.html
+
+Plus de flags : /scan --help  (--dry-run, --only <slug>, --json)
+```
+
+**File:** `.claude/commands/scan.md`
+
+Remove the `## Next step` section (currently says only "run `/score <url>` on each"). The CLI footer becomes the single source of truth.
+
+**Covers issue items:** 1, 5.
+
+### L2 — `--help` on CLI entry points
+
+**Files:** `src/scan/index.mjs`, `src/score/index.mjs`, `src/scan/explain.mjs`, `src/dashboard/build.mjs`
+
+Add a local `printHelp()` function to each module. At the very top of `main()`, before `requireConfig()` or any I/O, intercept the flag:
+
+```js
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    printHelp();
+    process.exit(0);
+  }
+  // ... existing body unchanged
+}
+```
+
+This guarantees `/<cmd> --help` works without any config present — critical for first-time users who haven't run `/apply-onboard` yet.
+
+If both `--help` and another flag are passed, `--help` wins (Unix convention).
+
+**Template for each help block** — four fixed sections: Usage / Flags / Files / See also. Each block is emitted verbatim via `console.log(` a template string `)`.
+
+**`/scan --help`:**
+
+```
+Usage: /scan [--dry-run] [--only <slug>] [--json]
+
+Scan enabled ATS portals and append new offers to data/pipeline.md.
+
+Flags:
+  --dry-run         Compute everything, write nothing.
+  --only <slug>     Scan a single company by ATS slug (e.g. mistral).
+  --json            Emit machine-readable output to stdout.
+  --help, -h        Show this help and exit.
+
+Files:
+  reads:  config/portals.yml, config/candidate-profile.yml
+  writes: data/pipeline.md, data/scan-history.tsv, data/filtered-out.tsv
+
+See also: /explain, /dashboard
+          docs/scan-workflow.md  (title_filter format, per-company overrides)
+```
+
+**`/score --help`:**
+
+```
+Usage: /score <url> [--re-score]
+
+LLM-evaluate a single offer URL against config/cv.md.
+
+Flags:
+  --re-score    Re-evaluate an offer already present in evaluations.jsonl.
+  --help, -h    Show this help and exit.
+
+Files:
+  reads:  config/cv.md, config/candidate-profile.yml
+  writes: data/evaluations.jsonl  (one JSON line per invocation)
+
+See also: /explain, /dashboard
+          docs/score-workflow.md
+```
+
+**`/explain --help`:**
+
+```
+Usage: /explain "<title>" [--company <name>] [--location <loc>]
+
+Trace which prefilter rule accepts or rejects a given title.
+
+Flags:
+  --company <name>    Apply blacklist check against this company.
+  --location <loc>    Apply location check against this string.
+  --help, -h          Show this help and exit.
+
+Files:
+  reads:  config/portals.yml, config/candidate-profile.yml
+  writes: (nothing)
+
+Exit codes: 0 = ACCEPTED, 1 = REJECTED, 2 = usage error.
+
+See also: /scan
+          docs/scan-workflow.md#title-filter
+```
+
+**`/dashboard --help`:**
+
+```
+Usage: /dashboard
+
+Regenerate dashboard.html from data/ and reports/.
+
+Flags:
+  --help, -h    Show this help and exit.
+
+Files:
+  reads:  data/pipeline.md, data/evaluations.jsonl, data/applications.md,
+          data/apply-log.jsonl, reports/
+  writes: dashboard.html  (at repo root)
+
+See also: /scan, /score
+```
+
+**`/apply` — skill, not CLI.** Add to `.claude/commands/apply.md`, immediately after the frontmatter and before the first heading:
+
+> **Si `$ARGUMENTS` commence par `--help` ou `-h`, imprime uniquement le bloc Usage ci-dessous et arrête-toi — n'ouvre pas Chrome, ne lis aucun autre fichier.**
+>
+> ```
+> Usage: /apply <url>
+>
+> Open the URL in Chrome (CDP on port 9222), classify the form,
+> fill from config/candidate-profile.yml, upload the CV, submit,
+> and update data/applications.md + data/apply-log.jsonl.
+>
+> Stops and asks the user on: captcha, login wall, unknown required field.
+>
+> Prerequisites:
+>   - chrome-apply alias launched (CDP port 9222 up)
+>   - claude-in-chrome extension installed with host permissions
+>
+> Files:
+>   reads:  config/candidate-profile.yml, config/cv.<lang>.pdf
+>   writes: data/applications.md, data/apply-log.jsonl
+>
+> See also: /scan, /score, /dashboard
+>           docs/apply-workflow.md, docs/cdp-setup.md
+> ```
+
+**Covers issue item:** 7.
+
+### L3 — `title_filter` format documentation
+
+**Status:** Already documented in `docs/scan-workflow.md` under `## Title filter`, including the per-company overrides `skip_required_any` and `target_locations`. No rewrite needed.
+
+**Two additions only, to make it reachable:**
+
+1. **`/scan --help` See also** — explicit pointer: `docs/scan-workflow.md (title_filter format, per-company overrides)`. (Already in L2.)
+2. **`.claude/commands/scan.md`** — append one line to the `## Interpreting the output` section:
+
+   > Pour comprendre en détail comment `title_filter` rejette une offre, voir [`docs/scan-workflow.md#title-filter`](../../docs/scan-workflow.md#title-filter) ou lance `/explain "<titre>"`.
+
+**Covers issue item:** 3.
+
+### L4 — Onboarding summary
+
+**File:** `.claude/commands/apply-onboard/setup.md`
+
+Three changes, preserving the existing six-step flow.
+
+**Step 2 — print `setup.sh --help` once.** Before invoking `bash scripts/setup.sh --yes …`, run `bash scripts/setup.sh --help` and print its output, prefaced by one sentence:
+
+> *"Voici les flags supportés par le script (affichés une fois pour que tu saches ce qui est disponible) — je vais maintenant lancer le setup avec les flags correspondant à ton choix clone-chrome-profile."*
+
+Zero additional execution cost (help exits immediately).
+
+**New step 5.5 — dry-run calibration.** Inserted after the user confirms extension permissions (end of step 5) and before the final summary (step 6). The dry-run does not require the extension — only the configs, which exist by this point.
+
+```
+Before printing the summary, run:
+
+  node src/scan/index.mjs --dry-run --json
+
+Parse the JSON to extract:
+  - result.raw                              (total raw offers)
+  - result.added.length                     (new hits after all filters)
+  - result.perCompany.filter(c => c.newCount > 0)
+      sorted desc by newCount, top 3        (top companies)
+```
+
+**Failure mode:** if the dry-run fails (network issue, ATS down, any non-zero exit), do **not** block onboarding. Skip the preview block in the summary and substitute:
+
+> `(First scan preview skipped — network issue during dry-run; run /scan --dry-run when ready.)`
+
+**Step 6 — rewritten summary:**
+
+```
+✅ Onboarding complete.
+
+Files written:
+  • config/cv.md
+  • config/cv.<lang>.pdf
+  • config/candidate-profile.yml
+  • config/portals.yml  (N companies)
+
+Your title_filter:
+  required_any  : Intern, Internship, Stage, Stagiaire
+  excluded_any  : Senior, Manager
+  (source: config/portals.yml — edit there to re-tune,
+   or run /explain "<title>" to debug one title)
+
+First scan preview (dry-run):
+  3 new offers after filter (from 2 359 raw).
+  Top hits: mistral (1), anthropic (1), photoroom (1).
+  → If 0 hits: your required_any is probably too strict.
+    Run /explain "<one of your target titles>" to trace it,
+    then edit config/portals.yml and re-run /scan.
+
+Chrome launched in CDP mode (port 9222) with the
+claude-in-chrome extension page open.
+
+One last manual step:
+  → Click "Add to Chrome" on the page that just opened,
+    then confirm the install dialog.
+
+Then you can run:
+  /scan                # fetch new offers into data/pipeline.md
+  /score <url>         # LLM-evaluate an offer
+  /apply <url>         # automated form fill + submit
+  /explain "<title>"   # debug why a title passes/fails the filter
+  /dashboard           # regenerate dashboard.html
+
+Tip: append --help to any command (e.g. /scan --help) to see its flags.
+```
+
+**Edge cases:**
+
+- `portals.yml` without any `title_filter` → print `Your title_filter: (none — every title accepted)`. Unlikely in practice because `apply-onboard:companies` always writes a filter, but the fallback stays robust.
+- Dry-run succeeds with `raw === 0` for every company → print `First scan preview (dry-run): 0 raw offers — likely an ATS outage or empty portals.yml. Run /scan after the extension install to retry.`
+
+**Covers issue items:** 2, 4, 6.
+
+## Testing
+
+| Layer | Test |
+|---|---|
+| L1 `formatSummary` | Extend `tests/scan-format-summary.test.mjs`: assert `Next steps` block is present in the default path; assert absence in `--json` output. |
+| L2 `--help` | One new test file per CLI: `tests/scan-help.test.mjs`, `tests/score-help.test.mjs`, `tests/explain-help.test.mjs`, `tests/dashboard-help.test.mjs`. Each spawns the node script with `--help` (e.g. via `node:child_process.spawnSync`), asserts `exitCode === 0` and that stdout contains `Usage:` and the command name. |
+| L2 `/apply --help` | Not unit-testable (skill). Verified manually via `/apply --help` in a real session. |
+| L3 | No test — pure Markdown. |
+| L4 onboarding | No automated test (skill). Add one entry to `docs/testing.md` E2E checklist: "`/apply-onboard` final summary shows `Your title_filter` block and dry-run preview (or graceful fallback when network fails)." |
+
+Every new test must run without any config present — that is the scenario where `--help` matters most.
+
+## Migration
+
+None. Every change is additive:
+
+- `formatSummary` gains a trailing block; existing callers keep working.
+- CLIs gain a `--help` branch; any invocation without `--help` is unchanged.
+- `apply.md` gains a preamble block that is a no-op when `$ARGUMENTS` does not contain `--help`.
+- `setup.md` gains one new step and rewrites the final summary block; the external contract of the skill (files written, Chrome launched, permissions granted) is unchanged.
+
+No data-file migration, no config-file migration, no version bump.
+
+## Coverage matrix
+
+| Issue item | Deliverable |
+|---|---|
+| 1. End of `/scan` doesn't surface `/explain`/`/dashboard` | L1 |
+| 2. `bash scripts/setup.sh --help` is never shown | L4 (step 2) |
+| 3. `title_filter` format undocumented at slash-command level | L3 |
+| 4. No post-onboarding recap | L4 (step 6 + step 5.5 dry-run) |
+| 5. `--dry-run` and `--only` never surfaced | L1 |
+| 6. `/explain` and `/dashboard` silent during onboarding | L4 (step 6) |
+| 7. No `/scan --help` (or any `--help`) | L2 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "js-yaml": "^4.1.0"
+        "js-yaml": "^4.1.0",
+        "yaml": "^2.8.3"
       },
       "devDependencies": {
         "jsdom": "^29.0.2",
@@ -630,6 +631,21 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "prettier": "^3.8.3"
   },
   "dependencies": {
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "yaml": "^2.8.3"
   }
 }

--- a/src/lib/candidate-profile.schema.mjs
+++ b/src/lib/candidate-profile.schema.mjs
@@ -37,6 +37,7 @@ const OPTIONAL_FIELDS = [
   'other_document_path',
   'internship_duration_months',
   'job_type',
+  'auto_generate_cover_letter',
 ];
 
 function validateEducationEntry(e, i) {

--- a/src/lib/candidate-profile.schema.mjs
+++ b/src/lib/candidate-profile.schema.mjs
@@ -13,7 +13,6 @@ export const REQUIRED_FIELDS = [
   'work_authorization',
   'requires_sponsorship',
   'availability_start',
-  'internship_duration_months',
   'cv_path',
   'auto_apply_min_score',
 ];
@@ -36,6 +35,8 @@ const OPTIONAL_FIELDS = [
   'transcript_path',
   'portfolio_path',
   'other_document_path',
+  'internship_duration_months',
+  'job_type',
 ];
 
 function validateEducationEntry(e, i) {
@@ -64,6 +65,24 @@ export function validateProfile(profile) {
   for (const f of REQUIRED_FIELDS) {
     if (profile[f] === undefined || profile[f] === null || profile[f] === '') {
       errors.push(`missing required field: ${f}`);
+    }
+  }
+  if (profile.job_type === 'internship' || profile.job_type === 'apprenticeship') {
+    if (!profile.internship_duration_months) {
+      errors.push(
+        'missing required field: internship_duration_months (required for internship/apprenticeship)'
+      );
+    }
+  }
+  if (
+    profile.internship_duration_months !== undefined &&
+    profile.internship_duration_months !== null
+  ) {
+    if (
+      typeof profile.internship_duration_months !== 'number' ||
+      profile.internship_duration_months < 1
+    ) {
+      errors.push('internship_duration_months must be a positive number');
     }
   }
   if (profile.email && !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(profile.email)) {

--- a/src/scan/add-company.mjs
+++ b/src/scan/add-company.mjs
@@ -48,3 +48,21 @@ export function appendCompany(portalsPath, entry) {
     },
   };
 }
+
+export function findByCareersUrl(doc, careersUrl) {
+  const list = doc.get('tracked_companies', true);
+  if (!isSeq(list)) return null;
+  const idx = list.items.findIndex((item) => item.get?.('careers_url') === careersUrl);
+  return idx >= 0 ? { index: idx, node: list.items[idx] } : null;
+}
+
+export function toggleEnabled(doc, careersUrl) {
+  const match = findByCareersUrl(doc, careersUrl);
+  if (!match) return null;
+  const current = match.node.get('enabled');
+  if (current === true) {
+    return { status: 'already-enabled', name: match.node.get('name') };
+  }
+  match.node.set('enabled', true);
+  return { status: 'toggled', name: match.node.get('name') };
+}

--- a/src/scan/add-company.mjs
+++ b/src/scan/add-company.mjs
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import { parseDocument, isSeq } from 'yaml';
+
 export class AddCompanyError extends Error {
   constructor(code, message, details = null) {
     super(message);
@@ -5,4 +8,43 @@ export class AddCompanyError extends Error {
     this.code = code;
     this.details = details;
   }
+}
+
+export function appendCompany(portalsPath, entry) {
+  const raw = fs.readFileSync(portalsPath, 'utf8');
+  const doc = parseDocument(raw);
+  if (doc.errors.length > 0) {
+    throw new AddCompanyError('SHAPE_INVALID', 'portals.yml parse failed', { errors: doc.errors });
+  }
+
+  const list = doc.get('tracked_companies', true);
+  if (!isSeq(list)) {
+    throw new AddCompanyError('SHAPE_INVALID', 'tracked_companies is not a sequence');
+  }
+
+  const node = doc.createNode({
+    name: entry.name,
+    careers_url: entry.careersUrl,
+    enabled: true,
+  });
+  list.add(node);
+
+  const out = String(doc);
+  const reparsed = parseDocument(out);
+  if (reparsed.errors.length > 0) {
+    throw new AddCompanyError('POST_PARSE_FAILED', 'post-mutation reparse failed', {
+      errors: reparsed.errors,
+    });
+  }
+
+  fs.writeFileSync(portalsPath, out);
+  return {
+    entryIndex: list.items.length - 1,
+    total: list.items.length,
+    entry: {
+      name: entry.name,
+      careers_url: entry.careersUrl,
+      enabled: true,
+    },
+  };
 }

--- a/src/scan/add-company.mjs
+++ b/src/scan/add-company.mjs
@@ -1,6 +1,10 @@
 import fs from 'node:fs';
 import { parseDocument, isSeq } from 'yaml';
-import { detectPlatform, getSupportedHosts, verifyCompany as defaultVerify } from './ats-detect.mjs';
+import {
+  detectPlatform,
+  getSupportedHosts,
+  verifyCompany as defaultVerify,
+} from './ats-detect.mjs';
 import { discoverCompany as defaultDiscover } from './discover-company.mjs';
 
 export class AddCompanyError extends Error {
@@ -107,7 +111,14 @@ async function resolveByUrl(url, doc, deps) {
 
   const { platform, slug } = detected;
   if (!VERIFIABLE_PLATFORMS.has(platform)) {
-    return { status: 'unsupported-platform', form: 'url', input: url, platform, slug, knownHost: platform };
+    return {
+      status: 'unsupported-platform',
+      form: 'url',
+      input: url,
+      platform,
+      slug,
+      knownHost: platform,
+    };
   }
 
   const dup = duplicateStatus(doc, url);
@@ -117,7 +128,14 @@ async function resolveByUrl(url, doc, deps) {
 
   const verify = await deps.verifyCompany(url);
   if (!verify.ok) {
-    return { status: 'not-found', form: 'url', input: url, platform, slug, reason: verify.reason ?? 'verify failed' };
+    return {
+      status: 'not-found',
+      form: 'url',
+      input: url,
+      platform,
+      slug,
+      reason: verify.reason ?? 'verify failed',
+    };
   }
 
   const out = {
@@ -152,7 +170,14 @@ async function resolveByName(name, doc, deps) {
 
   const dup = duplicateStatus(doc, result.careersUrl);
   if (dup) {
-    return { ...dup, form: 'name', input: name, platform: result.platform, slug: result.slug, careersUrl: result.careersUrl };
+    return {
+      ...dup,
+      form: 'name',
+      input: name,
+      platform: result.platform,
+      slug: result.slug,
+      careersUrl: result.careersUrl,
+    };
   }
 
   return {
@@ -193,15 +218,37 @@ function parseArgs(argv) {
     const key = argv[i];
     const next = argv[i + 1];
     switch (key) {
-      case '--input': args.input = next; i += 1; break;
-      case '--name': args.name = next; i += 1; break;
-      case '--dry-run': args.dryRun = true; break;
-      case '--yes': args.yes = true; break;
-      case '--json': args.json = true; break;
-      case '--portals': args.portals = next; i += 1; break;
-      case '--cache': args.cache = next; i += 1; break;
-      case '--workday-registry': args.workdayRegistry = next; i += 1; break;
-      default: break;
+      case '--input':
+        args.input = next;
+        i += 1;
+        break;
+      case '--name':
+        args.name = next;
+        i += 1;
+        break;
+      case '--dry-run':
+        args.dryRun = true;
+        break;
+      case '--yes':
+        args.yes = true;
+        break;
+      case '--json':
+        args.json = true;
+        break;
+      case '--portals':
+        args.portals = next;
+        i += 1;
+        break;
+      case '--cache':
+        args.cache = next;
+        i += 1;
+        break;
+      case '--workday-registry':
+        args.workdayRegistry = next;
+        i += 1;
+        break;
+      default:
+        break;
     }
   }
   if (!args.dryRun && !args.yes) args.dryRun = true;
@@ -234,12 +281,15 @@ export async function main(argv, depsOverride = {}) {
   if (args.yes && resolved.status === 'disabled-duplicate') {
     const raw = fs.readFileSync(args.portals, 'utf8');
     const doc = parseDocument(raw);
-    const careersUrl = resolved.careersUrl ?? (/^https?:\/\//i.test(args.input) ? args.input : null);
+    const careersUrl =
+      resolved.careersUrl ?? (/^https?:\/\//i.test(args.input) ? args.input : null);
     const toggle = toggleEnabled(doc, careersUrl);
     const outStr = String(doc);
     const reparsed = parseDocument(outStr);
     if (reparsed.errors.length > 0) {
-      throw new AddCompanyError('POST_PARSE_FAILED', 'post-mutation reparse failed', { errors: reparsed.errors });
+      throw new AddCompanyError('POST_PARSE_FAILED', 'post-mutation reparse failed', {
+        errors: reparsed.errors,
+      });
     }
     fs.writeFileSync(args.portals, outStr);
     emit(args, { status: 'toggled', name: toggle.name });
@@ -254,7 +304,12 @@ export async function main(argv, depsOverride = {}) {
   // --yes and status === 'ok' → append
   const finalName = args.name ?? resolved.suggestedName ?? resolved.input;
   const result = appendCompany(args.portals, { name: finalName, careersUrl: resolved.careersUrl });
-  emit(args, { status: 'written', entryIndex: result.entryIndex, total: result.total, entry: result.entry });
+  emit(args, {
+    status: 'written',
+    entryIndex: result.entryIndex,
+    total: result.total,
+    entry: result.entry,
+  });
 }
 
 const invokedDirectly = (() => {

--- a/src/scan/add-company.mjs
+++ b/src/scan/add-company.mjs
@@ -134,8 +134,36 @@ async function resolveByUrl(url, doc, deps) {
 }
 
 async function resolveByName(name, doc, deps) {
-  // Name branch implemented in Task 6.
-  return { status: 'not-found', form: 'name', input: name, tried: [] };
+  if (!name) {
+    return { status: 'not-found', form: 'name', input: name, reason: 'empty input', tried: [] };
+  }
+
+  const result = await deps.discoverCompany(name);
+  if (!result.ok) {
+    return {
+      status: 'not-found',
+      form: 'name',
+      input: name,
+      reason: result.reason ?? 'no slug matched',
+      tried: result.tried ?? [],
+    };
+  }
+
+  const dup = duplicateStatus(doc, result.careersUrl);
+  if (dup) {
+    return { ...dup, form: 'name', input: name, platform: result.platform, slug: result.slug, careersUrl: result.careersUrl };
+  }
+
+  return {
+    status: 'ok',
+    form: 'name',
+    input: name,
+    platform: result.platform,
+    slug: result.slug,
+    careersUrl: result.careersUrl,
+    count: result.count ?? null,
+    suggestedName: name,
+  };
 }
 
 export function toggleEnabled(doc, careersUrl) {

--- a/src/scan/add-company.mjs
+++ b/src/scan/add-company.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import { parseDocument, isSeq } from 'yaml';
-import { detectPlatform, getSupportedHosts } from './ats-detect.mjs';
+import { detectPlatform, getSupportedHosts, verifyCompany as defaultVerify } from './ats-detect.mjs';
+import { discoverCompany as defaultDiscover } from './discover-company.mjs';
 
 export class AddCompanyError extends Error {
   constructor(code, message, details = null) {
@@ -175,4 +176,99 @@ export function toggleEnabled(doc, careersUrl) {
   }
   match.node.set('enabled', true);
   return { status: 'toggled', name: match.node.get('name') };
+}
+
+function parseArgs(argv) {
+  const args = {
+    input: null,
+    name: null,
+    dryRun: false,
+    yes: false,
+    json: false,
+    portals: 'config/portals.yml',
+    cache: 'data/known-ats-slugs.json',
+    workdayRegistry: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const key = argv[i];
+    const next = argv[i + 1];
+    switch (key) {
+      case '--input': args.input = next; i += 1; break;
+      case '--name': args.name = next; i += 1; break;
+      case '--dry-run': args.dryRun = true; break;
+      case '--yes': args.yes = true; break;
+      case '--json': args.json = true; break;
+      case '--portals': args.portals = next; i += 1; break;
+      case '--cache': args.cache = next; i += 1; break;
+      case '--workday-registry': args.workdayRegistry = next; i += 1; break;
+      default: break;
+    }
+  }
+  if (!args.dryRun && !args.yes) args.dryRun = true;
+  return args;
+}
+
+function emit(args, payload) {
+  process.stdout.write(JSON.stringify(payload) + '\n');
+}
+
+export async function main(argv, depsOverride = {}) {
+  const args = parseArgs(argv);
+  if (!args.input) {
+    throw new AddCompanyError('MISSING_INPUT', '--input is required');
+  }
+
+  const deps = {
+    verifyCompany: depsOverride.verifyCompany ?? defaultVerify,
+    discoverCompany:
+      depsOverride.discoverCompany ??
+      ((name) =>
+        defaultDiscover(name, {
+          cachePath: args.cache,
+          workdayRegistryPath: args.workdayRegistry,
+        })),
+  };
+
+  const resolved = await resolveCompany({ input: args.input, portalsPath: args.portals, deps });
+
+  if (args.yes && resolved.status === 'disabled-duplicate') {
+    const raw = fs.readFileSync(args.portals, 'utf8');
+    const doc = parseDocument(raw);
+    const careersUrl = resolved.careersUrl ?? (/^https?:\/\//i.test(args.input) ? args.input : null);
+    const toggle = toggleEnabled(doc, careersUrl);
+    const outStr = String(doc);
+    const reparsed = parseDocument(outStr);
+    if (reparsed.errors.length > 0) {
+      throw new AddCompanyError('POST_PARSE_FAILED', 'post-mutation reparse failed', { errors: reparsed.errors });
+    }
+    fs.writeFileSync(args.portals, outStr);
+    emit(args, { status: 'toggled', name: toggle.name });
+    return;
+  }
+
+  if (!args.yes || resolved.status !== 'ok') {
+    emit(args, resolved);
+    return;
+  }
+
+  // --yes and status === 'ok' → append
+  const finalName = args.name ?? resolved.suggestedName ?? resolved.input;
+  const result = appendCompany(args.portals, { name: finalName, careersUrl: resolved.careersUrl });
+  emit(args, { status: 'written', entryIndex: result.entryIndex, total: result.total, entry: result.entry });
+}
+
+const invokedDirectly = (() => {
+  try {
+    return process.argv[1] && process.argv[1].endsWith('add-company.mjs');
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  main(process.argv.slice(2)).catch((err) => {
+    process.stderr.write(`${err.name}: ${err.message}\n`);
+    if (err.details) process.stderr.write(JSON.stringify(err.details, null, 2) + '\n');
+    process.exit(1);
+  });
 }

--- a/src/scan/add-company.mjs
+++ b/src/scan/add-company.mjs
@@ -1,0 +1,8 @@
+export class AddCompanyError extends Error {
+  constructor(code, message, details = null) {
+    super(message);
+    this.name = 'AddCompanyError';
+    this.code = code;
+    this.details = details;
+  }
+}

--- a/src/scan/add-company.mjs
+++ b/src/scan/add-company.mjs
@@ -62,7 +62,7 @@ export function findByCareersUrl(doc, careersUrl) {
   return idx >= 0 ? { index: idx, node: list.items[idx] } : null;
 }
 
-const VERIFIABLE_PLATFORMS = new Set(['lever', 'greenhouse', 'ashby', 'workday']);
+const VERIFIABLE_PLATFORMS = new Set(['lever', 'greenhouse', 'ashby', 'workable', 'workday']);
 
 function titleCaseSlug(slug) {
   return slug

--- a/src/scan/add-company.mjs
+++ b/src/scan/add-company.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import { parseDocument, isSeq } from 'yaml';
+import { detectPlatform, getSupportedHosts } from './ats-detect.mjs';
 
 export class AddCompanyError extends Error {
   constructor(code, message, details = null) {
@@ -54,6 +55,87 @@ export function findByCareersUrl(doc, careersUrl) {
   if (!isSeq(list)) return null;
   const idx = list.items.findIndex((item) => item.get?.('careers_url') === careersUrl);
   return idx >= 0 ? { index: idx, node: list.items[idx] } : null;
+}
+
+const VERIFIABLE_PLATFORMS = new Set(['lever', 'greenhouse', 'ashby', 'workday']);
+
+function titleCaseSlug(slug) {
+  return slug
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((w) => w[0].toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+function loadDoc(portalsPath) {
+  if (!fs.existsSync(portalsPath)) return null;
+  const raw = fs.readFileSync(portalsPath, 'utf8');
+  const doc = parseDocument(raw);
+  if (doc.errors.length > 0) {
+    throw new AddCompanyError('SHAPE_INVALID', 'portals.yml parse failed', { errors: doc.errors });
+  }
+  return doc;
+}
+
+function duplicateStatus(doc, careersUrl) {
+  const match = findByCareersUrl(doc, careersUrl);
+  if (!match) return null;
+  const enabled = match.node.get('enabled') === true;
+  return {
+    status: enabled ? 'duplicate' : 'disabled-duplicate',
+    duplicateOf: { name: match.node.get('name'), enabled },
+  };
+}
+
+export async function resolveCompany({ input, portalsPath, deps }) {
+  const trimmed = String(input ?? '').trim();
+  const doc = loadDoc(portalsPath);
+  if (!doc) return { status: 'no-portals', input: trimmed };
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return resolveByUrl(trimmed, doc, deps);
+  }
+  return resolveByName(trimmed, doc, deps);
+}
+
+async function resolveByUrl(url, doc, deps) {
+  const detected = detectPlatform(url);
+  if (!detected) {
+    return { status: 'unknown-host', form: 'url', input: url, supportedHosts: getSupportedHosts() };
+  }
+
+  const { platform, slug } = detected;
+  if (!VERIFIABLE_PLATFORMS.has(platform)) {
+    return { status: 'unsupported-platform', form: 'url', input: url, platform, slug, knownHost: platform };
+  }
+
+  const dup = duplicateStatus(doc, url);
+  if (dup) {
+    return { ...dup, form: 'url', input: url, platform, slug, careersUrl: url };
+  }
+
+  const verify = await deps.verifyCompany(url);
+  if (!verify.ok) {
+    return { status: 'not-found', form: 'url', input: url, platform, slug, reason: verify.reason ?? 'verify failed' };
+  }
+
+  const out = {
+    status: 'ok',
+    form: 'url',
+    input: url,
+    platform,
+    slug,
+    careersUrl: url,
+    count: verify.count ?? 0,
+    suggestedName: titleCaseSlug(slug),
+  };
+  if ((verify.count ?? 0) === 0) out.warning = 'empty board';
+  return out;
+}
+
+async function resolveByName(name, doc, deps) {
+  // Name branch implemented in Task 6.
+  return { status: 'not-found', form: 'name', input: name, tried: [] };
 }
 
 export function toggleEnabled(doc, careersUrl) {

--- a/tests/apply/candidate-profile.test.mjs
+++ b/tests/apply/candidate-profile.test.mjs
@@ -224,6 +224,29 @@ test('validateProfile tolerates internship_duration_months on a senior profile',
   assert.equal(ok, true, `errors: ${JSON.stringify(errors)}`);
 });
 
+test('validateProfile accepts auto_generate_cover_letter as optional', () => {
+  const { ok, errors } = validateProfile({
+    first_name: 'Alice',
+    last_name: 'Martin',
+    email: 'alice@example.com',
+    phone: '+33600000000',
+    linkedin_url: 'https://linkedin.com/in/a',
+    github_url: 'https://github.com/a',
+    city: 'Paris',
+    country: 'France',
+    school: 'S',
+    degree: 'D',
+    graduation_year: 2026,
+    work_authorization: 'EU',
+    requires_sponsorship: false,
+    availability_start: '2026-09-01',
+    cv_path: 'cv.pdf',
+    auto_apply_min_score: 8,
+    auto_generate_cover_letter: true,
+  });
+  assert.equal(ok, true, `errors: ${JSON.stringify(errors)}`);
+});
+
 test('validateProfile rejects profile without cv_path', () => {
   const { ok, errors } = validateProfile({
     first_name: 'Alice',

--- a/tests/apply/candidate-profile.test.mjs
+++ b/tests/apply/candidate-profile.test.mjs
@@ -153,6 +153,77 @@ test('validateProfile accepts profile with cv_path only', () => {
   assert.equal(ok, true, `errors: ${JSON.stringify(errors)}`);
 });
 
+test('validateProfile requires internship_duration_months when job_type is internship', () => {
+  const { ok, errors } = validateProfile({
+    first_name: 'Alice',
+    last_name: 'Martin',
+    email: 'alice@example.com',
+    phone: '+33600000000',
+    linkedin_url: 'https://linkedin.com/in/a',
+    github_url: 'https://github.com/a',
+    city: 'Paris',
+    country: 'France',
+    school: 'S',
+    degree: 'D',
+    graduation_year: 2026,
+    work_authorization: 'EU',
+    requires_sponsorship: false,
+    availability_start: '2026-09-01',
+    cv_path: 'cv.pdf',
+    auto_apply_min_score: 8,
+    job_type: 'internship',
+  });
+  assert.equal(ok, false);
+  assert.ok(errors.some((e) => e.includes('internship_duration_months')));
+});
+
+test('validateProfile does not require internship_duration_months when job_type is mid-level', () => {
+  const { ok, errors } = validateProfile({
+    first_name: 'Alice',
+    last_name: 'Martin',
+    email: 'alice@example.com',
+    phone: '+33600000000',
+    linkedin_url: 'https://linkedin.com/in/a',
+    github_url: 'https://github.com/a',
+    city: 'Paris',
+    country: 'France',
+    school: 'S',
+    degree: 'D',
+    graduation_year: 2026,
+    work_authorization: 'EU',
+    requires_sponsorship: false,
+    availability_start: '2026-09-01',
+    cv_path: 'cv.pdf',
+    auto_apply_min_score: 8,
+    job_type: 'mid-level',
+  });
+  assert.equal(ok, true, `errors: ${JSON.stringify(errors)}`);
+});
+
+test('validateProfile tolerates internship_duration_months on a senior profile', () => {
+  const { ok, errors } = validateProfile({
+    first_name: 'Alice',
+    last_name: 'Martin',
+    email: 'alice@example.com',
+    phone: '+33600000000',
+    linkedin_url: 'https://linkedin.com/in/a',
+    github_url: 'https://github.com/a',
+    city: 'Paris',
+    country: 'France',
+    school: 'S',
+    degree: 'D',
+    graduation_year: 2026,
+    work_authorization: 'EU',
+    requires_sponsorship: false,
+    availability_start: '2026-09-01',
+    cv_path: 'cv.pdf',
+    auto_apply_min_score: 8,
+    job_type: 'senior',
+    internship_duration_months: 6,
+  });
+  assert.equal(ok, true, `errors: ${JSON.stringify(errors)}`);
+});
+
 test('validateProfile rejects profile without cv_path', () => {
   const { ok, errors } = validateProfile({
     first_name: 'Alice',

--- a/tests/fixtures/add-company/portals.broken.yml
+++ b/tests/fixtures/add-company/portals.broken.yml
@@ -1,0 +1,5 @@
+tracked_companies:
+  - name: Broken
+    careers_url: https://jobs.lever.co/broken
+    enabled: true
+   this: is indented wrong and not a key

--- a/tests/fixtures/add-company/portals.disabled-entry.yml
+++ b/tests/fixtures/add-company/portals.disabled-entry.yml
@@ -1,0 +1,18 @@
+# Fixture with a disabled entry and extra keys.
+tracked_companies:
+  - name: Mistral AI
+    careers_url: https://jobs.lever.co/mistral
+    enabled: true
+  - name: OldCo
+    careers_url: https://jobs.lever.co/oldco
+    enabled: false
+    # Inline reason — must survive toggle.
+    skip_required_any: true
+    target_locations:
+      - Paris
+      - Remote
+
+title_filter:
+  positive: [Intern]
+  negative: []
+  required_any: []

--- a/tests/fixtures/add-company/portals.rich-comments.yml
+++ b/tests/fixtures/add-company/portals.rich-comments.yml
@@ -1,0 +1,24 @@
+# Companies to scan for open positions.
+# This fixture has rich comments used by add-company tests to assert
+# that AST-based mutation preserves trivia on round-trip.
+
+tracked_companies:
+  - name: Mistral AI
+    careers_url: https://jobs.lever.co/mistral
+    enabled: true
+    # Domain is implicit in company name — skip required_any filter
+    skip_required_any: true
+  - name: Anthropic
+    careers_url: https://jobs.lever.co/Anthropic
+    enabled: true
+  # Block comment between entries — must survive append.
+  - name: Photoroom
+    careers_url: https://jobs.lever.co/photoroom
+    enabled: true
+
+title_filter:
+  positive:
+    - Intern
+    - Stage
+  negative: []
+  required_any: []

--- a/tests/scan/add-company.test.mjs
+++ b/tests/scan/add-company.test.mjs
@@ -4,9 +4,23 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseDocument } from 'yaml';
+import { AddCompanyError } from '../../src/scan/add-company.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES = path.join(__dirname, '..', 'fixtures', 'add-company');
+
+test('AddCompanyError — exposes code and message', () => {
+  const err = new AddCompanyError('SHAPE_INVALID', 'tracked_companies is not a sequence');
+  assert.ok(err instanceof Error);
+  assert.equal(err.name, 'AddCompanyError');
+  assert.equal(err.code, 'SHAPE_INVALID');
+  assert.equal(err.message, 'tracked_companies is not a sequence');
+});
+
+test('AddCompanyError — accepts details object', () => {
+  const err = new AddCompanyError('POST_PARSE_FAILED', 'reparse failed', { errors: ['x'] });
+  assert.deepEqual(err.details, { errors: ['x'] });
+});
 
 test('yaml parseDocument — round-trip preserves the rich-comments fixture byte-for-byte', () => {
   const raw = fs.readFileSync(path.join(FIXTURES, 'portals.rich-comments.yml'), 'utf8');

--- a/tests/scan/add-company.test.mjs
+++ b/tests/scan/add-company.test.mjs
@@ -343,7 +343,7 @@ test('main — --dry-run --json on URL form prints status ok', async () => {
     main(['--input', 'https://jobs.ashbyhq.com/poolside', '--dry-run', '--json', '--portals', p], {
       verifyCompany: async () => ({ ok: true, count: 11 }),
       discoverCompany: async () => ({ ok: false }),
-    }),
+    })
   );
   const parsed = JSON.parse(out.trim());
   assert.equal(parsed.status, 'ok');
@@ -354,12 +354,21 @@ test('main — --yes writes a new entry and prints status written', async () => 
   const { path: p } = copyFixture('portals.rich-comments.yml');
   const out = await captureStdout(() =>
     main(
-      ['--input', 'https://jobs.ashbyhq.com/poolside', '--name', 'Poolside', '--yes', '--json', '--portals', p],
+      [
+        '--input',
+        'https://jobs.ashbyhq.com/poolside',
+        '--name',
+        'Poolside',
+        '--yes',
+        '--json',
+        '--portals',
+        p,
+      ],
       {
         verifyCompany: async () => ({ ok: true, count: 11 }),
         discoverCompany: async () => ({ ok: false }),
-      },
-    ),
+      }
+    )
   );
   const parsed = JSON.parse(out.trim());
   assert.equal(parsed.status, 'written');
@@ -376,7 +385,7 @@ test('main — --yes on disabled-duplicate toggles and prints status toggled', a
     main(['--input', 'https://jobs.lever.co/oldco', '--yes', '--json', '--portals', p], {
       verifyCompany: async () => ({ ok: true, count: 1 }),
       discoverCompany: async () => ({ ok: false }),
-    }),
+    })
   );
   const parsed = JSON.parse(out.trim());
   assert.equal(parsed.status, 'toggled');
@@ -392,7 +401,7 @@ test('main — --dry-run on duplicate does not write', async () => {
     main(['--input', 'https://jobs.lever.co/mistral', '--dry-run', '--json', '--portals', p], {
       verifyCompany: async () => ({ ok: true, count: 42 }),
       discoverCompany: async () => ({ ok: false }),
-    }),
+    })
   );
   assert.equal(fs.readFileSync(p, 'utf8'), before);
 });
@@ -404,9 +413,29 @@ test('main — --yes on plain duplicate (enabled: true) does not rewrite file', 
     main(['--input', 'https://jobs.lever.co/mistral', '--yes', '--json', '--portals', p], {
       verifyCompany: async () => ({ ok: true, count: 42 }),
       discoverCompany: async () => ({ ok: false }),
-    }),
+    })
   );
   const parsed = JSON.parse(out.trim());
   assert.equal(parsed.status, 'duplicate');
   assert.equal(fs.readFileSync(p, 'utf8'), before);
+});
+
+test('appendCompany — throws SHAPE_INVALID on a malformed portals.yml', () => {
+  const { path: p } = copyFixture('portals.broken.yml');
+  assert.throws(
+    () => appendCompany(p, { name: 'X', careersUrl: 'https://jobs.lever.co/x' }),
+    (err) => err.code === 'SHAPE_INVALID'
+  );
+});
+
+test('resolveCompany — propagates SHAPE_INVALID when portals.yml is malformed', async () => {
+  const { path: p } = copyFixture('portals.broken.yml');
+  await assert.rejects(
+    resolveCompany({
+      input: 'https://jobs.ashbyhq.com/poolside',
+      portalsPath: p,
+      deps: makeDeps(),
+    }),
+    (err) => err.code === 'SHAPE_INVALID'
+  );
 });

--- a/tests/scan/add-company.test.mjs
+++ b/tests/scan/add-company.test.mjs
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseDocument } from 'yaml';
 import os from 'node:os';
-import { AddCompanyError, appendCompany } from '../../src/scan/add-company.mjs';
+import { AddCompanyError, appendCompany, findByCareersUrl, toggleEnabled } from '../../src/scan/add-company.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES = path.join(__dirname, '..', 'fixtures', 'add-company');
@@ -87,4 +87,55 @@ test('yaml parseDocument — round-trip preserves the rich-comments fixture byte
   const doc = parseDocument(raw);
   assert.equal(doc.errors.length, 0);
   assert.equal(String(doc), raw);
+});
+
+test('findByCareersUrl — returns {index, node} when URL matches', () => {
+  const raw = fs.readFileSync(path.join(FIXTURES, 'portals.rich-comments.yml'), 'utf8');
+  const doc = parseDocument(raw);
+  const match = findByCareersUrl(doc, 'https://jobs.lever.co/Anthropic');
+  assert.equal(match.index, 1);
+  assert.equal(match.node.get('name'), 'Anthropic');
+});
+
+test('findByCareersUrl — case-strict on URL', () => {
+  const raw = fs.readFileSync(path.join(FIXTURES, 'portals.rich-comments.yml'), 'utf8');
+  const doc = parseDocument(raw);
+  assert.equal(findByCareersUrl(doc, 'https://jobs.lever.co/anthropic'), null);
+});
+
+test('findByCareersUrl — returns null when no match', () => {
+  const raw = fs.readFileSync(path.join(FIXTURES, 'portals.rich-comments.yml'), 'utf8');
+  const doc = parseDocument(raw);
+  assert.equal(findByCareersUrl(doc, 'https://jobs.lever.co/zzz'), null);
+});
+
+test('toggleEnabled — flips enabled: false to true on matching entry', () => {
+  const { path: p } = copyFixture('portals.disabled-entry.yml');
+  const raw = fs.readFileSync(p, 'utf8');
+  const doc = parseDocument(raw);
+  const result = toggleEnabled(doc, 'https://jobs.lever.co/oldco');
+  assert.equal(result.status, 'toggled');
+  assert.equal(result.name, 'OldCo');
+  fs.writeFileSync(p, String(doc));
+  const out = fs.readFileSync(p, 'utf8');
+  const reparsed = parseDocument(out);
+  const list = reparsed.get('tracked_companies', true);
+  assert.equal(list.items[1].get('enabled'), true);
+  assert.equal(list.items[1].get('skip_required_any'), true);
+  assert.deepEqual(list.items[1].get('target_locations').toJSON(), ['Paris', 'Remote']);
+  assert.ok(out.includes('# Inline reason — must survive toggle.'));
+});
+
+test('toggleEnabled — returns already-enabled when entry is already true', () => {
+  const { path: p } = copyFixture('portals.disabled-entry.yml');
+  const doc = parseDocument(fs.readFileSync(p, 'utf8'));
+  const result = toggleEnabled(doc, 'https://jobs.lever.co/mistral');
+  assert.equal(result.status, 'already-enabled');
+  assert.equal(result.name, 'Mistral AI');
+});
+
+test('toggleEnabled — returns null when careers_url is not found', () => {
+  const { path: p } = copyFixture('portals.disabled-entry.yml');
+  const doc = parseDocument(fs.readFileSync(p, 'utf8'));
+  assert.equal(toggleEnabled(doc, 'https://nope'), null);
 });

--- a/tests/scan/add-company.test.mjs
+++ b/tests/scan/add-company.test.mjs
@@ -193,15 +193,16 @@ test('resolveCompany — URL form unknown host returns supportedHosts list', asy
   assert.ok(out.supportedHosts.length > 0);
 });
 
-test('resolveCompany — URL form workable returns unsupported-platform with knownHost', async () => {
+test('resolveCompany — URL form workable verifies and returns ok', async () => {
   const { path: p } = copyFixture('portals.rich-comments.yml');
   const out = await resolveCompany({
     input: 'https://apply.workable.com/huggingface',
     portalsPath: p,
-    deps: makeDeps(),
+    deps: makeDeps({ verifyCompany: async () => ({ ok: true, count: 7 }) }),
   });
-  assert.equal(out.status, 'unsupported-platform');
-  assert.equal(out.knownHost, 'workable');
+  assert.equal(out.status, 'ok');
+  assert.equal(out.platform, 'workable');
+  assert.equal(out.count, 7);
 });
 
 test('resolveCompany — URL form verify failure returns not-found', async () => {

--- a/tests/scan/add-company.test.mjs
+++ b/tests/scan/add-company.test.mjs
@@ -5,7 +5,13 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseDocument } from 'yaml';
 import os from 'node:os';
-import { AddCompanyError, appendCompany, findByCareersUrl, toggleEnabled } from '../../src/scan/add-company.mjs';
+import {
+  AddCompanyError,
+  appendCompany,
+  findByCareersUrl,
+  toggleEnabled,
+  resolveCompany,
+} from '../../src/scan/add-company.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES = path.join(__dirname, '..', 'fixtures', 'add-company');
@@ -138,4 +144,107 @@ test('toggleEnabled — returns null when careers_url is not found', () => {
   const { path: p } = copyFixture('portals.disabled-entry.yml');
   const doc = parseDocument(fs.readFileSync(p, 'utf8'));
   assert.equal(toggleEnabled(doc, 'https://nope'), null);
+});
+
+function makeDeps({ verifyCompany, discoverCompany } = {}) {
+  return {
+    verifyCompany: verifyCompany ?? (async () => ({ ok: true, count: 5 })),
+    discoverCompany:
+      discoverCompany ?? (async () => ({ ok: false, reason: 'no slug matched', tried: [] })),
+  };
+}
+
+test('resolveCompany — URL form happy path returns status ok with platform/slug', async () => {
+  const { path: p } = copyFixture('portals.rich-comments.yml');
+  const out = await resolveCompany({
+    input: 'https://jobs.ashbyhq.com/poolside',
+    portalsPath: p,
+    deps: makeDeps({ verifyCompany: async () => ({ ok: true, count: 11 }) }),
+  });
+  assert.equal(out.status, 'ok');
+  assert.equal(out.form, 'url');
+  assert.equal(out.platform, 'ashby');
+  assert.equal(out.slug, 'poolside');
+  assert.equal(out.careersUrl, 'https://jobs.ashbyhq.com/poolside');
+  assert.equal(out.count, 11);
+  assert.equal(out.suggestedName, 'Poolside');
+});
+
+test('resolveCompany — URL form with count 0 sets warning empty board', async () => {
+  const { path: p } = copyFixture('portals.rich-comments.yml');
+  const out = await resolveCompany({
+    input: 'https://jobs.ashbyhq.com/poolside',
+    portalsPath: p,
+    deps: makeDeps({ verifyCompany: async () => ({ ok: true, count: 0 }) }),
+  });
+  assert.equal(out.status, 'ok');
+  assert.equal(out.warning, 'empty board');
+});
+
+test('resolveCompany — URL form unknown host returns supportedHosts list', async () => {
+  const { path: p } = copyFixture('portals.rich-comments.yml');
+  const out = await resolveCompany({
+    input: 'https://careers.example.com/company',
+    portalsPath: p,
+    deps: makeDeps(),
+  });
+  assert.equal(out.status, 'unknown-host');
+  assert.ok(Array.isArray(out.supportedHosts));
+  assert.ok(out.supportedHosts.length > 0);
+});
+
+test('resolveCompany — URL form workable returns unsupported-platform with knownHost', async () => {
+  const { path: p } = copyFixture('portals.rich-comments.yml');
+  const out = await resolveCompany({
+    input: 'https://apply.workable.com/huggingface',
+    portalsPath: p,
+    deps: makeDeps(),
+  });
+  assert.equal(out.status, 'unsupported-platform');
+  assert.equal(out.knownHost, 'workable');
+});
+
+test('resolveCompany — URL form verify failure returns not-found', async () => {
+  const { path: p } = copyFixture('portals.rich-comments.yml');
+  const out = await resolveCompany({
+    input: 'https://jobs.lever.co/does-not-exist',
+    portalsPath: p,
+    deps: makeDeps({ verifyCompany: async () => ({ ok: false, reason: 'slug 404' }) }),
+  });
+  assert.equal(out.status, 'not-found');
+  assert.equal(out.platform, 'lever');
+  assert.equal(out.slug, 'does-not-exist');
+});
+
+test('resolveCompany — URL form duplicate on exact careers_url match', async () => {
+  const { path: p } = copyFixture('portals.rich-comments.yml');
+  const out = await resolveCompany({
+    input: 'https://jobs.lever.co/mistral',
+    portalsPath: p,
+    deps: makeDeps({ verifyCompany: async () => ({ ok: true, count: 42 }) }),
+  });
+  assert.equal(out.status, 'duplicate');
+  assert.equal(out.duplicateOf.name, 'Mistral AI');
+  assert.equal(out.duplicateOf.enabled, true);
+});
+
+test('resolveCompany — URL form disabled-duplicate when existing entry is enabled false', async () => {
+  const { path: p } = copyFixture('portals.disabled-entry.yml');
+  const out = await resolveCompany({
+    input: 'https://jobs.lever.co/oldco',
+    portalsPath: p,
+    deps: makeDeps({ verifyCompany: async () => ({ ok: true, count: 1 }) }),
+  });
+  assert.equal(out.status, 'disabled-duplicate');
+  assert.equal(out.duplicateOf.name, 'OldCo');
+  assert.equal(out.duplicateOf.enabled, false);
+});
+
+test('resolveCompany — missing portals.yml returns no-portals', async () => {
+  const out = await resolveCompany({
+    input: 'https://jobs.ashbyhq.com/poolside',
+    portalsPath: '/tmp/definitely-not-here-xyz/portals.yml',
+    deps: makeDeps(),
+  });
+  assert.equal(out.status, 'no-portals');
 });

--- a/tests/scan/add-company.test.mjs
+++ b/tests/scan/add-company.test.mjs
@@ -1,0 +1,16 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseDocument } from 'yaml';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES = path.join(__dirname, '..', 'fixtures', 'add-company');
+
+test('yaml parseDocument — round-trip preserves the rich-comments fixture byte-for-byte', () => {
+  const raw = fs.readFileSync(path.join(FIXTURES, 'portals.rich-comments.yml'), 'utf8');
+  const doc = parseDocument(raw);
+  assert.equal(doc.errors.length, 0);
+  assert.equal(String(doc), raw);
+});

--- a/tests/scan/add-company.test.mjs
+++ b/tests/scan/add-company.test.mjs
@@ -320,3 +320,93 @@ test('resolveCompany — name form duplicate when discovered URL is already pres
   assert.equal(out.status, 'duplicate');
   assert.equal(out.duplicateOf.name, 'Mistral AI');
 });
+
+import { main } from '../../src/scan/add-company.mjs';
+
+function captureStdout(fn) {
+  const chunks = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (s) => {
+    chunks.push(typeof s === 'string' ? s : s.toString('utf8'));
+    return true;
+  };
+  return fn()
+    .finally(() => {
+      process.stdout.write = originalWrite;
+    })
+    .then(() => chunks.join(''));
+}
+
+test('main — --dry-run --json on URL form prints status ok', async () => {
+  const { path: p } = copyFixture('portals.rich-comments.yml');
+  const out = await captureStdout(() =>
+    main(['--input', 'https://jobs.ashbyhq.com/poolside', '--dry-run', '--json', '--portals', p], {
+      verifyCompany: async () => ({ ok: true, count: 11 }),
+      discoverCompany: async () => ({ ok: false }),
+    }),
+  );
+  const parsed = JSON.parse(out.trim());
+  assert.equal(parsed.status, 'ok');
+  assert.equal(parsed.suggestedName, 'Poolside');
+});
+
+test('main — --yes writes a new entry and prints status written', async () => {
+  const { path: p } = copyFixture('portals.rich-comments.yml');
+  const out = await captureStdout(() =>
+    main(
+      ['--input', 'https://jobs.ashbyhq.com/poolside', '--name', 'Poolside', '--yes', '--json', '--portals', p],
+      {
+        verifyCompany: async () => ({ ok: true, count: 11 }),
+        discoverCompany: async () => ({ ok: false }),
+      },
+    ),
+  );
+  const parsed = JSON.parse(out.trim());
+  assert.equal(parsed.status, 'written');
+  assert.equal(parsed.entryIndex, 3);
+  assert.equal(parsed.total, 4);
+  const reparsed = parseDocument(fs.readFileSync(p, 'utf8'));
+  const list = reparsed.get('tracked_companies', true);
+  assert.equal(list.items[3].get('name'), 'Poolside');
+});
+
+test('main — --yes on disabled-duplicate toggles and prints status toggled', async () => {
+  const { path: p } = copyFixture('portals.disabled-entry.yml');
+  const out = await captureStdout(() =>
+    main(['--input', 'https://jobs.lever.co/oldco', '--yes', '--json', '--portals', p], {
+      verifyCompany: async () => ({ ok: true, count: 1 }),
+      discoverCompany: async () => ({ ok: false }),
+    }),
+  );
+  const parsed = JSON.parse(out.trim());
+  assert.equal(parsed.status, 'toggled');
+  const reparsed = parseDocument(fs.readFileSync(p, 'utf8'));
+  const list = reparsed.get('tracked_companies', true);
+  assert.equal(list.items[1].get('enabled'), true);
+});
+
+test('main — --dry-run on duplicate does not write', async () => {
+  const { path: p } = copyFixture('portals.rich-comments.yml');
+  const before = fs.readFileSync(p, 'utf8');
+  await captureStdout(() =>
+    main(['--input', 'https://jobs.lever.co/mistral', '--dry-run', '--json', '--portals', p], {
+      verifyCompany: async () => ({ ok: true, count: 42 }),
+      discoverCompany: async () => ({ ok: false }),
+    }),
+  );
+  assert.equal(fs.readFileSync(p, 'utf8'), before);
+});
+
+test('main — --yes on plain duplicate (enabled: true) does not rewrite file', async () => {
+  const { path: p } = copyFixture('portals.rich-comments.yml');
+  const before = fs.readFileSync(p, 'utf8');
+  const out = await captureStdout(() =>
+    main(['--input', 'https://jobs.lever.co/mistral', '--yes', '--json', '--portals', p], {
+      verifyCompany: async () => ({ ok: true, count: 42 }),
+      discoverCompany: async () => ({ ok: false }),
+    }),
+  );
+  const parsed = JSON.parse(out.trim());
+  assert.equal(parsed.status, 'duplicate');
+  assert.equal(fs.readFileSync(p, 'utf8'), before);
+});

--- a/tests/scan/add-company.test.mjs
+++ b/tests/scan/add-company.test.mjs
@@ -4,7 +4,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseDocument } from 'yaml';
-import { AddCompanyError } from '../../src/scan/add-company.mjs';
+import os from 'node:os';
+import { AddCompanyError, appendCompany } from '../../src/scan/add-company.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES = path.join(__dirname, '..', 'fixtures', 'add-company');
@@ -20,6 +21,65 @@ test('AddCompanyError — exposes code and message', () => {
 test('AddCompanyError — accepts details object', () => {
   const err = new AddCompanyError('POST_PARSE_FAILED', 'reparse failed', { errors: ['x'] });
   assert.deepEqual(err.details, { errors: ['x'] });
+});
+
+function copyFixture(name) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'add-company-'));
+  const dst = path.join(dir, 'portals.yml');
+  fs.copyFileSync(path.join(FIXTURES, name), dst);
+  return { dir, path: dst };
+}
+
+test('appendCompany — appends a new entry and returns index + total', () => {
+  const { path: p } = copyFixture('portals.rich-comments.yml');
+  const result = appendCompany(p, {
+    name: 'Hugging Face',
+    careersUrl: 'https://apply.workable.com/huggingface',
+  });
+  assert.equal(result.total, 4);
+  assert.equal(result.entryIndex, 3);
+  assert.deepEqual(result.entry, {
+    name: 'Hugging Face',
+    careers_url: 'https://apply.workable.com/huggingface',
+    enabled: true,
+  });
+});
+
+test('appendCompany — preserves header comment and inter-entry block comment', () => {
+  const { path: p } = copyFixture('portals.rich-comments.yml');
+  appendCompany(p, {
+    name: 'Hugging Face',
+    careersUrl: 'https://apply.workable.com/huggingface',
+  });
+  const out = fs.readFileSync(p, 'utf8');
+  assert.ok(out.includes('# Companies to scan for open positions.'));
+  assert.ok(out.includes('# Block comment between entries'));
+  assert.ok(out.includes('# Domain is implicit in company name — skip required_any filter'));
+});
+
+test('appendCompany — the new entry has name, careers_url, enabled in that order', () => {
+  const { path: p } = copyFixture('portals.rich-comments.yml');
+  appendCompany(p, {
+    name: 'Hugging Face',
+    careersUrl: 'https://apply.workable.com/huggingface',
+  });
+  const out = fs.readFileSync(p, 'utf8');
+  const doc = parseDocument(out);
+  const list = doc.get('tracked_companies', true);
+  const last = list.items[list.items.length - 1];
+  assert.equal(last.get('name'), 'Hugging Face');
+  assert.equal(last.get('careers_url'), 'https://apply.workable.com/huggingface');
+  assert.equal(last.get('enabled'), true);
+});
+
+test('appendCompany — throws SHAPE_INVALID when tracked_companies is missing', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'add-company-'));
+  const p = path.join(dir, 'portals.yml');
+  fs.writeFileSync(p, 'title_filter: {}\n');
+  assert.throws(
+    () => appendCompany(p, { name: 'x', careersUrl: 'https://jobs.lever.co/x' }),
+    (err) => err.code === 'SHAPE_INVALID'
+  );
 });
 
 test('yaml parseDocument — round-trip preserves the rich-comments fixture byte-for-byte', () => {

--- a/tests/scan/add-company.test.mjs
+++ b/tests/scan/add-company.test.mjs
@@ -248,3 +248,75 @@ test('resolveCompany — missing portals.yml returns no-portals', async () => {
   });
   assert.equal(out.status, 'no-portals');
 });
+
+test('resolveCompany — name form returns ok when discoverCompany succeeds', async () => {
+  const { path: p } = copyFixture('portals.rich-comments.yml');
+  const out = await resolveCompany({
+    input: 'Poolside',
+    portalsPath: p,
+    deps: makeDeps({
+      discoverCompany: async () => ({
+        ok: true,
+        platform: 'ashby',
+        slug: 'poolside',
+        careersUrl: 'https://jobs.ashbyhq.com/poolside',
+        count: 11,
+      }),
+    }),
+  });
+  assert.equal(out.status, 'ok');
+  assert.equal(out.form, 'name');
+  assert.equal(out.platform, 'ashby');
+  assert.equal(out.slug, 'poolside');
+  assert.equal(out.careersUrl, 'https://jobs.ashbyhq.com/poolside');
+  assert.equal(out.count, 11);
+  assert.equal(out.suggestedName, 'Poolside');
+});
+
+test('resolveCompany — name form returns not-found with tried candidates', async () => {
+  const { path: p } = copyFixture('portals.rich-comments.yml');
+  const out = await resolveCompany({
+    input: 'Unknown Corp',
+    portalsPath: p,
+    deps: makeDeps({
+      discoverCompany: async () => ({
+        ok: false,
+        reason: 'no slug matched',
+        tried: [{ platform: 'lever', slug: 'unknowncorp' }],
+      }),
+    }),
+  });
+  assert.equal(out.status, 'not-found');
+  assert.equal(out.form, 'name');
+  assert.deepEqual(out.tried, [{ platform: 'lever', slug: 'unknowncorp' }]);
+});
+
+test('resolveCompany — name form empty input returns not-found', async () => {
+  const { path: p } = copyFixture('portals.rich-comments.yml');
+  const out = await resolveCompany({
+    input: '   ',
+    portalsPath: p,
+    deps: makeDeps(),
+  });
+  assert.equal(out.status, 'not-found');
+  assert.equal(out.reason, 'empty input');
+});
+
+test('resolveCompany — name form duplicate when discovered URL is already present', async () => {
+  const { path: p } = copyFixture('portals.rich-comments.yml');
+  const out = await resolveCompany({
+    input: 'Mistral',
+    portalsPath: p,
+    deps: makeDeps({
+      discoverCompany: async () => ({
+        ok: true,
+        platform: 'lever',
+        slug: 'mistral',
+        careersUrl: 'https://jobs.lever.co/mistral',
+        count: 42,
+      }),
+    }),
+  });
+  assert.equal(out.status, 'duplicate');
+  assert.equal(out.duplicateOf.name, 'Mistral AI');
+});


### PR DESCRIPTION
## Summary

- New slash command `/add-company <name-or-url>` wraps `discoverCompany` + `verifyCompany` + safe YAML mutation so users stop hand-editing `config/portals.yml`.
- Two forms: by name (e.g. `/add-company "Poolside"`) or by URL (e.g. `/add-company https://jobs.ashbyhq.com/poolside`).
- YAML mutation uses the new `yaml` dep with the Document AST API — comments and formatting are preserved on round-trip.
- Dry-run first (`--dry-run --json`), LLM confirms name, then `--yes --json` writes or toggles.

## Test plan

- [x] `npm test` — 560/560 pass (32 new tests in `tests/scan/add-company.test.mjs`).
- [ ] Manual: `node src/scan/add-company.mjs --input https://jobs.ashbyhq.com/poolside --dry-run --json --portals <tmp>` returns `status: "ok"`.
- [ ] Manual: same command with `--yes` appends the entry; re-running returns `status: "duplicate"`.
- [ ] Manual: flip an entry to `enabled: false` in a tmp file, re-run `--yes`, observe `status: "toggled"` and comments preserved.
- [ ] Manual: `--input https://apply.workable.com/huggingface` returns `unsupported-platform` with `knownHost: "workable"` (pointer to #83).

Closes #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)