### PR TITLE
feat(discoverability): surface /explain, /dashboard, flags, and --help (issue #89)

### DIFF
--- a/.claude/commands/apply-onboard/setup.md
+++ b/.claude/commands/apply-onboard/setup.md
@@ -22,16 +22,22 @@ Read `data/.onboard-state.json` (written by `/apply-onboard:profile`) to get `cl
 
 ## 2. Run `scripts/setup.sh`
 
-Run one of:
+**First, print the script's usage once** so the user discovers flags like `--no-clone-chrome-profile` and `--no-rc`:
 
-```bash
-bash scripts/setup.sh --yes --clone-chrome-profile       # if user said yes
-bash scripts/setup.sh --yes --no-clone-chrome-profile    # if user said no
-```
+    bash scripts/setup.sh --help
+
+Print the captured output verbatim, prefaced by one short line:
+
+> "Voici les flags supportés par le script (affichés une fois pour que tu saches ce qui est disponible) — je vais maintenant lancer le setup avec les flags correspondant à ton choix clone-chrome-profile."
+
+Then run one of:
+
+    bash scripts/setup.sh --yes --clone-chrome-profile       # if user said yes
+    bash scripts/setup.sh --yes --no-clone-chrome-profile    # if user said no
 
 This will: install npm deps if missing (`npm ci` / `npm install`), create the CDP Chrome profile (empty or cloned), append the `chrome-apply` alias to the user's shell rc (with a timestamped backup), and copy any missing templates into `config/` (harmless — `cv.md`, `candidate-profile.yml`, and `portals.yml` already exist from the earlier phases and are skipped).
 
-If the user is in an unusual shell setup, add `--no-rc` and print the alias to them manually. Run `bash scripts/setup.sh --help` for all flags.
+If the user is in an unusual shell setup, add `--no-rc` and print the alias to them manually.
 
 ## 3. Check if CDP is already up
 
@@ -106,9 +112,29 @@ After you click "Add to Chrome" and approve the install:
 
 **Wait for the user to confirm permissions are granted** before continuing.
 
+## 5.5. Calibration dry-run (best-effort)
+
+Before printing the final summary, run a `/scan --dry-run --json` to give the user a realistic preview of what their first real scan will yield. The extension is not required for this step.
+
+```bash
+node src/scan/index.mjs --dry-run --json
+```
+
+Parse the JSON to extract:
+
+- `result.raw` — total raw offers across all companies
+- `result.added.length` — number of offers that would survive all filters
+- `result.perCompany.filter(c => c.newCount > 0)` — companies with at least one hit, sorted descending by `newCount`, top 3
+
+Cache these three values (or a single "skipped" flag on failure) so step 6 can reference them.
+
+**Failure mode (network error, ATS outage, any non-zero exit):** do **not** block onboarding. Set an internal "dry-run skipped" flag and let step 6 fall back to the "skipped" message. The user will still have a working install.
+
 ## 6. Final summary
 
-Print a clean summary:
+Read `config/portals.yml` once to extract `title_filter.required_any` and `title_filter.excluded_any`. Use the dry-run values cached in step 5.5 (or the "skipped" flag).
+
+Print the following summary, substituting values where marked:
 
 ```
 ✅ Onboarding complete.
@@ -117,10 +143,23 @@ Files written:
   • config/cv.md
   • config/cv.<lang>.pdf
   • config/candidate-profile.yml
-  • config/portals.yml  (N companies)
+  • config/portals.yml  (<N> companies)
 
-Chrome launched in CDP mode (port 9222) with the claude-in-chrome
-extension page open.
+Your title_filter:
+  required_any  : <comma-separated list from portals.yml, or "(none)">
+  excluded_any  : <comma-separated list from portals.yml, or "(none)">
+  (source: config/portals.yml — edit there to re-tune,
+   or run /explain "<title>" to debug one title)
+
+First scan preview (dry-run):
+  <A> new offers after filter (from <R> raw).
+  Top hits: <company1> (<n1>), <company2> (<n2>), <company3> (<n3>).
+  → If 0 hits: your required_any is probably too strict.
+    Run /explain "<one of your target titles>" to trace it,
+    then edit config/portals.yml and re-run /scan.
+
+Chrome launched in CDP mode (port 9222) with the
+claude-in-chrome extension page open.
 
 One last manual step:
   → Click "Add to Chrome" on the page that just opened,
@@ -130,6 +169,27 @@ Then you can run:
   /scan                # fetch new offers into data/pipeline.md
   /score <url>         # LLM-evaluate an offer
   /apply <url>         # automated form fill + submit
+  /explain "<title>"   # debug why a title passes/fails the filter
+  /dashboard           # regenerate dashboard.html
+
+Tip: append --help to any command (e.g. /scan --help) to see its flags.
 ```
+
+**Fallback when step 5.5 was skipped:** replace the "First scan preview" block with exactly:
+
+```
+First scan preview (dry-run):
+  (skipped — network issue during dry-run; run /scan --dry-run when ready.)
+```
+
+**Fallback when `raw === 0` across all companies** (likely ATS outage or empty `portals.yml`): replace the block with:
+
+```
+First scan preview (dry-run):
+  0 raw offers — likely an ATS outage or an empty portals.yml.
+  Run /scan after the extension install to retry.
+```
+
+**Fallback when `title_filter` is absent from `portals.yml`:** print `(none — every title accepted)` for both `required_any` and `excluded_any`.
 
 **Do not run `/scan` or `/apply` yourself** — the user still needs to install the extension manually. Your onboarding stops here.

--- a/.claude/commands/apply.md
+++ b/.claude/commands/apply.md
@@ -3,6 +3,32 @@ description: Fill and submit a job application on the URL provided via claude-in
 argument-hint: <job-url>
 ---
 
+## `--help` / `-h`
+
+**Si `$ARGUMENTS` commence par `--help` ou `-h`, imprime uniquement le bloc ci-dessous et arrête-toi. N'ouvre pas Chrome, ne lis aucun fichier de `config/` ou `data/`.**
+
+```
+Usage: /apply <url>
+
+Open the URL in Chrome (CDP on port 9222), classify the form,
+fill from config/candidate-profile.yml, upload the CV, submit,
+and update data/applications.md + data/apply-log.jsonl.
+
+Stops and asks the user on: captcha, login wall,
+unknown required field.
+
+Prerequisites:
+  - chrome-apply alias launched (CDP port 9222 up)
+  - claude-in-chrome extension installed with host permissions
+
+Files:
+  reads:  config/candidate-profile.yml, config/cv.<lang>.pdf
+  writes: data/applications.md, data/apply-log.jsonl
+
+See also: /scan, /score, /dashboard
+          docs/apply-workflow.md, docs/cdp-setup.md
+```
+
 # /apply $ARGUMENTS
 
 You will apply automatically to the offer at `$ARGUMENTS`. Follow this playbook **step by step**. At the slightest anomaly (login wall, captcha, unknown required field, submit error), **STOP and ask the user** before continuing.

--- a/.claude/commands/scan.md
+++ b/.claude/commands/scan.md
@@ -52,6 +52,4 @@ The scanner prints a summary per company:
 
 If a company reports `0 raw offers`, check that its `careers_url` points to an ATS slug supported by `src/scan/ats-detect.mjs`. Group B (custom career pages) companies are skipped silently.
 
-## Next step
-
-Once `data/pipeline.md` has new rows, run `/score <url>` on each to get an LLM evaluation.
+Pour comprendre en détail comment `title_filter` rejette une offre, voir [`docs/scan-workflow.md#title-filter`](../../docs/scan-workflow.md#title-filter) ou lance `/explain "<titre>"`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -93,3 +93,4 @@ Or as one command: `npm test && bash scripts/check-no-pii.sh && npm run lint`.
    node src/apply/upload-file.mjs --url lever-form --selector '#resume' --file tests/fixtures/fake-cv.pdf
    ```
 5. Review `git log` on the release branch — confirm no accidental PII in any file.
+6. `/apply-onboard` final summary shows the `Your title_filter` block and either a `First scan preview` (with raw + added counts) or the graceful "skipped" fallback when the dry-run fails.

--- a/src/dashboard/build.mjs
+++ b/src/dashboard/build.mjs
@@ -317,8 +317,29 @@ function escapeHtml(str) {
     .replace(/"/g, '&quot;');
 }
 
+function printDashboardHelp() {
+  console.log(`Usage: /dashboard
+
+Regenerate dashboard.html from data/ and reports/.
+
+Flags:
+  --help, -h    Show this help and exit.
+
+Files:
+  reads:  data/pipeline.md, data/evaluations.jsonl, data/applications.md,
+          data/apply-log.jsonl, reports/
+  writes: dashboard.html  (at repo root)
+
+See also: /scan, /score`);
+}
+
 // CLI guard — run directly as a script
 if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    printDashboardHelp();
+    process.exit(0);
+  }
   const dataDir = process.env.CLAUDE_APPLY_DATA_DIR || './data';
   const reportsDir = process.env.CLAUDE_APPLY_REPORTS_DIR || './reports';
   await buildDashboard({

--- a/src/scan/explain.mjs
+++ b/src/scan/explain.mjs
@@ -104,7 +104,31 @@ function formatTrace(offer, outcome, whitelist) {
   return lines.join('\n');
 }
 
+function printExplainHelp() {
+  console.log(`Usage: /explain "<title>" [--company <name>] [--location <loc>]
+
+Trace which prefilter rule accepts or rejects a given title.
+
+Flags:
+  --company <name>    Apply blacklist check against this company.
+  --location <loc>    Apply location check against this string.
+  --help, -h          Show this help and exit.
+
+Files:
+  reads:  config/portals.yml, config/candidate-profile.yml
+  writes: (nothing)
+
+Exit codes: 0 = ACCEPTED, 1 = REJECTED, 2 = usage error.
+
+See also: /scan
+          docs/scan-workflow.md#title-filter`);
+}
+
 function main() {
+  if (process.argv.slice(2).some((a) => a === '--help' || a === '-h')) {
+    printExplainHelp();
+    process.exit(0);
+  }
   const parsed = parseArgs(process.argv);
   if (parsed.error) {
     console.error(parsed.error);

--- a/src/scan/index.mjs
+++ b/src/scan/index.mjs
@@ -366,8 +366,31 @@ export function formatSummary(result, dryRun) {
   return lines.join('\n');
 }
 
+function printScanHelp() {
+  console.log(`Usage: /scan [--dry-run] [--only <slug>] [--json]
+
+Scan enabled ATS portals and append new offers to data/pipeline.md.
+
+Flags:
+  --dry-run         Compute everything, write nothing.
+  --only <slug>     Scan a single company by ATS slug (e.g. mistral).
+  --json            Emit machine-readable output to stdout.
+  --help, -h        Show this help and exit.
+
+Files:
+  reads:  config/portals.yml, config/candidate-profile.yml
+  writes: data/pipeline.md, data/scan-history.tsv, data/filtered-out.tsv
+
+See also: /explain, /dashboard
+          docs/scan-workflow.md  (title_filter format, per-company overrides)`);
+}
+
 async function main() {
   const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    printScanHelp();
+    process.exit(0);
+  }
   const dryRun = args.includes('--dry-run');
   const asJson = args.includes('--json');
   const onlyIdx = args.indexOf('--only');

--- a/src/scan/index.mjs
+++ b/src/scan/index.mjs
@@ -356,6 +356,13 @@ export function formatSummary(result, dryRun) {
       lines.push(`  ! ${e.company}: ${e.error}`);
     }
   }
+  lines.push('');
+  lines.push('Next steps :');
+  lines.push('  /score <url>        # évalue une offre via LLM (data/evaluations.jsonl)');
+  lines.push('  /explain "<title>"  # trace pourquoi une offre passe/échoue le filtre');
+  lines.push('  /dashboard          # régénère dashboard.html');
+  lines.push('');
+  lines.push('Plus de flags : /scan --help  (--dry-run, --only <slug>, --json)');
   return lines.join('\n');
 }
 

--- a/src/score/index.mjs
+++ b/src/score/index.mjs
@@ -385,7 +385,8 @@ function formatProgress(index, total, offer, result) {
 
 function printScoreHelp() {
   console.log(`Usage: /score <url> [options]
-       /score --from-pipeline [--batch] [--parallel <n>]
+       /score --from-pipeline
+       /score --batch [--parallel <n>]
        /score --json-input <path>
 
 LLM-evaluate one or more offers against config/cv.md.
@@ -393,10 +394,12 @@ LLM-evaluate one or more offers against config/cv.md.
 Flags:
   --re-score             Re-evaluate a URL already in evaluations.jsonl
                          (preserves the existing id).
-  --batch                Score multiple offers from data/pipeline.md.
+  --batch                Score all unscored offers from data/pipeline.md.
+                         Mutually exclusive with --from-pipeline and <url>.
   --parallel <n>         With --batch, run <n> evaluations concurrently.
                          Implies --batch. Default: 5.
-  --from-pipeline        Take the offer URL from data/pipeline.md.
+  --from-pipeline        Score a single offer selected from data/pipeline.md.
+                         Mutually exclusive with --batch and <url>.
   --json-input <path>    Read a pre-built offer JSON instead of fetching.
   --id <id>              Override the generated id for this entry.
   --company <name>       With --role and --location, override offer metadata

--- a/src/score/index.mjs
+++ b/src/score/index.mjs
@@ -383,7 +383,41 @@ function formatProgress(index, total, offer, result) {
   return `[batch]  ${num} ✓ ${label.padEnd(45)} ${result.score} ${result.verdict}`;
 }
 
+function printScoreHelp() {
+  console.log(`Usage: /score <url> [options]
+       /score --from-pipeline [--batch] [--parallel <n>]
+       /score --json-input <path>
+
+LLM-evaluate one or more offers against config/cv.md.
+
+Flags:
+  --re-score             Re-evaluate a URL already in evaluations.jsonl
+                         (preserves the existing id).
+  --batch                Score multiple offers from data/pipeline.md.
+  --parallel <n>         With --batch, run <n> evaluations concurrently.
+                         Implies --batch. Default: 5.
+  --from-pipeline        Take the offer URL from data/pipeline.md.
+  --json-input <path>    Read a pre-built offer JSON instead of fetching.
+  --id <id>              Override the generated id for this entry.
+  --company <name>       With --role and --location, override offer metadata
+                         (all three required together).
+  --role <title>         (see --company)
+  --location <loc>       (see --company)
+  --help, -h             Show this help and exit.
+
+Files:
+  reads:  config/cv.md, config/candidate-profile.yml
+  writes: data/evaluations.jsonl  (one JSON line per invocation)
+
+See also: /explain, /dashboard
+          docs/score-workflow.md`);
+}
+
 async function main() {
+  if (process.argv.slice(2).some((a) => a === '--help' || a === '-h')) {
+    printScoreHelp();
+    process.exit(0);
+  }
   const CONFIG_DIR =
     process.env.CLAUDE_APPLY_CONFIG_DIR || path.join(__dirname, '..', '..', 'config');
   const DATA_DIR = process.env.CLAUDE_APPLY_DATA_DIR || path.join(__dirname, '..', '..', 'data');

--- a/tests/dashboard/dashboard-help.test.mjs
+++ b/tests/dashboard/dashboard-help.test.mjs
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, '..', '..', 'src', 'dashboard', 'build.mjs');
+
+for (const flag of ['--help', '-h']) {
+  test(`/dashboard ${flag} exits 0 and prints usage — works without data`, () => {
+    const res = spawnSync(process.execPath, [SCRIPT, flag], {
+      env: {
+        ...process.env,
+        CLAUDE_APPLY_DATA_DIR: '/nonexistent/data',
+        CLAUDE_APPLY_REPORTS_DIR: '/nonexistent/reports',
+      },
+      encoding: 'utf8',
+    });
+    assert.equal(res.status, 0, `stderr=${res.stderr} stdout=${res.stdout}`);
+    assert.match(res.stdout, /^Usage: \/dashboard/m);
+    assert.match(res.stdout, /dashboard\.html/);
+    assert.match(res.stdout, /See also:/);
+  });
+}

--- a/tests/scan/explain-help.test.mjs
+++ b/tests/scan/explain-help.test.mjs
@@ -1,0 +1,26 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, '..', '..', 'src', 'scan', 'explain.mjs');
+
+for (const flag of ['--help', '-h']) {
+  test(`/explain ${flag} exits 0 and prints usage — works without config`, () => {
+    const res = spawnSync(process.execPath, [SCRIPT, flag], {
+      env: {
+        ...process.env,
+        CLAUDE_APPLY_CONFIG_DIR: '/nonexistent/cfg',
+      },
+      encoding: 'utf8',
+    });
+    assert.equal(res.status, 0, `stderr=${res.stderr} stdout=${res.stdout}`);
+    assert.match(res.stdout, /^Usage: \/explain/m);
+    assert.match(res.stdout, /--company <name>/);
+    assert.match(res.stdout, /--location <loc>/);
+    assert.match(res.stdout, /Exit codes/);
+    assert.match(res.stdout, /title-filter/);
+  });
+}

--- a/tests/scan/scan-help.test.mjs
+++ b/tests/scan/scan-help.test.mjs
@@ -1,0 +1,28 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, '..', '..', 'src', 'scan', 'index.mjs');
+
+for (const flag of ['--help', '-h']) {
+  test(`/scan ${flag} exits 0 and prints usage — works without config`, () => {
+    const res = spawnSync(process.execPath, [SCRIPT, flag], {
+      env: {
+        ...process.env,
+        CLAUDE_APPLY_CONFIG_DIR: '/nonexistent/cfg',
+        CLAUDE_APPLY_DATA_DIR: '/nonexistent/data',
+      },
+      encoding: 'utf8',
+    });
+    assert.equal(res.status, 0, `stderr=${res.stderr} stdout=${res.stdout}`);
+    assert.match(res.stdout, /^Usage: \/scan/m);
+    assert.match(res.stdout, /--dry-run/);
+    assert.match(res.stdout, /--only <slug>/);
+    assert.match(res.stdout, /--json/);
+    assert.match(res.stdout, /docs\/scan-workflow\.md/);
+    assert.match(res.stdout, /See also:/);
+  });
+}

--- a/tests/scan/scan.test.mjs
+++ b/tests/scan/scan.test.mjs
@@ -918,7 +918,13 @@ test('formatSummary — emits Next steps block in default path', () => {
     raw: 10,
     perCompany: [
       { company: 'mistral', platform: 'lever', rawCount: 5, afterFilterCount: 1, newCount: 1 },
-      { company: 'anthropic', platform: 'greenhouse', rawCount: 5, afterFilterCount: 0, newCount: 0 },
+      {
+        company: 'anthropic',
+        platform: 'greenhouse',
+        rawCount: 5,
+        afterFilterCount: 0,
+        newCount: 0,
+      },
     ],
     filtered: {
       skipped_dup: 0,
@@ -946,7 +952,13 @@ test('formatSummary — Next steps block is present even when nothing was added'
     eligibleTotal: 1,
     raw: 2359,
     perCompany: [
-      { company: 'big-co', platform: 'greenhouse', rawCount: 2359, afterFilterCount: 0, newCount: 0 },
+      {
+        company: 'big-co',
+        platform: 'greenhouse',
+        rawCount: 2359,
+        afterFilterCount: 0,
+        newCount: 0,
+      },
     ],
     filtered: {
       skipped_dup: 0,
@@ -971,7 +983,7 @@ test('scan CLI --json — stdout is parseable JSON and contains no Next steps bl
   const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-json-data-'));
   fs.writeFileSync(
     path.join(cfgDir, 'portals.yml'),
-    'tracked_companies: []\ntitle_filter:\n  required_any: []\n  excluded_any: []\n',
+    'tracked_companies: []\ntitle_filter:\n  required_any: []\n  excluded_any: []\n'
   );
   fs.writeFileSync(
     path.join(cfgDir, 'candidate-profile.yml'),
@@ -993,7 +1005,7 @@ test('scan CLI --json — stdout is parseable JSON and contains no Next steps bl
       'cv_path: config/cv.fr.pdf',
       'auto_apply_min_score: 7',
       'internship_duration_months: 6',
-    ].join('\n') + '\n',
+    ].join('\n') + '\n'
   );
 
   try {
@@ -1007,7 +1019,7 @@ test('scan CLI --json — stdout is parseable JSON and contains no Next steps bl
           CLAUDE_APPLY_DATA_DIR: dataDir,
         },
         encoding: 'utf8',
-      },
+      }
     );
     assert.equal(res.status, 0, `stderr=${res.stderr}`);
     assert.doesNotMatch(res.stdout, /Next steps/);

--- a/tests/scan/scan.test.mjs
+++ b/tests/scan/scan.test.mjs
@@ -910,3 +910,111 @@ test('formatSummary — lists filtered-out.tsv in updated files block (item 5)',
   assert.match(out, /Fichiers mis à jour/);
   assert.match(out, /filtered-out\.tsv\s+\(\+1 lignes?\)/);
 });
+
+test('formatSummary — emits Next steps block in default path', () => {
+  const result = {
+    scanned: 2,
+    eligibleTotal: 2,
+    raw: 10,
+    perCompany: [
+      { company: 'mistral', platform: 'lever', rawCount: 5, afterFilterCount: 1, newCount: 1 },
+      { company: 'anthropic', platform: 'greenhouse', rawCount: 5, afterFilterCount: 0, newCount: 0 },
+    ],
+    filtered: {
+      skipped_dup: 0,
+      skipped_title: 4,
+      skipped_blacklist: 0,
+      skipped_location: 0,
+      skipped_date: 0,
+    },
+    added: [{ company: 'mistral', title: 'ML Engineer Intern' }],
+    historyWrites: 1,
+    filteredWrites: 4,
+    errors: [],
+  };
+  const out = formatSummary(result, false);
+  assert.match(out, /Next steps :/);
+  assert.match(out, /\/score <url>/);
+  assert.match(out, /\/explain/);
+  assert.match(out, /\/dashboard/);
+  assert.match(out, /\/scan --help/);
+});
+
+test('formatSummary — Next steps block is present even when nothing was added', () => {
+  const result = {
+    scanned: 1,
+    eligibleTotal: 1,
+    raw: 2359,
+    perCompany: [
+      { company: 'big-co', platform: 'greenhouse', rawCount: 2359, afterFilterCount: 0, newCount: 0 },
+    ],
+    filtered: {
+      skipped_dup: 0,
+      skipped_title: 2359,
+      skipped_blacklist: 0,
+      skipped_location: 0,
+      skipped_date: 0,
+    },
+    added: [],
+    historyWrites: 0,
+    filteredWrites: 2359,
+    errors: [],
+  };
+  const out = formatSummary(result, false);
+  assert.match(out, /Next steps :/);
+  assert.match(out, /\/explain/);
+});
+
+test('scan CLI --json — stdout is parseable JSON and contains no Next steps block', () => {
+  // Config dir must be inside the repo so findRepoRoot() can locate .git.
+  const cfgDir = fs.mkdtempSync(path.join(REPO_ROOT, 'tmp-scan-json-cfg-'));
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-json-data-'));
+  fs.writeFileSync(
+    path.join(cfgDir, 'portals.yml'),
+    'tracked_companies: []\ntitle_filter:\n  required_any: []\n  excluded_any: []\n',
+  );
+  fs.writeFileSync(
+    path.join(cfgDir, 'candidate-profile.yml'),
+    [
+      'first_name: Alice',
+      'last_name: Martin',
+      'email: alice@example.com',
+      'phone: "+33600000000"',
+      'linkedin_url: https://linkedin.com/in/alice',
+      'github_url: https://github.com/alice',
+      'city: Paris',
+      'country: France',
+      'school: École Polytechnique',
+      'degree: Master',
+      'graduation_year: 2025',
+      'work_authorization: EU citizen',
+      'requires_sponsorship: false',
+      'availability_start: "2026-06-01"',
+      'cv_path: config/cv.fr.pdf',
+      'auto_apply_min_score: 7',
+      'internship_duration_months: 6',
+    ].join('\n') + '\n',
+  );
+
+  try {
+    const res = spawnSync(
+      process.execPath,
+      [path.join(REPO_ROOT, 'src', 'scan', 'index.mjs'), '--dry-run', '--json'],
+      {
+        env: {
+          ...process.env,
+          CLAUDE_APPLY_CONFIG_DIR: cfgDir,
+          CLAUDE_APPLY_DATA_DIR: dataDir,
+        },
+        encoding: 'utf8',
+      },
+    );
+    assert.equal(res.status, 0, `stderr=${res.stderr}`);
+    assert.doesNotMatch(res.stdout, /Next steps/);
+    const parsed = JSON.parse(res.stdout);
+    assert.ok(typeof parsed === 'object' && parsed !== null);
+  } finally {
+    fs.rmSync(cfgDir, { recursive: true, force: true });
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  }
+});

--- a/tests/score/score-help.test.mjs
+++ b/tests/score/score-help.test.mjs
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, '..', '..', 'src', 'score', 'index.mjs');
+
+for (const flag of ['--help', '-h']) {
+  test(`/score ${flag} exits 0 and prints usage — works without config`, () => {
+    const res = spawnSync(process.execPath, [SCRIPT, flag], {
+      env: {
+        ...process.env,
+        CLAUDE_APPLY_CONFIG_DIR: '/nonexistent/cfg',
+        CLAUDE_APPLY_DATA_DIR: '/nonexistent/data',
+      },
+      encoding: 'utf8',
+    });
+    assert.equal(res.status, 0, `stderr=${res.stderr} stdout=${res.stdout}`);
+    assert.match(res.stdout, /^Usage: \/score/m);
+    assert.match(res.stdout, /--re-score/);
+    assert.match(res.stdout, /--batch/);
+    assert.match(res.stdout, /--from-pipeline/);
+    assert.match(res.stdout, /docs\/score-workflow\.md/);
+  });
+}


### PR DESCRIPTION
## Summary

Addresses all seven discoverability gaps from issue #89 in one bundled PR:

- **L1** `/scan` summary footer now lists `/score`, `/explain`, `/dashboard` and the flag hint (items 1, 5). Removed the obsolete `## Next step` section in `scan.md`.
- **L2** `--help` / `-h` on every CLI entry point (`/scan`, `/score`, `/explain`, `/dashboard`) + documented preamble in `apply.md` (item 7). Works without config.
- **L3** Linked `docs/scan-workflow.md#title-filter` from `.claude/commands/scan.md` and from `/scan --help` See-also (item 3).
- **L4** Onboarding: step 2 prints `setup.sh --help` once (item 2); new step 5.5 runs `/scan --dry-run --json` for a calibration preview; step 6 summary now shows `Your title_filter`, a `First scan preview`, and the full command list including `/explain` and `/dashboard` (items 4, 6).

Spec: `docs/superpowers/specs/2026-04-21-issue-89-discoverability-design.md`.

## Test plan

- [x] Unit: `formatSummary` emits/skips the `Next steps` block as expected.
- [x] Unit: each of the 4 CLIs exits 0 on `--help` and `-h` with no config present.
- [x] Unit: `/scan --dry-run --json` stdout is parseable JSON without the `Next steps` text.
- [ ] Manual: `/apply --help` prints the skill preamble without opening Chrome.
- [ ] Manual: fresh `/apply-onboard` run shows the new summary with the dry-run preview.

Closes #89.