### PR TITLE
fix(scan): remaining #88 bugs — Workday stderr + discover batch mode

### DIFF
--- a/.claude/commands/apply-onboard/companies.md
+++ b/.claude/commands/apply-onboard/companies.md
@@ -95,10 +95,25 @@ Add a 100 ms delay between verifications to be polite to the APIs.
 If you only have a company **name** (no URL, or your guessed URL 404s), use `discoverCompany` from `src/scan/discover-company.mjs`. It walks platform-specific slug variations (`x`, `x-ai`, `xhq`, `xlabs`, `x-labs`, …) across Lever → Greenhouse → Ashby → Workday registry and returns the first hit. Successful resolutions are cached in `data/known-ats-slugs.json` so the next run is instant.
 
 ```bash
-node src/scan/discover-company.mjs "Doctolib" \
+cat > /tmp/names.txt <<'EOF'
+Doctolib
+Cohere
+Modal
+EOF
+node src/scan/discover-company.mjs --batch /tmp/names.txt \
   --cache-path data/known-ats-slugs.json \
   --workday-registry data/known-workday-slugs.json
 ```
+
+Output is JSON Lines, one record per input name, in input order:
+
+```
+{"name":"Doctolib","result":{"ok":true,"cached":false,"platform":"greenhouse","slug":"doctolib","careersUrl":"https://boards.greenhouse.io/doctolib","count":12}}
+{"name":"Cohere","result":{"ok":true,"cached":false,"platform":"lever","slug":"cohere","careersUrl":"https://jobs.lever.co/cohere","count":8}}
+{"name":"Modal","result":{"ok":false,"reason":"no slug matched","tried":[…]}}
+```
+
+Parse the stream line-by-line. **Do not loop one name at a time via bash** — that pattern was causing duplicated, out-of-order output in onboarding sessions.
 
 Use this whenever your naive guess returns `ok: false` before dropping the candidate — many companies (Doctolib, Cohere, Modal, Scale AI, Writer, OpenAI, …) live on a different ATS or under a non-obvious slug.
 

--- a/src/scan/discover-company.mjs
+++ b/src/scan/discover-company.mjs
@@ -4,6 +4,7 @@
 // data/known-ats-slugs.json so subsequent runs are instant.
 //
 // CLI: node src/scan/discover-company.mjs "<CompanyName>" [--cache-path <path>] [--workday-registry <path>]
+//   or: node src/scan/discover-company.mjs --batch <names-file> [--cache-path <path>] [--workday-registry <path>]
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/src/scan/discover-company.mjs
+++ b/src/scan/discover-company.mjs
@@ -144,22 +144,26 @@ export async function main({
   verifiers,
   _write = (s) => process.stdout.write(s),
 } = {}) {
-  const args = argv.slice(2).filter((a) => !a.startsWith('--'));
-  const flags = argv.slice(2).filter((a) => a.startsWith('--'));
-
-  const name = args[0];
-  if (!name) {
-    process.stderr.write(
-      'Usage: node src/scan/discover-company.mjs "<CompanyName>" [--cache-path <path>] [--workday-registry <path>]\n'
-    );
-    return 1;
-  }
+  const rest = argv.slice(2);
 
   const flag = (key) => {
-    const idx = flags.indexOf(key);
-    return idx >= 0 ? argv[argv.indexOf(key) + 1] : null;
+    const idx = rest.indexOf(key);
+    return idx >= 0 ? (rest[idx + 1] ?? null) : null;
   };
 
+  const FLAGS_WITH_VALUES = ['--batch', '--cache-path', '--workday-registry'];
+  const positional = [];
+  for (let i = 0; i < rest.length; i++) {
+    const tok = rest[i];
+    if (FLAGS_WITH_VALUES.includes(tok)) {
+      i += 1;
+      continue;
+    }
+    if (tok.startsWith('--')) continue;
+    positional.push(tok);
+  }
+
+  const batchPath = flag('--batch');
   const cachePath = flag('--cache-path');
   const workdayRegistryPath = flag('--workday-registry');
   const delayMs = Number(process.env.DISCOVER_DELAY_MS ?? 100);
@@ -169,6 +173,44 @@ export async function main({
   const resolvedRegistry = workdayRegistryPath
     ? path.resolve(__repoRoot, workdayRegistryPath)
     : null;
+
+  if (batchPath) {
+    if (positional.length > 0) {
+      process.stderr.write('--batch is mutually exclusive with a positional name argument\n');
+      return 1;
+    }
+    let contents;
+    try {
+      contents = fs.readFileSync(batchPath, 'utf8');
+    } catch (err) {
+      process.stderr.write(`cannot read --batch file ${batchPath}: ${err.message}\n`);
+      return 1;
+    }
+    const names = contents
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0 && !l.startsWith('#'));
+
+    for (const name of names) {
+      const result = await discoverCompany(name, {
+        cachePath: resolvedCache,
+        workdayRegistryPath: resolvedRegistry,
+        delayMs,
+        verifiers,
+      });
+      _write(JSON.stringify({ name, result }) + '\n');
+    }
+    return 0;
+  }
+
+  const name = positional[0];
+  if (!name) {
+    process.stderr.write(
+      'Usage: node src/scan/discover-company.mjs "<CompanyName>" [--cache-path <path>] [--workday-registry <path>]\n' +
+        '   or: node src/scan/discover-company.mjs --batch <names-file> [--cache-path <path>] [--workday-registry <path>]\n'
+    );
+    return 1;
+  }
 
   const result = await discoverCompany(name, {
     cachePath: resolvedCache,
@@ -183,8 +225,10 @@ export async function main({
 
 const isMain = import.meta.url === `file://${process.argv[1]}`;
 if (isMain) {
-  main().then(process.exit).catch((err) => {
-    process.stderr.write(`${err.message}\n`);
-    process.exit(1);
-  });
+  main()
+    .then(process.exit)
+    .catch((err) => {
+      process.stderr.write(`${err.message}\n`);
+      process.exit(1);
+    });
 }

--- a/src/scan/index.mjs
+++ b/src/scan/index.mjs
@@ -68,20 +68,7 @@ async function fetchCompanyOffers(company) {
   if (!fn) {
     return { company: company.name, platform: det.platform, offers: [], error: 'no fetcher' };
   }
-  let opts;
-  if (det.platform === 'workday') {
-    opts = {
-      onProgress: (e) => {
-        if (e.type === 'term_start') {
-          process.stderr.write(`[workday ${e.tenant}] fetching "${e.term}"…\n`);
-        } else if (e.type === 'term_done') {
-          process.stderr.write(
-            `[workday ${e.tenant}] "${e.term}" done — ${e.pages} pages, ${e.total} offers total\n`
-          );
-        }
-      },
-    };
-  }
+  const opts = undefined;
 
   let lastError = null;
   // Retry once on transient network errors (e.g. "fetch failed" from concurrent

--- a/tests/scan/discover-company-batch.test.mjs
+++ b/tests/scan/discover-company-batch.test.mjs
@@ -1,0 +1,157 @@
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { main } from '../../src/scan/discover-company.mjs';
+
+let tmpDir;
+afterEach(() => {
+  if (tmpDir && fs.existsSync(tmpDir)) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+  tmpDir = null;
+});
+
+function mkTmp() {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'discover-batch-'));
+  return tmpDir;
+}
+
+function captureWrites() {
+  const writes = [];
+  return { writes, _write: (s) => writes.push(s) };
+}
+
+function fakeVerifiers({ hits = {} } = {}) {
+  const make = (platform) => async (slug) => {
+    const key = `${platform}:${slug}`;
+    if (hits[key]) return { ok: true, count: hits[key] };
+    return { ok: false, status: 404, reason: 'not found' };
+  };
+  return {
+    lever: make('lever'),
+    greenhouse: make('greenhouse'),
+    ashby: make('ashby'),
+    workable: make('workable'),
+  };
+}
+
+test('main --batch emits one JSONL line per name, in input order', async () => {
+  const dir = mkTmp();
+  const namesFile = path.join(dir, 'names.txt');
+  fs.writeFileSync(namesFile, 'Foo\nBar\nBaz\n');
+
+  const verifiers = fakeVerifiers({ hits: { 'lever:bar': 5 } });
+  const { writes, _write } = captureWrites();
+
+  process.env.DISCOVER_DELAY_MS = '0';
+  const code = await main({
+    argv: ['node', 'discover-company.mjs', '--batch', namesFile],
+    verifiers,
+    _write,
+  });
+  delete process.env.DISCOVER_DELAY_MS;
+
+  assert.equal(code, 0);
+  assert.equal(writes.length, 3, `expected 3 lines, got ${writes.length}`);
+
+  const records = writes.map((l) => JSON.parse(l));
+  assert.deepEqual(
+    records.map((r) => r.name),
+    ['Foo', 'Bar', 'Baz']
+  );
+  assert.equal(records[0].result.ok, false);
+  assert.equal(records[1].result.ok, true);
+  assert.equal(records[1].result.platform, 'lever');
+  assert.equal(records[1].result.slug, 'bar');
+  assert.equal(records[2].result.ok, false);
+});
+
+test('main --batch skips empty lines and # comments', async () => {
+  const dir = mkTmp();
+  const namesFile = path.join(dir, 'names.txt');
+  fs.writeFileSync(namesFile, '# header\n\nFoo\n   \n# mid\nBar\n');
+
+  const { writes, _write } = captureWrites();
+  process.env.DISCOVER_DELAY_MS = '0';
+  const code = await main({
+    argv: ['node', 'discover-company.mjs', '--batch', namesFile],
+    verifiers: fakeVerifiers(),
+    _write,
+  });
+  delete process.env.DISCOVER_DELAY_MS;
+
+  assert.equal(code, 0);
+  assert.equal(writes.length, 2);
+  assert.equal(JSON.parse(writes[0]).name, 'Foo');
+  assert.equal(JSON.parse(writes[1]).name, 'Bar');
+});
+
+test('main --batch + positional name returns exit 1', async () => {
+  const dir = mkTmp();
+  const namesFile = path.join(dir, 'names.txt');
+  fs.writeFileSync(namesFile, 'Foo\n');
+
+  const { _write } = captureWrites();
+  const stderrCaptured = [];
+  const origWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk) => {
+    stderrCaptured.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+    return true;
+  };
+
+  let code;
+  try {
+    code = await main({
+      argv: ['node', 'discover-company.mjs', 'Acme', '--batch', namesFile],
+      verifiers: fakeVerifiers(),
+      _write,
+    });
+  } finally {
+    process.stderr.write = origWrite;
+  }
+
+  assert.equal(code, 1);
+  assert.match(stderrCaptured.join(''), /--batch/);
+});
+
+test('main --batch with missing file returns exit 1', async () => {
+  const { _write } = captureWrites();
+  const stderrCaptured = [];
+  const origWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk) => {
+    stderrCaptured.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+    return true;
+  };
+
+  let code;
+  try {
+    code = await main({
+      argv: ['node', 'discover-company.mjs', '--batch', '/nonexistent/path/names.txt'],
+      verifiers: fakeVerifiers(),
+      _write,
+    });
+  } finally {
+    process.stderr.write = origWrite;
+  }
+
+  assert.equal(code, 1);
+  assert.match(stderrCaptured.join(''), /batch/);
+});
+
+test('main --batch with empty file returns exit 0 and writes nothing', async () => {
+  const dir = mkTmp();
+  const namesFile = path.join(dir, 'empty.txt');
+  fs.writeFileSync(namesFile, '');
+
+  const { writes, _write } = captureWrites();
+  const code = await main({
+    argv: ['node', 'discover-company.mjs', '--batch', namesFile],
+    verifiers: fakeVerifiers(),
+    _write,
+  });
+
+  assert.equal(code, 0);
+  assert.equal(writes.length, 0);
+});

--- a/tests/scan/scan.test.mjs
+++ b/tests/scan/scan.test.mjs
@@ -963,6 +963,65 @@ test('formatSummary: includes Langue line even when zero', () => {
   assert.match(summary, /Langue\s+0/);
 });
 
+test('runScan — Workday fetch emits no [workday ...] line on stderr', async () => {
+  const fxPath = path.join(REPO_ROOT, 'tests', 'fixtures', 'workday-totalenergies-page2.json');
+  const workdayBody = JSON.parse(fs.readFileSync(fxPath, 'utf8'));
+
+  const portalsConfig = {
+    title_filter: { positive: [], negative: [] },
+    tracked_companies: [
+      {
+        name: 'TotalEnergies',
+        careers_url: 'https://totalenergies.wd3.myworkdayjobs.com/TotalEnergies_careers',
+        enabled: true,
+      },
+    ],
+  };
+  const profile = {
+    min_start_date: '2020-01-01',
+    blacklist_companies: [],
+    target_locations: ['France', 'Paris', 'Remote'],
+  };
+
+  const workdayEndpoint =
+    'https://totalenergies.wd3.myworkdayjobs.com/wday/cxs/totalenergies/TotalEnergies_careers/jobs';
+  const restoreFetch = installMockFetch({ [workdayEndpoint]: workdayBody });
+
+  const captured = [];
+  const origWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk, ...rest) => {
+    captured.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+    return origWrite(chunk, ...rest);
+  };
+
+  const pipelinePath = path.join(tmp, 'pipeline.md');
+  const historyPath = path.join(tmp, 'scan-history.tsv');
+  const filteredPath = path.join(tmp, 'filtered-out.tsv');
+  const applicationsPath = path.join(tmp, 'applications.md');
+  fs.writeFileSync(applicationsPath, '# Apps\n');
+
+  try {
+    await runScan({
+      portalsConfig,
+      profile,
+      pipelinePath,
+      historyPath,
+      filteredPath,
+      applicationsPath,
+      dryRun: false,
+    });
+  } finally {
+    process.stderr.write = origWrite;
+    restoreFetch();
+  }
+
+  const joined = captured.join('');
+  assert.ok(
+    !/\[workday\s/.test(joined),
+    `expected no [workday ...] line on stderr, got:\n${joined}`
+  );
+});
+
 test('runScan — Workday { offers, warnings } shape is normalised correctly', async () => {
   const portalsConfig = {
     title_filter: { positive: [], negative: [] },


### PR DESCRIPTION
## Summary
- Drop the Workday per-term progress writes on stderr in `fetchCompanyOffers` — they printed before the per-company `[N/M]` numbering because Workday fetches run in parallel.
- Add `--batch <file>` to `discover-company.mjs` CLI and update `/apply-onboard:companies` §5b to use it. One Node process, deterministic JSONL output, no more bash-loop duplication.
- Closes the two remaining items from issue #88 (bugs 2 and 3). Bugs 1, 4, 5 shipped in PR #95.

## Test plan
- [x] `npm test` — full suite passes (683 → 689, +1 stderr regression test, +5 batch tests)
- [ ] Manual: `npm run scan` against a portals config containing at least one Workday tenant — confirm no `[workday …]` line on stderr
- [ ] Manual: create a small names file and run `node src/scan/discover-company.mjs --batch <file>` — confirm one JSONL line per name, in input order